### PR TITLE
chore(taskmaster): mark task 5 (GetPublishedProjects) as done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -2536,7 +2536,7 @@
           "1",
           "2"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -2921,9 +2921,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-03-16T01:26:48.269Z",
+      "lastModified": "2026-03-18T21:00:00.000Z",
       "taskCount": 13,
-      "completedCount": 7,
+      "completedCount": 8,
       "tags": [
         "sprint-1"
       ]


### PR DESCRIPTION
## Summary

- Marca task #5 (Implement GetPublishedProjects use case) como `done` em `.taskmaster/tasks/tasks.json`
- Atualiza `completedCount` de 7 para 8 e `lastModified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)