### PR TITLE
docs: update docs to reflect Sprint 1 application layer progress

### DIFF
--- a/docs/04-APPLICATION-LAYER.md
+++ b/docs/04-APPLICATION-LAYER.md
@@ -2,8 +2,6 @@
 
 > Use cases, ports, DTOs, and the orchestration pattern between domain and infrastructure.
 
-**Status: WIP** — `packages/application` is being introduced in Sprint 1.
-
 ---
 
 ## Goal
@@ -15,30 +13,68 @@ The application layer:
 
 ---
 
+## Abstract `UseCase` Base Class
+
+All use cases extend the abstract base class defined in `packages/application/src/shared/UseCase.ts`:
+
+```typescript
+export abstract class UseCase<TInput, TOutput, TError = DomainError> {
+  abstract execute(input: TInput): Promise<Either<TError, TOutput>>;
+}
+```
+
+Concrete use cases inject their required port via the constructor and implement `execute()`:
+
+```typescript
+export class GetFeaturedProjects extends UseCase<GetFeaturedProjectsInput, ProjectSummaryDTO[]> {
+  constructor(private readonly projectRepository: IProjectRepository) {
+    super();
+  }
+
+  async execute(input: GetFeaturedProjectsInput): Promise<Either<DomainError, ProjectSummaryDTO[]>> {
+    try {
+      const projects = await this.projectRepository.findFeatured();
+      return right(projects.map((p) => this.toDTO(p, input.locale)));
+    } catch {
+      return left(new DomainError('FETCH_FAILED', { message: 'Failed to fetch featured projects' }));
+    }
+  }
+}
+```
+
+---
+
 ## Ports
 
-Interfaces defined in the application layer and implemented by infrastructure:
+Repository interfaces live in `@repo/core` (not in `@repo/application`). Service ports that are not related to the domain are defined in `@repo/application`:
 
-| Port | Planned methods |
-|------|-----------------|
-| `IProjectRepository` | `findAll()`, `findFeatured()`, `findPublished()`, `findBySlug(slug)`, `findById(id)` |
-| `IExperienceRepository` | `findAll()` |
-| `IProfileRepository` | `findOne()` |
-| `ISkillRepository` | `findAll()` |
-| `IContactSender` | `send(payload)` |
+| Port | Package | Status |
+|------|---------|--------|
+| `IProjectRepository` | `@repo/core/portfolio` | defined |
+| `IExperienceRepository` | `@repo/core/portfolio` | defined |
+| `IProfileRepository` | `@repo/core/portfolio` | defined |
+| `IEmailService` | `@repo/application/contact` | ✅ implemented |
+
+`IEmailService` signature:
+
+```typescript
+interface IEmailService {
+  send(message: IContactMessageDTO): Promise<Either<DomainError, void>>;
+}
+```
 
 ---
 
 ## Use Cases
 
-| Use case | Port(s) | Input | Output |
-|----------|---------|-------|--------|
-| `GetFeaturedProjects` | `IProjectRepository` | — | `ProjectDTO[]` |
-| `GetPublishedProjects` | `IProjectRepository` | `{ locale }` | `ProjectDTO[]` |
-| `GetProjectBySlug` | `IProjectRepository` | `slug: string` | `ProjectDTO \| null` |
-| `GetExperiences` | `IExperienceRepository` | `{ locale }` | `ExperienceDTO[]` |
-| `GetProfile` | `IProfileRepository` | `{ locale }` | `ProfileDTO` |
-| `SendContactMessage` | `IContactSender` | `{ name, email, subject, message }` | `{ ok }` or error |
+| Use case | Port(s) | Input | Output | Status |
+|----------|---------|-------|--------|--------|
+| `GetFeaturedProjects` | `IProjectRepository` | `{ locale }` | `ProjectSummaryDTO[]` | ✅ implemented |
+| `GetPublishedProjects` | `IProjectRepository` | `{ locale }` | `ProjectSummaryDTO[]` | pending |
+| `GetProjectBySlug` | `IProjectRepository` | `{ locale, slug }` | `ProjectDetailDTO` | pending |
+| `GetExperiences` | `IExperienceRepository` | `{ locale }` | `ExperienceDTO[]` | pending |
+| `GetProfile` | `IProfileRepository` | `{ locale }` | `ProfileDTO` | pending |
+| `SendContactMessage` | `IEmailService` | `IContactMessageDTO` | `void` | pending |
 
 Use cases **never** know Supabase, HTTP, or Prisma. Domain errors are propagated as `Either` and mapped at the edge.
 
@@ -46,48 +82,68 @@ Use cases **never** know Supabase, HTTP, or Prisma. Domain errors are propagated
 
 ## DTOs
 
-DTOs are plain serializable objects — no domain logic. They are the output contract of use cases.
+DTOs are plain serializable types — no domain logic, no Either. They are the output contract of use cases, with all localized fields already resolved to a single string.
+
+| DTO | File | Description |
+|-----|------|-------------|
+| `ProjectSummaryDTO` | `portfolio/dtos/ProjectSummaryDTO.ts` | Card / listing view |
+| `ProjectDetailDTO` | `portfolio/dtos/ProjectDetailDTO.ts` | Detail page; extends `ProjectSummaryDTO` |
+| `ExperienceDTO` | `portfolio/dtos/ExperienceDTO.ts` | Work experience entry |
+| `ExperienceSkillDTO` | `portfolio/dtos/ExperienceSkillDTO.ts` | Skill inside an experience |
+| `ProfileDTO` | `portfolio/dtos/ProfileDTO.ts` | Full profile |
+| `ProfileStatDTO` | `portfolio/dtos/ProfileStatDTO.ts` | Single stat inside a profile |
+| `SocialNetworkDTO` | `portfolio/dtos/SocialNetworkDTO.ts` | Social link |
+| `IContactMessageDTO` | `contact/dtos/ContactMessageDTO.ts` | Input DTO for contact form |
 
 ```typescript
-// Example
-interface ProjectDTO {
+// ProjectSummaryDTO — output of GetFeaturedProjects
+type ProjectSummaryDTO = {
   id: string;
   slug: string;
-  title: string;         // resolved for requested locale
+  title: string;
   caption: string;
-  content: string;
-  skills: SkillDTO[];
-  featured: boolean;
-  status: 'DRAFT' | 'PUBLISHED' | 'ARCHIVED';
-}
-```
+  coverImage: { url: string; alt: string };
+  theme?: string;
+  skills: string[];
+  publishedAt: string;
+};
 
-When a Core entity is directly serializable and sufficient, the use case may return it directly. Prefer explicit DTOs for summary listings or when the shape differs from the domain entity.
+// ProjectDetailDTO — extends ProjectSummaryDTO
+type ProjectDetailDTO = ProjectSummaryDTO & {
+  content: string;
+  summary?: string;
+  objectives?: string;
+  role?: string;
+  team?: string;
+  period: { startAt: string; endAt?: string };
+  relatedProjects: ProjectSummaryDTO[];
+};
+```
 
 ---
 
-## Planned Structure
+## Current Structure
 
 ```text
 packages/application/src/
-  ports/
-    IProjectRepository.ts
-    IExperienceRepository.ts
-    IProfileRepository.ts
-    ISkillRepository.ts
-    IContactSender.ts
-  use-cases/
-    GetFeaturedProjects.ts
-    GetPublishedProjects.ts
-    GetProjectBySlug.ts
-    GetExperiences.ts
-    GetProfile.ts
-    SendContactMessage.ts
-  dtos/
-    ProjectDTO.ts
-    ExperienceDTO.ts
-    ProfileDTO.ts
-    SkillDTO.ts
+  shared/
+    UseCase.ts              ✅ abstract base class
+  portfolio/
+    dtos/
+      ProjectSummaryDTO.ts  ✅
+      ProjectDetailDTO.ts   ✅
+      ExperienceDTO.ts      ✅
+      ExperienceSkillDTO.ts ✅
+      ProfileDTO.ts         ✅
+      ProfileStatDTO.ts     ✅
+      SocialNetworkDTO.ts   ✅
+    use-cases/
+      GetFeaturedProjects.ts ✅
+  contact/
+    dtos/
+      ContactMessageDTO.ts  ✅
+    ports/
+      IEmailService.ts      ✅
   index.ts
 ```
 

--- a/docs/06-VALIDATION.md
+++ b/docs/06-VALIDATION.md
@@ -60,7 +60,26 @@ static create(raw?: string): Either<ValidationError, Slug> {
 }
 ```
 
-`Validator` methods: `.notEmpty()`, `.length()`, `.regex()`, `.refine()`, `.url()`, `.uuid()`, `.datetime()`, `.in()`, `.combine()`.
+`Validator` methods:
+
+| Method | Description |
+|--------|-------------|
+| `.length(min, max, error)` | String length between `min` and `max` |
+| `.notEmpty(error)` | Non-empty string |
+| `.empty(error)` | Empty string |
+| `.alpha(error)` | Alphabetic characters only (supports accents) |
+| `.string(error)` | Valid string type |
+| `.regex(pattern, error)` | Matches regular expression |
+| `.url(error)` | Valid URL |
+| `.uuid(error)` | Valid UUID |
+| `.datetime(error)` | Valid ISO 8601 datetime |
+| `.in(values, error)` | Value must be one of the allowed values |
+| `.gt(n, error)` / `.gte(n, error)` | Number greater than / greater than or equal to `n` |
+| `.lt(n, error)` / `.lte(n, error)` | Number less than / less than or equal to `n` |
+| `.nil(error)` | Value is `null` or `undefined` |
+| `.notNil(error)` | Value is not `null` or `undefined` |
+| `.refine(predicate, error)` | Arbitrary predicate function |
+| `Validator.combine(...validators)` | Runs multiple validators; returns first error |
 
 ---
 
@@ -79,19 +98,6 @@ static create(raw?: string): Either<ValidationError, Slug> {
 - Added `.notEmpty()`, `.regex()`, `.refine()` ✓ (Sprint 1, PR #338)
 - All domain VOs and entities use `Validator` instead of raw `if` guards ✓ (Sprint 1, PR #339)
 - Zod-backed internals in `Validator` ✓ (Sprint 1, PR #338)
-
----
-
-## Pending Domain Invariants
-
-The items below require a product decision before they can be enforced in the domain layer. Once decided, implement in the corresponding `create()` method using `Validator`.
-
-| Entity / VO | Open question | If "yes" → implementation hint |
-|---|---|---|
-| `Experience` | Can an experience have zero skills (`skills: []`)? | Validate `props.skills.length >= 1` in `Experience.create()` |
-| `ProjectStatus` | Are status transitions enforced (e.g. `ARCHIVED → PUBLISHED` forbidden)? | Add `publish()` / `archive()` methods to `Project` with transition guards |
-| `ExperienceSkill` | Can the same skill appear more than once in the same `Experience`? | After the skills loop in `Experience.create()`, verify uniqueness by skill id |
-| `ProfileStat` | Must `value` always be a numeric string (e.g. `"7"`)? | Add `.regex(/^\d+$/, …)` to `Text.create` call in `ProfileStat.create()` |
 
 ---
 

--- a/docs/09-PATTERNS.md
+++ b/docs/09-PATTERNS.md
@@ -71,6 +71,58 @@ class Slug extends ValueObject<string> {
 
 ---
 
+## `collect()` — batch Either validation
+
+When composing multiple Value Objects in `create()`, use `collect()` instead of sequential `if (isLeft())` guards.
+
+```typescript
+import { collect, left, right } from '@repo/core/shared';
+
+static create(props: IProjectProps): Either<ValidationError, Project> {
+  const result = collect([
+    Slug.create(props.slug),
+    LocalizedText.create(props.title),
+    Image.create(props.coverImage?.url, props.coverImage?.alt),
+  ]);
+  if (result.isLeft()) return left(result.value); // first error, fail-fast
+
+  const [slug, title, coverImage] = result.value; // typed tuple
+
+  return right(new Project(props, slug, title, coverImage));
+}
+```
+
+**When to use `collect()` vs manual loop:**
+
+| Situation | Pattern |
+|-----------|---------|
+| Multiple independent VOs created at once | `collect([...])` |
+| An array of children that each need validation | manual `for` loop |
+| An optional field that may or may not be created | manual `if (prop) { ... }` |
+
+```typescript
+// ✅ collect — 3 independent VOs
+const result = collect([Name.create(p.name), Url.create(p.url), Text.create(p.icon)]);
+
+// ✅ loop — variable-length children array
+const skills: Skill[] = [];
+for (const s of props.skills) {
+  const r = Skill.create(s);
+  if (r.isLeft()) return left(r.value);
+  skills.push(r.value);
+}
+
+// ✅ optional field
+let theme: LocalizedText | undefined;
+if (props.theme) {
+  const r = LocalizedText.create(props.theme);
+  if (r.isLeft()) return left(r.value);
+  theme = r.value;
+}
+```
+
+---
+
 ## Entity Template
 
 ```typescript
@@ -85,13 +137,14 @@ class Project extends Entity<Project, IProjectProps> {
   }
 
   static create(props: IProjectProps): Either<ValidationError, Project> {
-    const slugResult = Slug.create(props.slug);
-    if (slugResult.isLeft()) return left(slugResult.value);
+    const result = collect([
+      Slug.create(props.slug),
+      LocalizedText.create(props.title),
+    ]);
+    if (result.isLeft()) return left(result.value);
+    const [slug, title] = result.value;
 
-    const titleResult = LocalizedText.create(props.title);
-    if (titleResult.isLeft()) return left(titleResult.value);
-
-    return right(new Project(props, slugResult.value, titleResult.value, props.status));
+    return right(new Project(props, slug, title, props.status));
   }
 
   publish(): Either<ValidationError, void> {
@@ -106,7 +159,7 @@ class Project extends Entity<Project, IProjectProps> {
 **Rules for Entities:**
 - Private constructor — always use `Entity.create()`
 - No public setters — expose business-semantic methods (`publish()`, `archive()`)
-- Compose Value Objects — propagate their errors with `if (result.isLeft()) return left(result.value)`
+- Compose Value Objects with `collect()` for independent fields; use manual loops for children arrays
 - `Profile` supports at most 6 featured projects
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,10 +62,13 @@ Evolution view for the portfolio, aligned with Clean Architecture, DDD, i18n, an
 
 ## Phase 3 — Application and Contact Backend
 
-- [ ] **`packages/application`** (or equivalent)
-  - Ports: `IProjectRepository`, `IPostRepository`, `ITagRepository`, `IContactSender`
-  - Use cases: `GetProjects`, `GetProjectById`, `ListPosts`, `GetPostBySlug`, `ListTags`, `SendContact`
-  - View models where needed
+- [x] **`packages/application`** — base structure
+  - [x] Abstract `UseCase` base class
+  - [x] Output DTOs: `ProjectSummaryDTO`, `ProjectDetailDTO`, `ExperienceDTO`, `ProfileDTO`, and others
+  - [x] `IEmailService` port
+  - [x] `ContactMessageDTO`
+  - [x] `GetFeaturedProjects` use case
+  - [ ] Remaining use cases: `GetPublishedProjects`, `GetProjectBySlug`, `GetExperiences`, `GetProfile`, `SendContactMessage`
 - [ ] **Infra**
   - Concrete implementations of the ports; `ContactSender` (Supabase `contacts`, Resend, or another provider)
 - [ ] **API**


### PR DESCRIPTION
## Summary

- **04-APPLICATION-LAYER**: documenta `UseCase` base class, DTOs reais implementados, port `IEmailService`, use case `GetFeaturedProjects` e estrutura atual de arquivos; remove status "WIP" e seção "Planned Structure"
- **06-VALIDATION**: expande tabela de métodos do `Validator` para todos os 16 métodos disponíveis; remove seção "Pending Domain Invariants" (invariantes já estão implementados no código)
- **09-PATTERNS**: adiciona seção `collect()` com exemplos de uso e guia de quando usar `collect` vs loop vs optional; atualiza template de Entity para usar `collect()`
- **ROADMAP**: marca progresso parcial na Fase 3 (UseCase, DTOs, IEmailService, GetFeaturedProjects)

## Test plan

- [ ] Revisar que os exemplos de código nas docs batem com a implementação atual
- [ ] Verificar que nenhuma seção removida ainda é necessária

🤖 Generated with [Claude Code](https://claude.com/claude-code)