### PR TITLE
fix(application): bring GetProjectBySlug use case to develop

### DIFF
--- a/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
+++ b/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
@@ -1,0 +1,95 @@
+import { DomainError, Either, Locale, NotFoundError, Slug, ValidationError, left, right } from '@repo/core/shared';
+import { IProjectRepository, Project } from '@repo/core/portfolio';
+
+import { UseCase } from '../../shared/UseCase';
+import { ProjectDetailDTO } from '../dtos/ProjectDetailDTO';
+import { ProjectSummaryDTO } from '../dtos/ProjectSummaryDTO';
+
+export interface GetProjectBySlugInput {
+  slug: string;
+  locale: Locale;
+}
+
+export class GetProjectBySlug extends UseCase<
+  GetProjectBySlugInput,
+  ProjectDetailDTO,
+  NotFoundError | ValidationError | DomainError
+> {
+  constructor(private readonly projectRepository: IProjectRepository) {
+    super();
+  }
+
+  async execute(
+    input: GetProjectBySlugInput,
+  ): Promise<Either<NotFoundError | ValidationError | DomainError, ProjectDetailDTO>> {
+    const slugResult = Slug.create(input.slug);
+    if (slugResult.isLeft()) return left(slugResult.value);
+
+    let project: Project | null;
+    try {
+      project = await this.projectRepository.findBySlug(slugResult.value);
+    } catch {
+      return left(new DomainError('FETCH_FAILED', { message: 'Failed to fetch project' }));
+    }
+
+    if (!project) {
+      return left(new NotFoundError({ slug: input.slug }));
+    }
+
+    let relatedProjects: Project[];
+    try {
+      relatedProjects = await this.projectRepository.findRelated(project.id, 3);
+    } catch {
+      relatedProjects = [];
+    }
+
+    const relatedDTOs = relatedProjects.map((p) => this.toSummaryDTO(p, input.locale));
+    return right(this.toDetailDTO(project, input.locale, relatedDTOs));
+  }
+
+  private toDetailDTO(
+    project: Project,
+    locale: Locale,
+    relatedProjects: ProjectSummaryDTO[],
+  ): ProjectDetailDTO {
+    return {
+      id: project.id.value,
+      slug: project.slug.value,
+      title: project.title.get(locale),
+      caption: project.caption.get(locale),
+      coverImage: {
+        url: project.coverImage.url.value,
+        alt: project.coverImage.alt.get(locale),
+      },
+      theme: project.theme?.get(locale),
+      skills: project.skills.map((s) => s.description.value),
+      publishedAt: project.period.startAt.value,
+      content: project.content.value,
+      summary: project.summary?.get(locale),
+      objectives: project.objectives?.get(locale),
+      role: project.role?.get(locale),
+      team: project.team,
+      period: {
+        startAt: project.period.startAt.value,
+        endAt: project.period.endAt?.value,
+      },
+      relatedProjects,
+    };
+  }
+
+  private toSummaryDTO(project: Project, locale: Locale): ProjectSummaryDTO {
+    return {
+      id: project.id.value,
+      slug: project.slug.value,
+      title: project.title.get(locale),
+      caption: project.caption.get(locale),
+      coverImage: {
+        url: project.coverImage.url.value,
+        alt: project.coverImage.alt.get(locale),
+      },
+      theme: project.theme?.get(locale),
+      skills: project.skills.map((s) => s.description.value),
+      publishedAt: project.period.startAt.value,
+    };
+  }
+}

--- a/packages/application/src/portfolio/use-cases/index.ts
+++ b/packages/application/src/portfolio/use-cases/index.ts
@@ -1,2 +1,3 @@
 export { GetFeaturedProjects, type GetFeaturedProjectsInput } from './GetFeaturedProjects';
 export { GetPublishedProjects, type GetPublishedProjectsInput } from './GetPublishedProjects';
+export { GetProjectBySlug, type GetProjectBySlugInput } from './GetProjectBySlug';

--- a/packages/application/test/portfolio/GetProjectBySlug.test.ts
+++ b/packages/application/test/portfolio/GetProjectBySlug.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  IProjectProps,
+  IProjectRepository,
+  Project,
+  ProjectStatus,
+} from '@repo/core/portfolio';
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { ProjectDetailDTO } from '~/portfolio/dtos/ProjectDetailDTO';
+import { GetProjectBySlug } from '~/portfolio/use-cases/GetProjectBySlug';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_PROPS: IProjectProps = {
+  slug: 'my-project',
+  coverImage: {
+    url: 'https://example.com/cover.jpg',
+    alt: { 'pt-BR': 'Capa do projeto', 'en-US': 'Project cover' },
+  },
+  title: { 'pt-BR': 'Título do Projeto', 'en-US': 'Project Title' },
+  caption: { 'pt-BR': 'Legenda do projeto', 'en-US': 'Project caption' },
+  content: 'Conteúdo detalhado do projeto aqui.',
+  skills: [],
+  period: { start: '2023-01-01T00:00:00.000Z' },
+  featured: false,
+  status: ProjectStatus.PUBLISHED,
+};
+
+function makeProject(overrides: Partial<IProjectProps> = {}): Project {
+  const result = Project.create({ ...BASE_PROPS, ...overrides });
+  if (result.isLeft()) throw new Error(`makeProject failed: ${result.value.message}`);
+  return result.value;
+}
+
+function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRepository {
+  return {
+    findAll: vi.fn(),
+    findPublished: vi.fn(),
+    findFeatured: vi.fn(),
+    findById: vi.fn(),
+    findBySlug: vi.fn(),
+    findRelated: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GetProjectBySlug', () => {
+  describe('execute()', () => {
+    it('should return Right with ProjectDetailDTO when project is found', async () => {
+      const project = makeProject();
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(project),
+        findRelated: vi.fn().mockResolvedValue([]),
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+    });
+
+    it('should map all ProjectDetailDTO fields correctly', async () => {
+      const project = makeProject({
+        summary: { 'pt-BR': 'Resumo PT', 'en-US': 'Summary EN' },
+        objectives: { 'pt-BR': 'Objetivos PT', 'en-US': 'Objectives EN' },
+        role: { 'pt-BR': 'Papel PT', 'en-US': 'Role EN' },
+        team: 'Team A',
+        period: { start: '2023-01-01T00:00:00.000Z', end: '2023-12-31T00:00:00.000Z' },
+      });
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(project),
+        findRelated: vi.fn().mockResolvedValue([]),
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = result.value as ProjectDetailDTO;
+
+      expect(dto.id).toBe(project.id.value);
+      expect(dto.slug).toBe('my-project');
+      expect(dto.title).toBe('Título do Projeto');
+      expect(dto.caption).toBe('Legenda do projeto');
+      expect(dto.coverImage.url).toBe('https://example.com/cover.jpg');
+      expect(dto.coverImage.alt).toBe('Capa do projeto');
+      expect(dto.content).toBe('Conteúdo detalhado do projeto aqui.');
+      expect(dto.summary).toBe('Resumo PT');
+      expect(dto.objectives).toBe('Objetivos PT');
+      expect(dto.role).toBe('Papel PT');
+      expect(dto.team).toBe('Team A');
+      expect(dto.period.startAt).toBe('2023-01-01T00:00:00.000Z');
+      expect(dto.period.endAt).toBe('2023-12-31T00:00:00.000Z');
+      expect(dto.relatedProjects).toEqual([]);
+    });
+
+    it('should leave optional fields undefined when not set', async () => {
+      const project = makeProject();
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(project),
+        findRelated: vi.fn().mockResolvedValue([]),
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = result.value as ProjectDetailDTO;
+
+      expect(dto.theme).toBeUndefined();
+      expect(dto.summary).toBeUndefined();
+      expect(dto.objectives).toBeUndefined();
+      expect(dto.role).toBeUndefined();
+      expect(dto.team).toBeUndefined();
+      expect(dto.period.endAt).toBeUndefined();
+    });
+
+    it('should use the requested locale for all localized fields', async () => {
+      const project = makeProject({
+        theme: { 'pt-BR': 'Tema PT', 'en-US': 'Theme EN' },
+      });
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(project),
+        findRelated: vi.fn().mockResolvedValue([]),
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      const enResult = await useCase.execute({ slug: 'my-project', locale: 'en-US' });
+
+      expect(enResult.isRight()).toBe(true);
+      const dto = enResult.value as ProjectDetailDTO;
+      expect(dto.title).toBe('Project Title');
+      expect(dto.caption).toBe('Project caption');
+      expect(dto.coverImage.alt).toBe('Project cover');
+      expect(dto.theme).toBe('Theme EN');
+    });
+
+    it('should include related projects as ProjectSummaryDTO', async () => {
+      const project = makeProject();
+      const related = makeProject({ slug: 'related-project' });
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(project),
+        findRelated: vi.fn().mockResolvedValue([related]),
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = result.value as ProjectDetailDTO;
+      expect(dto.relatedProjects).toHaveLength(1);
+      expect(dto.relatedProjects[0]!.slug).toBe('related-project');
+      expect(dto.relatedProjects[0]!.title).toBe('Título do Projeto');
+    });
+
+    it('should call findRelated with project id and limit 3', async () => {
+      const project = makeProject();
+      const findRelated = vi.fn().mockResolvedValue([]);
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(project),
+        findRelated,
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
+
+      expect(findRelated).toHaveBeenCalledWith(project.id, 3);
+    });
+
+    it('should return Left with NotFoundError when project does not exist', async () => {
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(null),
+        findRelated: vi.fn().mockResolvedValue([]),
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      const result = await useCase.execute({ slug: 'non-existent', locale: 'pt-BR' });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+
+    it('should return Left with ValidationError when slug is invalid', async () => {
+      const repo = makeRepository();
+      const useCase = new GetProjectBySlug(repo);
+
+      const result = await useCase.execute({ slug: 'ab', locale: 'pt-BR' });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should not call repository when slug is invalid', async () => {
+      const findBySlug = vi.fn();
+      const repo = makeRepository({ findBySlug });
+      const useCase = new GetProjectBySlug(repo);
+
+      await useCase.execute({ slug: '', locale: 'pt-BR' });
+
+      expect(findBySlug).not.toHaveBeenCalled();
+    });
+
+    it('should return Left with DomainError when repository throws', async () => {
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+      expect((result.value as DomainError).code).toBe('FETCH_FAILED');
+    });
+
+    it('should return Right with empty relatedProjects when findRelated throws', async () => {
+      const project = makeProject();
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(project),
+        findRelated: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+      const useCase = new GetProjectBySlug(repo);
+
+      const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = result.value as ProjectDetailDTO;
+      expect(dto.relatedProjects).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Cherry-picks the `GetProjectBySlug` use case from `279-t-14-implementar-use-case-getprojectbyslug-1` which was accidentally merged into the feature branch instead of `develop`
- No code changes — identical to the original commit `eed1dc4`
- All 27 application tests pass

## Test plan

- [x] `pnpm --filter @repo/application run test` — 27 tests pass (GetFeaturedProjects, GetPublishedProjects, GetProjectBySlug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)