### PR TITLE
feat(application): add GetExperiences use case

### DIFF
--- a/packages/application/src/portfolio/use-cases/GetExperiences.ts
+++ b/packages/application/src/portfolio/use-cases/GetExperiences.ts
@@ -1,0 +1,58 @@
+import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
+import { Experience, ExperienceSkill, IExperienceRepository } from '@repo/core/portfolio';
+
+import { UseCase } from '../../shared/UseCase';
+import { ExperienceDTO } from '../dtos/ExperienceDTO';
+import { ExperienceSkillDTO } from '../dtos/ExperienceSkillDTO';
+
+export interface GetExperiencesInput {
+  locale: Locale;
+}
+
+export class GetExperiences extends UseCase<GetExperiencesInput, ExperienceDTO[]> {
+  constructor(private readonly experienceRepository: IExperienceRepository) {
+    super();
+  }
+
+  async execute(input: GetExperiencesInput): Promise<Either<DomainError, ExperienceDTO[]>> {
+    try {
+      const experiences = await this.experienceRepository.findAll();
+      const sorted = [...experiences].sort((a, b) => b.period.startAt.ms - a.period.startAt.ms);
+      return right(sorted.map((e) => this.toDTO(e, input.locale)));
+    } catch {
+      return left(
+        new DomainError('FETCH_FAILED', {
+          message: 'Failed to fetch experiences',
+        }),
+      );
+    }
+  }
+
+  private toDTO(experience: Experience, locale: Locale): ExperienceDTO {
+    return {
+      id: experience.id.value,
+      company: experience.company.get(locale),
+      position: experience.position.get(locale),
+      location: experience.location.get(locale),
+      description: experience.description.get(locale),
+      logo: {
+        url: experience.logo.url.value,
+        alt: experience.logo.alt.get(locale),
+      },
+      employmentType: experience.employment_type.value,
+      locationType: experience.location_type.value,
+      startAt: experience.period.startAt.value,
+      endAt: experience.period.endAt?.value,
+      skills: experience.skills.map((s) => this.toSkillDTO(s, locale)),
+    };
+  }
+
+  private toSkillDTO(skill: ExperienceSkill, locale: Locale): ExperienceSkillDTO {
+    return {
+      id: skill.skill.id.value,
+      name: skill.skill.description.value,
+      type: skill.skill.type.value,
+      workDescription: skill.workDescription.get(locale),
+    };
+  }
+}

--- a/packages/application/src/portfolio/use-cases/index.ts
+++ b/packages/application/src/portfolio/use-cases/index.ts
@@ -1,3 +1,4 @@
+export { GetExperiences, type GetExperiencesInput } from './GetExperiences';
 export { GetFeaturedProjects, type GetFeaturedProjectsInput } from './GetFeaturedProjects';
 export { GetPublishedProjects, type GetPublishedProjectsInput } from './GetPublishedProjects';
 export { GetProjectBySlug, type GetProjectBySlugInput } from './GetProjectBySlug';

--- a/packages/application/test/portfolio/GetExperiences.test.ts
+++ b/packages/application/test/portfolio/GetExperiences.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  Experience,
+  IExperienceProps,
+  IExperienceRepository,
+} from '@repo/core/portfolio';
+import { DomainError } from '@repo/core/shared';
+
+import { ExperienceDTO } from '~/portfolio/dtos/ExperienceDTO';
+import { GetExperiences } from '~/portfolio/use-cases/GetExperiences';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_SKILL_PROPS = {
+  skill: { description: 'TypeScript', icon: 'ts', type: 'TECHNOLOGY' as const },
+  workDescription: { 'pt-BR': 'Desenvolvimento com TypeScript', 'en-US': 'TypeScript development' },
+};
+
+const BASE_PROPS: IExperienceProps = {
+  company: { 'pt-BR': 'Empresa Exemplo', 'en-US': 'Example Company' },
+  position: { 'pt-BR': 'Engenheiro de Software', 'en-US': 'Software Engineer' },
+  location: { 'pt-BR': 'São Paulo, Brasil', 'en-US': 'São Paulo, Brazil' },
+  description: { 'pt-BR': 'Descrição do trabalho', 'en-US': 'Job description' },
+  logo: { url: 'https://example.com/logo.png', alt: { 'pt-BR': 'Logo da empresa', 'en-US': 'Company logo' } },
+  employment_type: 'FULL_TIME',
+  location_type: 'HYBRID',
+  start_at: '2022-01-01T00:00:00.000Z',
+  end_at: '2023-01-01T00:00:00.000Z',
+  skills: [BASE_SKILL_PROPS],
+};
+
+function makeExperience(overrides: Partial<IExperienceProps> = {}): Experience {
+  const result = Experience.create({ ...BASE_PROPS, ...overrides });
+  if (result.isLeft()) throw new Error(`makeExperience failed: ${result.value.message}`);
+  return result.value;
+}
+
+function makeRepository(overrides: Partial<IExperienceRepository> = {}): IExperienceRepository {
+  return {
+    findAll: vi.fn(),
+    findById: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GetExperiences', () => {
+  describe('execute()', () => {
+    it('should return Right with empty array when repository returns no experiences', async () => {
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([]) });
+      const useCase = new GetExperiences(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      expect(result.value).toEqual([]);
+    });
+
+    it('should return Right with mapped DTOs when repository returns experiences', async () => {
+      const experience = makeExperience();
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([experience]) });
+      const useCase = new GetExperiences(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      expect(result.value as ExperienceDTO[]).toHaveLength(1);
+    });
+
+    it('should sort experiences by startAt descending (newest first)', async () => {
+      const oldest = makeExperience({ start_at: '2020-01-01T00:00:00.000Z', end_at: '2021-01-01T00:00:00.000Z', company: { 'pt-BR': 'oldest' } });
+      const middle = makeExperience({ start_at: '2021-06-01T00:00:00.000Z', end_at: '2022-06-01T00:00:00.000Z', company: { 'pt-BR': 'middle' } });
+      const newest = makeExperience({ start_at: '2023-01-01T00:00:00.000Z', end_at: '2024-01-01T00:00:00.000Z', company: { 'pt-BR': 'newest' } });
+
+      const repo = makeRepository({
+        findAll: vi.fn().mockResolvedValue([oldest, newest, middle]),
+      });
+      const useCase = new GetExperiences(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dtos = result.value as ExperienceDTO[];
+      expect(dtos[0]!.company).toBe('newest');
+      expect(dtos[1]!.company).toBe('middle');
+      expect(dtos[2]!.company).toBe('oldest');
+    });
+
+    it('should not mutate the original array from the repository', async () => {
+      const oldest = makeExperience({ start_at: '2020-01-01T00:00:00.000Z', end_at: '2021-01-01T00:00:00.000Z' });
+      const newest = makeExperience({ start_at: '2023-01-01T00:00:00.000Z', end_at: '2024-01-01T00:00:00.000Z' });
+      const original = [oldest, newest];
+
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue(original) });
+      const useCase = new GetExperiences(repo);
+
+      await useCase.execute({ locale: 'pt-BR' });
+
+      expect(original[0]!.period.startAt.value).toBe('2020-01-01T00:00:00.000Z');
+      expect(original[1]!.period.startAt.value).toBe('2023-01-01T00:00:00.000Z');
+    });
+
+    it('should map all DTO fields correctly for pt-BR locale', async () => {
+      const experience = makeExperience();
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([experience]) });
+      const useCase = new GetExperiences(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = (result.value as ExperienceDTO[])[0]!;
+
+      expect(dto.id).toBe(experience.id.value);
+      expect(dto.company).toBe('Empresa Exemplo');
+      expect(dto.position).toBe('Engenheiro de Software');
+      expect(dto.location).toBe('São Paulo, Brasil');
+      expect(dto.description).toBe('Descrição do trabalho');
+      expect(dto.logo).toEqual({ url: 'https://example.com/logo.png', alt: 'Logo da empresa' });
+      expect(dto.employmentType).toBe('FULL_TIME');
+      expect(dto.locationType).toBe('HYBRID');
+      expect(dto.startAt).toBe('2022-01-01T00:00:00.000Z');
+      expect(dto.endAt).toBe('2023-01-01T00:00:00.000Z');
+    });
+
+    it('should map localized fields using the requested locale', async () => {
+      const experience = makeExperience();
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([experience]) });
+      const useCase = new GetExperiences(repo);
+
+      const ptResult = await useCase.execute({ locale: 'pt-BR' });
+      const enResult = await useCase.execute({ locale: 'en-US' });
+
+      expect(ptResult.isRight()).toBe(true);
+      expect(enResult.isRight()).toBe(true);
+
+      const ptDto = (ptResult.value as ExperienceDTO[])[0]!;
+      const enDto = (enResult.value as ExperienceDTO[])[0]!;
+
+      expect(ptDto.company).toBe('Empresa Exemplo');
+      expect(ptDto.position).toBe('Engenheiro de Software');
+      expect(enDto.company).toBe('Example Company');
+      expect(enDto.position).toBe('Software Engineer');
+    });
+
+    it('should map skills with workDescription correctly', async () => {
+      const experience = makeExperience({
+        skills: [
+          {
+            skill: { description: 'TypeScript', icon: 'ts', type: 'TECHNOLOGY' },
+            workDescription: { 'pt-BR': 'Uso de TypeScript', 'en-US': 'TypeScript usage' },
+          },
+          {
+            skill: { description: 'React', icon: 'react', type: 'TECHNOLOGY' },
+            workDescription: { 'pt-BR': 'Desenvolvimento React', 'en-US': 'React development' },
+          },
+        ],
+      });
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([experience]) });
+      const useCase = new GetExperiences(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = (result.value as ExperienceDTO[])[0]!;
+
+      expect(dto.skills).toHaveLength(2);
+      expect(dto.skills[0]!.name).toBe('TypeScript');
+      expect(dto.skills[0]!.type).toBe('TECHNOLOGY');
+      expect(dto.skills[0]!.workDescription).toBe('Uso de TypeScript');
+      expect(dto.skills[1]!.name).toBe('React');
+      expect(dto.skills[1]!.workDescription).toBe('Desenvolvimento React');
+    });
+
+    it('should map skill workDescription using the requested locale', async () => {
+      const experience = makeExperience({
+        skills: [
+          {
+            skill: { description: 'TypeScript', icon: 'ts', type: 'TECHNOLOGY' },
+            workDescription: { 'pt-BR': 'Uso de TypeScript', 'en-US': 'TypeScript usage' },
+          },
+        ],
+      });
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([experience]) });
+      const useCase = new GetExperiences(repo);
+
+      const ptResult = await useCase.execute({ locale: 'pt-BR' });
+      const enResult = await useCase.execute({ locale: 'en-US' });
+
+      const ptDto = (ptResult.value as ExperienceDTO[])[0]!;
+      const enDto = (enResult.value as ExperienceDTO[])[0]!;
+
+      expect(ptDto.skills[0]!.workDescription).toBe('Uso de TypeScript');
+      expect(enDto.skills[0]!.workDescription).toBe('TypeScript usage');
+    });
+
+    it('should include endAt as undefined when experience has no end date', async () => {
+      const experience = makeExperience({ end_at: undefined });
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([experience]) });
+      const useCase = new GetExperiences(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = (result.value as ExperienceDTO[])[0]!;
+      expect(dto.endAt).toBeUndefined();
+    });
+
+    it('should return Left with DomainError when repository throws', async () => {
+      const repo = makeRepository({
+        findAll: vi.fn().mockRejectedValue(new Error('DB connection failed')),
+      });
+      const useCase = new GetExperiences(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+      expect((result.value as DomainError).code).toBe('FETCH_FAILED');
+    });
+
+    it('should call findAll() on the repository', async () => {
+      const findAll = vi.fn().mockResolvedValue([]);
+      const repo = makeRepository({ findAll });
+      const useCase = new GetExperiences(repo);
+
+      await useCase.execute({ locale: 'pt-BR' });
+
+      expect(findAll).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the `GetExperiences` use case (Task T-15, issue #280)
- Accepts `{ locale: Locale }` input, returns `Either<DomainError, ExperienceDTO[]>`
- Sorts experiences by `startAt` DESC without mutating the repository array
- Maps all `Experience` entity fields to `ExperienceDTO`, including `logo` and optional `endAt`
- Maps each `ExperienceSkill` to `ExperienceSkillDTO` with localized `workDescription`
- Exports the use case from the `use-cases/index.ts` barrel

## Test plan

- [x] 11 unit tests covering:
  - Empty array result
  - Mapped DTOs
  - Sorting DESC by `startAt`
  - Array immutability
  - All DTO fields (pt-BR)
  - Locale handling (pt-BR vs en-US)
  - Skills with localized `workDescription`
  - `endAt` as `undefined` when not present
  - `DomainError` with `FETCH_FAILED` on repository failure
  - `findAll()` called exactly once
- [x] `pnpm --filter @repo/application run test` — 27 tests pass

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)