### PR TITLE
feat(application): add GetFeaturedProjects use case

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,2 +1,3 @@
+export * from './shared';
 export * from './contact';
 export * from './portfolio';

--- a/packages/application/src/portfolio/index.ts
+++ b/packages/application/src/portfolio/index.ts
@@ -1,1 +1,2 @@
 export * from './dtos';
+export * from './use-cases';

--- a/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
@@ -1,0 +1,43 @@
+import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
+import { IProjectRepository, Project } from '@repo/core/portfolio';
+
+import { ProjectSummaryDTO } from '../dtos/ProjectSummaryDTO';
+
+export interface GetFeaturedProjectsInput {
+  locale: Locale;
+}
+
+export class GetFeaturedProjects {
+  constructor(private readonly projectRepository: IProjectRepository) {}
+
+  async execute(
+    input: GetFeaturedProjectsInput,
+  ): Promise<Either<DomainError, ProjectSummaryDTO[]>> {
+    try {
+      const projects = await this.projectRepository.findFeatured();
+      return right(projects.map((p) => this.toDTO(p, input.locale)));
+    } catch {
+      return left(
+        new DomainError('FETCH_FAILED', {
+          message: 'Failed to fetch featured projects',
+        }),
+      );
+    }
+  }
+
+  private toDTO(project: Project, locale: Locale): ProjectSummaryDTO {
+    return {
+      id: project.id.value,
+      slug: project.slug.value,
+      title: project.title.get(locale),
+      caption: project.caption.get(locale),
+      coverImage: {
+        url: project.coverImage.url.value,
+        alt: project.coverImage.alt.get(locale),
+      },
+      theme: project.theme?.get(locale),
+      skills: project.skills.map((s) => s.description.value),
+      publishedAt: project.period.startAt.value,
+    };
+  }
+}

--- a/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
@@ -1,14 +1,17 @@
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 import { IProjectRepository, Project } from '@repo/core/portfolio';
 
+import { UseCase } from '../../shared/UseCase';
 import { ProjectSummaryDTO } from '../dtos/ProjectSummaryDTO';
 
 export interface GetFeaturedProjectsInput {
   locale: Locale;
 }
 
-export class GetFeaturedProjects {
-  constructor(private readonly projectRepository: IProjectRepository) {}
+export class GetFeaturedProjects extends UseCase<GetFeaturedProjectsInput, ProjectSummaryDTO[]> {
+  constructor(private readonly projectRepository: IProjectRepository) {
+    super();
+  }
 
   async execute(
     input: GetFeaturedProjectsInput,

--- a/packages/application/src/portfolio/use-cases/index.ts
+++ b/packages/application/src/portfolio/use-cases/index.ts
@@ -1,0 +1,1 @@
+export { GetFeaturedProjects, type GetFeaturedProjectsInput } from './GetFeaturedProjects';

--- a/packages/application/src/shared/UseCase.ts
+++ b/packages/application/src/shared/UseCase.ts
@@ -1,0 +1,5 @@
+import { DomainError, Either } from '@repo/core/shared';
+
+export abstract class UseCase<TInput, TOutput, TError = DomainError> {
+  abstract execute(input: TInput): Promise<Either<TError, TOutput>>;
+}

--- a/packages/application/src/shared/index.ts
+++ b/packages/application/src/shared/index.ts
@@ -1,0 +1,1 @@
+export { UseCase } from './UseCase';

--- a/packages/application/test/portfolio/GetFeaturedProjects.test.ts
+++ b/packages/application/test/portfolio/GetFeaturedProjects.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  IProjectProps,
+  IProjectRepository,
+  Project,
+  ProjectStatus,
+} from '@repo/core/portfolio';
+import { DomainError } from '@repo/core/shared';
+
+import { ProjectSummaryDTO } from '~/portfolio/dtos/ProjectSummaryDTO';
+import { GetFeaturedProjects } from '~/portfolio/use-cases/GetFeaturedProjects';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_PROPS: IProjectProps = {
+  slug: 'my-project',
+  coverImage: {
+    url: 'https://example.com/cover.jpg',
+    alt: { 'pt-BR': 'Capa do projeto', 'en-US': 'Project cover' },
+  },
+  title: { 'pt-BR': 'Título do Projeto', 'en-US': 'Project Title' },
+  caption: { 'pt-BR': 'Legenda do projeto', 'en-US': 'Project caption' },
+  content: 'Conteúdo detalhado do projeto aqui.',
+  skills: [],
+  period: { start: '2023-01-01T00:00:00.000Z' },
+  featured: true,
+  status: ProjectStatus.PUBLISHED,
+};
+
+function makeProject(overrides: Partial<IProjectProps> = {}): Project {
+  const result = Project.create({ ...BASE_PROPS, ...overrides });
+  if (result.isLeft()) throw new Error(`makeProject failed: ${result.value.message}`);
+  return result.value;
+}
+
+function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRepository {
+  return {
+    findAll: vi.fn(),
+    findPublished: vi.fn(),
+    findFeatured: vi.fn(),
+    findById: vi.fn(),
+    findBySlug: vi.fn(),
+    findRelated: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GetFeaturedProjects', () => {
+  describe('execute()', () => {
+    it('should return Right with empty array when repository returns no projects', async () => {
+      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([]) });
+      const useCase = new GetFeaturedProjects(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      expect(result.value).toEqual([]);
+    });
+
+    it('should return Right with mapped DTOs when repository returns projects', async () => {
+      const project = makeProject();
+      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
+      const useCase = new GetFeaturedProjects(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      expect(result.value as ProjectSummaryDTO[]).toHaveLength(1);
+    });
+
+    it('should map all DTO fields correctly for pt-BR locale', async () => {
+      const project = makeProject();
+      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
+      const useCase = new GetFeaturedProjects(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = (result.value as ProjectSummaryDTO[])[0]!;
+
+      expect(dto.id).toBe(project.id.value);
+      expect(dto.slug).toBe('my-project');
+      expect(dto.title).toBe('Título do Projeto');
+      expect(dto.caption).toBe('Legenda do projeto');
+      expect(dto.coverImage.url).toBe('https://example.com/cover.jpg');
+      expect(dto.coverImage.alt).toBe('Capa do projeto');
+      expect(dto.theme).toBeUndefined();
+      expect(dto.skills).toEqual([]);
+      expect(dto.publishedAt).toBe('2023-01-01T00:00:00.000Z');
+    });
+
+    it('should map localized fields using the requested locale', async () => {
+      const project = makeProject({
+        theme: { 'pt-BR': 'Tema PT', 'en-US': 'Theme EN' },
+      });
+      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
+      const useCase = new GetFeaturedProjects(repo);
+
+      const ptResult = await useCase.execute({ locale: 'pt-BR' });
+      const enResult = await useCase.execute({ locale: 'en-US' });
+
+      expect(ptResult.isRight()).toBe(true);
+      expect(enResult.isRight()).toBe(true);
+
+      const ptDto = (ptResult.value as ProjectSummaryDTO[])[0]!;
+      const enDto = (enResult.value as ProjectSummaryDTO[])[0]!;
+
+      expect(ptDto.title).toBe('Título do Projeto');
+      expect(ptDto.theme).toBe('Tema PT');
+      expect(enDto.title).toBe('Project Title');
+      expect(enDto.theme).toBe('Theme EN');
+    });
+
+    it('should include mapped skills descriptions in DTO', async () => {
+      const project = makeProject({
+        skills: [
+          { description: 'TypeScript', icon: 'ts', type: 'TECHNOLOGY' },
+          { description: 'React', icon: 'react', type: 'TECHNOLOGY' },
+        ],
+      });
+      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
+      const useCase = new GetFeaturedProjects(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = (result.value as ProjectSummaryDTO[])[0]!;
+      expect(dto.skills).toEqual(['TypeScript', 'React']);
+    });
+
+    it('should return Left with DomainError when repository throws', async () => {
+      const repo = makeRepository({
+        findFeatured: vi.fn().mockRejectedValue(new Error('DB connection failed')),
+      });
+      const useCase = new GetFeaturedProjects(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+      expect((result.value as DomainError).code).toBe('FETCH_FAILED');
+    });
+
+    it('should call findFeatured() on the repository', async () => {
+      const findFeatured = vi.fn().mockResolvedValue([]);
+      const repo = makeRepository({ findFeatured });
+      const useCase = new GetFeaturedProjects(repo);
+
+      await useCase.execute({ locale: 'pt-BR' });
+
+      expect(findFeatured).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `GetFeaturedProjects` use case in `packages/application/src/portfolio/use-cases/`
- Orchestrates `IProjectRepository.findFeatured()` and maps `Project` entities to `ProjectSummaryDTO` with locale-aware field resolution
- Adds barrel exports in `use-cases/index.ts` and updates `portfolio/index.ts`

## Test plan

- [x] 7 tests covering: empty results, happy path, all DTO field mappings, locale handling (pt-BR / en-US), skills mapping, repository error propagation, and `findFeatured()` call verification
- [x] `pnpm -C packages/application test` — all 7 tests pass
- [x] `pnpm -C packages/application types` — no type errors

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)