### PR TITLE
chore(taskmaster): mark task 9 (SendContactMessage) as done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -2816,7 +2816,7 @@
           "1",
           "3"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -2867,7 +2867,8 @@
         ],
         "complexity": 5,
         "recommendedSubtasks": 4,
-        "expansionPrompt": "Implement SendContactMessage use case with comprehensive input validation: (1) Create use case class with IEmailService DI and SendContactMessageInput interface, implement execute() method signature returning Either<ValidationError | DomainError, void>, (2) Implement validation logic for name (required, non-whitespace), email (required, regex format validation), and message (required, non-whitespace) with early returns on ValidationError, (3) Implement DTO construction with trimmed values and emailService.send() orchestration with error propagation, (4) Create comprehensive test suite covering: happy path with successful send, 6+ validation error scenarios (empty name, whitespace-only name, empty email, invalid email formats, empty message, whitespace-only message), trimming verification, email service error propagation, and verification that emailService.send() is NOT called when validation fails."
+        "expansionPrompt": "Implement SendContactMessage use case with comprehensive input validation: (1) Create use case class with IEmailService DI and SendContactMessageInput interface, implement execute() method signature returning Either<ValidationError | DomainError, void>, (2) Implement validation logic for name (required, non-whitespace), email (required, regex format validation), and message (required, non-whitespace) with early returns on ValidationError, (3) Implement DTO construction with trimmed values and emailService.send() orchestration with error propagation, (4) Create comprehensive test suite covering: happy path with successful send, 6+ validation error scenarios (empty name, whitespace-only name, empty email, invalid email formats, empty message, whitespace-only message), trimming verification, email service error propagation, and verification that emailService.send() is NOT called when validation fails.",
+        "updatedAt": "2026-03-18T03:07:25.140Z"
       },
       {
         "id": "10",
@@ -2924,9 +2925,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-03-18T02:47:24.036Z",
+      "lastModified": "2026-03-18T03:07:25.140Z",
       "taskCount": 13,
-      "completedCount": 12,
+      "completedCount": 13,
       "tags": [
         "sprint-1"
       ]


### PR DESCRIPTION
Updates `.taskmaster/tasks/tasks.json` to mark task 9 (SendContactMessage) as `done`.

PR #361 has been opened with the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)