### PR TITLE
chore(taskmaster): fix task 5 (GetPublishedProjects) status to done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -2536,7 +2536,7 @@
           "1",
           "2"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -2922,9 +2922,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-03-18T21:00:00.000Z",
+      "lastModified": "2026-03-18T22:00:00.000Z",
       "taskCount": 13,
-      "completedCount": 9,
+      "completedCount": 10,
       "tags": [
         "sprint-1"
       ]


### PR DESCRIPTION
## Summary

Task 5 foi revertida para `pending` durante uma resolução de conflito no PR #353. Esta PR corrige o status para `done` e atualiza `completedCount` para 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)