### PR TITLE
docs(claude): add development workflow protocol to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,6 +605,28 @@ describe('Project entity', () => {
 - Circular dependencies between monorepo packages
 - Direct imports between bounded contexts; use only the Shared Kernel
 
+## 🔄 Development Workflow
+
+### Issue → Branch → PR Protocol
+
+Follow this sequence for every piece of work, without exception:
+
+1. **Task Master tag** — ensure the task exists under the tag that matches the issue's Sprint (e.g. `sprint-1`). Switch with `task-master tags use <tag>` if needed.
+2. **Set status to In Progress** — run `task-master set-status --id=<id> --status=in-progress` before touching any code.
+3. **Create the branch from the GitHub issue** — always use `gh issue develop <issue-number> --checkout` so the branch name is derived from the issue. Never create branches manually for tracked issues.
+4. **Implement** — write code, tests, and commits on that branch.
+5. **Open PR against `develop`** — always target `develop`, never `master` or `staging`. Use `gh pr create --base develop`.
+6. **Set status to Done** — run `task-master set-status --id=<id> --status=done` after the PR is created.
+
+### Rules
+
+- One GitHub issue = one Task Master task (same Sprint tag).
+- The Task Master task status must mirror reality at all times: `pending → in-progress → done`.
+- PRs always point to `develop`, regardless of the Sprint or branch source.
+- If a rebase against `develop` is needed before pushing, resolve lock-file conflicts by checking out `develop`'s version (`git checkout --theirs pnpm-lock.yaml`) then running `pnpm install`.
+
+---
+
 ## Task Master AI Instructions
 **Import Task Master's development workflow commands and guidelines, and treat them as if the import were in the main `CLAUDE.md` file.**
 @./.taskmaster/CLAUDE.md


### PR DESCRIPTION
## Summary

- Documenta o protocolo obrigatório **Issue → Branch → PR** no `CLAUDE.md`
- Define que a tag do Task Master deve corresponder à Sprint da issue
- Estabelece que branches devem sempre ser criadas via `gh issue develop`
- Deixa explícito que PRs sempre apontam para `develop`
- Inclui regra de resolução de conflito no `pnpm-lock.yaml` durante rebase

## Test plan

- [ ] Ler a seção **🔄 Development Workflow** no `CLAUDE.md` e validar que as regras estão claras e completas

🤖 Generated with [Claude Code](https://claude.com/claude-code)