### PR TITLE
[T-10] Criar output DTOs para contexto Portfolio

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,1 +1,1 @@
-// exports added progressively as use cases and DTOs are implemented
+export * from "./portfolio";

--- a/packages/application/src/portfolio/dtos/ExperienceDTO.ts
+++ b/packages/application/src/portfolio/dtos/ExperienceDTO.ts
@@ -1,0 +1,15 @@
+import { ExperienceSkillDTO } from "./ExperienceSkillDTO";
+
+export type ExperienceDTO = {
+  id: string;
+  company: string;
+  position: string;
+  location: string;
+  description?: string;
+  logo?: { url: string; alt: string };
+  employmentType: string;
+  locationType: string;
+  startAt: string;
+  endAt?: string;
+  skills: ExperienceSkillDTO[];
+};

--- a/packages/application/src/portfolio/dtos/ExperienceSkillDTO.ts
+++ b/packages/application/src/portfolio/dtos/ExperienceSkillDTO.ts
@@ -1,0 +1,6 @@
+export type ExperienceSkillDTO = {
+  id: string;
+  name: string;
+  type: string;
+  workDescription: string;
+};

--- a/packages/application/src/portfolio/dtos/ProfileDTO.ts
+++ b/packages/application/src/portfolio/dtos/ProfileDTO.ts
@@ -1,0 +1,13 @@
+import { ProfileStatDTO } from "./ProfileStatDTO";
+import { SocialNetworkDTO } from "./SocialNetworkDTO";
+
+export type ProfileDTO = {
+  id: string;
+  name: string;
+  headline: string;
+  bio: string;
+  photo: { url: string; alt: string };
+  stats: ProfileStatDTO[];
+  featuredProjectSlugs: string[];
+  socialNetworks: SocialNetworkDTO[];
+};

--- a/packages/application/src/portfolio/dtos/ProfileStatDTO.ts
+++ b/packages/application/src/portfolio/dtos/ProfileStatDTO.ts
@@ -1,0 +1,5 @@
+export type ProfileStatDTO = {
+  label: string;
+  value: string;
+  icon: string;
+};

--- a/packages/application/src/portfolio/dtos/ProjectDetailDTO.ts
+++ b/packages/application/src/portfolio/dtos/ProjectDetailDTO.ts
@@ -1,0 +1,11 @@
+import { ProjectSummaryDTO } from "./ProjectSummaryDTO";
+
+export type ProjectDetailDTO = ProjectSummaryDTO & {
+  content: string;
+  summary?: string;
+  objectives?: string;
+  role?: string;
+  team?: string;
+  period: { startAt: string; endAt?: string };
+  relatedProjects: ProjectSummaryDTO[];
+};

--- a/packages/application/src/portfolio/dtos/ProjectSummaryDTO.ts
+++ b/packages/application/src/portfolio/dtos/ProjectSummaryDTO.ts
@@ -1,0 +1,10 @@
+export type ProjectSummaryDTO = {
+  id: string;
+  slug: string;
+  title: string;
+  caption: string;
+  coverImage: { url: string; alt: string };
+  theme?: string;
+  skills: string[];
+  publishedAt: string;
+};

--- a/packages/application/src/portfolio/dtos/SocialNetworkDTO.ts
+++ b/packages/application/src/portfolio/dtos/SocialNetworkDTO.ts
@@ -1,0 +1,5 @@
+export type SocialNetworkDTO = {
+  id: string;
+  name: string;
+  url: string;
+};

--- a/packages/application/src/portfolio/dtos/index.ts
+++ b/packages/application/src/portfolio/dtos/index.ts
@@ -1,0 +1,7 @@
+export * from "./ExperienceDTO";
+export * from "./ExperienceSkillDTO";
+export * from "./ProfileDTO";
+export * from "./ProfileStatDTO";
+export * from "./ProjectDetailDTO";
+export * from "./ProjectSummaryDTO";
+export * from "./SocialNetworkDTO";

--- a/packages/application/src/portfolio/index.ts
+++ b/packages/application/src/portfolio/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "./dtos";


### PR DESCRIPTION
## Summary

- `ProjectSummaryDTO` — campos de listagem de projeto (id, slug, title, caption, coverImage, theme, skills, publishedAt)
- `ProjectDetailDTO` — estende ProjectSummaryDTO com content, summary, objectives, role, team, period e relatedProjects
- `ExperienceSkillDTO` — id, name, type e workDescription localizado
- `ExperienceDTO` — experience completa com `ExperienceSkillDTO[]` aninhado
- `ProfileStatDTO` — label, value, icon (contadores de stats)
- `SocialNetworkDTO` — id, name, url
- `ProfileDTO` — profile completo com stats[], featuredProjectSlugs[] e socialNetworks[]

> DTOs implementados como `type` (não `interface`) para evitar o prefixo `I` exigido pela regra ESLint de naming convention — DTOs são shapes de dados, não contratos.

## Test plan

- [ ] `pnpm -C packages/application lint` passa sem erros
- [ ] `pnpm -C packages/application types` passa sem erros
- [ ] Verificar que todos os tipos são exportados via `@repo/application` e `@repo/application/portfolio`

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)