### PR TITLE
feat: organize Claude skills and add mattpocock/skills

### DIFF
--- a/.claude/skills/engineering-standards/SKILL.md
+++ b/.claude/skills/engineering-standards/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: engineering-standards
+description: Apply DDD, Clean Architecture, Either pattern, validation, and testing standards. Use when implementing features, entities, value objects, use cases, or when no other skill clearly applies.
+---
+
+# Engineering Standards (DDD / Clean Architecture)
+
+## Use when
+
+- User asks to implement features, entities, value objects, use cases, repositories, or API contracts.
+- User mentions **DDD**, **Clean Architecture**, **Either**, **Validator**, **Value Object**, **Entity**, **bounded context**, **dependency rule**, or layer boundaries.
+- No other skill (task-master, vscode-rules, self-improve) clearly matches the request — treat as default for implementation work.
+
+## Reference (single source of truth)
+
+- Root [CLAUDE.md](../../../CLAUDE.md) — role, monorepo structure, dependency rule, DDD templates (Either, VO, Entity), anti-patterns, general standards
+- [docs/INDEX.md](../../../docs/INDEX.md) — documentation map
+- [docs/02-ARCHITECTURE.md](../../../docs/02-ARCHITECTURE.md) — layers and ESLint enforcement
+- [docs/06-VALIDATION.md](../../../docs/06-VALIDATION.md) — Validator and domain validation
+- [docs/09-PATTERNS.md](../../../docs/09-PATTERNS.md) — Either, VO, Entity, Repository, collect()
+- [docs/08-TESTING.md](../../../docs/08-TESTING.md) — testing strategy and naming
+
+Do not duplicate long content here; use the references above for full templates and rules.

--- a/.claude/skills/git-guardrails-claude-code/SKILL.md
+++ b/.claude/skills/git-guardrails-claude-code/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: git-guardrails-claude-code
+description: Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.
+---
+
+# Setup Git Guardrails
+
+Sets up a PreToolUse hook that intercepts and blocks dangerous git commands before Claude executes them.
+
+## What Gets Blocked
+
+- `git push` (all variants including `--force`)
+- `git reset --hard`
+- `git clean -f` / `git clean -fd`
+- `git branch -D`
+- `git checkout .` / `git restore .`
+
+When blocked, Claude sees a message telling it that it does not have authority to access these commands.
+
+## Steps
+
+### 1. Ask scope
+
+Ask the user: install for **this project only** (`.claude/settings.json`) or **all projects** (`~/.claude/settings.json`)?
+
+### 2. Copy the hook script
+
+The bundled script is at: [scripts/block-dangerous-git.sh](scripts/block-dangerous-git.sh)
+
+Copy it to the target location based on scope:
+
+- **Project**: `.claude/hooks/block-dangerous-git.sh`
+- **Global**: `~/.claude/hooks/block-dangerous-git.sh`
+
+Make it executable with `chmod +x`.
+
+### 3. Add hook to settings
+
+Add to the appropriate settings file:
+
+**Project** (`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Global** (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If the settings file already exists, merge the hook into existing `hooks.PreToolUse` array — don't overwrite other settings.
+
+### 4. Ask about customization
+
+Ask if user wants to add or remove any patterns from the blocked list. Edit the copied script accordingly.
+
+### 5. Verify
+
+Run a quick test:
+
+```bash
+echo '{"tool_input":{"command":"git push origin main"}}' | <path-to-script>
+```
+
+Should exit with code 2 and print a BLOCKED message to stderr.

--- a/.claude/skills/git-guardrails-claude-code/scripts/block-dangerous-git.sh
+++ b/.claude/skills/git-guardrails-claude-code/scripts/block-dangerous-git.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+
+DANGEROUS_PATTERNS=(
+ "git push"
+ "git reset --hard"
+ "git clean -fd"
+ "git clean -f"
+ "git branch -D"
+ "git checkout \."
+ "git restore \."
+ "push --force"
+ "reset --hard"
+)
+
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+ if echo "$COMMAND" | grep -qE "$pattern"; then
+ echo "BLOCKED: '$COMMAND' matches dangerous pattern '$pattern'. The user has prevented you from doing this." >&2
+ exit 2
+ fi
+done
+
+exit 0

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/.claude/skills/improve-codebase-architecture/REFERENCE.md
+++ b/.claude/skills/improve-codebase-architecture/REFERENCE.md
@@ -1,0 +1,76 @@
+# Reference
+
+## Dependency Categories
+
+When assessing a candidate for deepening, classify its dependencies:
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — just merge the modules and test directly.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (e.g., PGLite for Postgres, in-memory filesystem). Deepenable if the test substitute exists. The deepened module is tested with the local stand-in running in the test suite.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a port (interface) at the module boundary. The deep module owns the logic; the transport is injected. Tests use an in-memory adapter. Production uses the real HTTP/gRPC/queue adapter.
+
+Recommendation shape: "Define a shared interface (port), implement an HTTP adapter for production and an in-memory adapter for testing, so the logic can be tested as one deep module even though it's deployed across a network boundary."
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. Mock at the boundary. The deepened module takes the external dependency as an injected port, and tests provide a mock implementation.
+
+## Testing Strategy
+
+The core principle: **replace, don't layer.**
+
+- Old unit tests on shallow modules are waste once boundary tests exist — delete them
+- Write new tests at the deepened module's interface boundary
+- Tests assert on observable outcomes through the public interface, not internal state
+- Tests should survive internal refactors — they describe behavior, not implementation
+
+## Issue Template
+
+```markdown
+## Problem
+
+Describe the architectural friction:
+
+- Which modules are shallow and tightly coupled
+- What integration risk exists in the seams between them
+- Why this makes the codebase harder to navigate and maintain
+
+## Proposed Interface
+
+The chosen interface design:
+
+- Interface signature (types, methods, params)
+- Usage example showing how callers use it
+- What complexity it hides internally
+
+## Dependency Strategy
+
+Which category applies and how dependencies are handled:
+
+- **In-process**: merged directly
+- **Local-substitutable**: tested with [specific stand-in]
+- **Ports & adapters**: port definition, production adapter, test adapter
+- **Mock**: mock boundary for external services
+
+## Testing Strategy
+
+- **New boundary tests to write**: describe the behaviors to verify at the interface
+- **Old tests to delete**: list the shallow module tests that become redundant
+- **Test environment needs**: any local stand-ins or adapters required
+
+## Implementation Recommendations
+
+Durable architectural guidance that is NOT coupled to current file paths:
+
+- What the module should own (responsibilities)
+- What it should hide (implementation details)
+- What it should expose (the interface contract)
+- How callers should migrate to the new interface
+```

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: improve-codebase-architecture
+description: Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Explore a codebase like an AI would, surface architectural friction, discover opportunities for improving testability, and propose module-deepening refactors as GitHub issue RFCs.
+
+A **deep module** (John Ousterhout, "A Philosophy of Software Design") has a small interface hiding a large implementation. Deep modules are more testable, more AI-navigable, and let you test at the boundary instead of inside.
+
+## Process
+
+### 1. Explore the codebase
+
+Use the Agent tool with subagent_type=Explore to navigate the codebase naturally. Do NOT follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small files?
+- Where are modules so shallow that the interface is nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called?
+- Where do tightly-coupled modules create integration risk in the seams between them?
+- Which parts of the codebase are untested, or hard to test?
+
+The friction you encounter IS the signal.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate, show:
+
+- **Cluster**: Which modules/concepts are involved
+- **Why they're coupled**: Shared types, call patterns, co-ownership of a concept
+- **Dependency category**: See [REFERENCE.md](REFERENCE.md) for the four categories
+- **Test impact**: What existing tests would be replaced by boundary tests
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. User picks a candidate
+
+### 4. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would need to rely on
+- A rough illustrative code sketch to make the constraints concrete — this is not a proposal, just a way to ground the constraints
+
+Show this to the user, then immediately proceed to Step 5. The user reads and thinks about the problem while the sub-agents work in parallel.
+
+### 5. Design multiple interfaces
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category, what's being hidden). This brief is independent of the user-facing explanation in Step 4. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1-3 entry points max"
+- Agent 2: "Maximize flexibility — support many use cases and extension"
+- Agent 3: "Optimize for the most common caller — make the default case trivial"
+- Agent 4 (if applicable): "Design around the ports & adapters pattern for cross-boundary dependencies"
+
+Each sub-agent outputs:
+
+1. Interface signature (types, methods, params)
+2. Usage example showing how callers use it
+3. What complexity it hides internally
+4. Dependency strategy (how deps are handled — see [REFERENCE.md](REFERENCE.md))
+5. Trade-offs
+
+Present designs sequentially, then compare them in prose.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not just a menu.
+
+### 6. User picks an interface (or accepts recommendation)
+
+### 7. Create GitHub issue
+
+Create a refactor RFC as a GitHub issue using `gh issue create`. Use the template in [REFERENCE.md](REFERENCE.md). Do NOT ask the user to review before creating — just create it and share the URL.

--- a/.claude/skills/prd-to-issues/SKILL.md
+++ b/.claude/skills/prd-to-issues/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: prd-to-issues
+description: Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.
+---
+
+# PRD to Issues
+
+Break a PRD into independently-grabbable GitHub issues using vertical slices (tracer bullets).
+
+## Process
+
+### 1. Locate the PRD
+
+Ask the user for the PRD GitHub issue number (or URL).
+
+If the PRD is not already in your context window, fetch it with `gh issue view <number>` (with comments).
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code.
+
+### 3. Draft vertical slices
+
+Break the PRD into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
+
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Prefer many thin slices over few thick ones
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Type**: HITL / AFK
+- **Blocked by**: which other slices (if any) must complete first
+- **User stories covered**: which user stories from the PRD this addresses
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+- Are the correct slices marked as HITL and AFK?
+
+Iterate until the user approves the breakdown.
+
+### 5. Create the GitHub issues
+
+For each approved slice, create a GitHub issue using `gh issue create`. Use the issue body template below.
+
+Create issues in dependency order (blockers first) so you can reference real issue numbers in the "Blocked by" field.
+
+```markdown
+## Parent PRD
+
+#<issue-number>
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation. Reference specific sections of the parent PRD rather than duplicating content.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Blocked by
+
+- Blocked by #<n> (if any)
+
+Or "None - can start immediately" if no blockers.
+
+## User stories addressed
+
+Reference by number from the parent PRD:
+
+- User story 3
+- User story 7
+```
+
+Do NOT close or modify the parent PRD issue.

--- a/.claude/skills/prd-to-plan/SKILL.md
+++ b/.claude/skills/prd-to-plan/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: prd-to-plan
+description: Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in ./plans/. Use when user wants to break down a PRD, create an implementation plan, plan phases from a PRD, or mentions "tracer bullets".
+---
+
+# PRD to Plan
+
+Break a PRD into a phased implementation plan using vertical slices (tracer bullets). Output is a Markdown file in `./plans/`.
+
+## Process
+
+### 1. Confirm the PRD is in context
+
+The PRD should already be in the conversation. If it isn't, ask the user to paste it or point you to the file.
+
+### 2. Explore the codebase
+
+If you have not already explored the codebase, do so to understand the current architecture, existing patterns, and integration layers.
+
+### 3. Identify durable architectural decisions
+
+Before slicing, identify high-level decisions that are unlikely to change throughout implementation:
+
+- Route structures / URL patterns
+- Database schema shape
+- Key data models
+- Authentication / authorization approach
+- Third-party service boundaries
+
+These go in the plan header so every phase can reference them.
+
+### 4. Draft vertical slices
+
+Break the PRD into **tracer bullet** phases. Each phase is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Prefer many thin slices over few thick ones
+- Do NOT include specific file names, function names, or implementation details that are likely to change as later phases are built
+- DO include durable decisions: route paths, schema shapes, data model names
+
+### 5. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each phase show:
+
+- **Title**: short descriptive name
+- **User stories covered**: which user stories from the PRD this addresses
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Should any phases be merged or split further?
+
+Iterate until the user approves the breakdown.
+
+### 6. Write the plan file
+
+Create `./plans/` if it doesn't exist. Write the plan as a Markdown file named after the feature (e.g. `./plans/user-onboarding.md`). Use the template below.
+
+```markdown
+# Plan: <name>
+
+> Source PRD: <reference>
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Routes**: ...
+- **Schema**: ...
+- **Key models**: ...
+- (add/remove sections as appropriate)
+
+---
+
+## Phase 1: <title>
+
+**User stories**: <refs>
+
+### What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+### Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+---
+
+## Phase 2: <title>
+
+**User stories**: <refs>
+
+### What to build
+
+...
+
+### Acceptance criteria
+
+- [ ] ...
+```

--- a/.claude/skills/request-refactor-plan/SKILL.md
+++ b/.claude/skills/request-refactor-plan/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: request-refactor-plan
+description: Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+---
+
+This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.
+
+1. Ask the user for a long, detailed description of the problem they want to solve and any potential ideas for solutions.
+
+2. Explore the repo to verify their assertions and understand the current state of the codebase.
+
+3. Ask whether they have considered other options, and present other options to them.
+
+4. Interview the user about the implementation. Be extremely detailed and thorough.
+
+5. Hammer out the exact scope of the implementation. Work out what you plan to change and what you plan not to change.
+
+6. Look in the codebase to check for test coverage of this area of the codebase. If there is insufficient test coverage, ask the user what their plans for testing are.
+
+7. Break the implementation into a plan of tiny commits. Remember Martin Fowler's advice to "make each refactoring step as small as possible, so that you can always see the program working."
+
+8. Create a GitHub issue with the refactor plan. Use the following template for the issue description:
+
+```markdown
+## Problem Statement
+
+The problem that the developer is facing, from the developer's perspective.
+
+## Solution
+
+The solution to the problem, from the developer's perspective.
+
+## Commits
+
+A LONG, detailed implementation plan. Write the plan in plain English, breaking down the implementation into the tiniest commits possible. Each commit should leave the codebase in a working state.
+
+## Decision Document
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this refactor.
+
+## Further Notes (optional)
+
+Any further notes about the refactor.
+```

--- a/.claude/skills/self-improve/SKILL.md
+++ b/.claude/skills/self-improve/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: self-improve
+description: Continuously improve rules and instructions from code patterns and best practices. Use when the user asks to improve rules, add new patterns, or evolve instructions from repeated code.
+---
+
+# Self-Improve Rules
+
+## Use when
+
+- User mentions **self-improve**, **improve rules**, **evolve rules**, **new patterns**, or updating instructions from repeated implementations.
+- User wants to add or modify rules based on emerging patterns, code reviews, or new libraries in the codebase.
+
+## Reference (single source of truth)
+
+Follow guidelines from:
+
+- [self_improve.instructions.md](../../../.github/instructions/self_improve.instructions.md) — triggers, analysis process, when to add/modify rules, quality checks, deprecation
+- [vscode_rules.instructions.md](../../../.github/instructions/vscode_rules.instructions.md) — rule formatting when creating or updating rule files
+
+Do not duplicate long content here; use the references above for full procedures.

--- a/.claude/skills/task-master/SKILL.md
+++ b/.claude/skills/task-master/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: task-master
+description: Plan and execute work using Task Master (MCP tools and CLI). Use when the user talks about tasks, PRD, parse-prd, set-status, task IDs, next task, expand, or workflow planning.
+---
+
+# Task Master
+
+## Use when
+
+- User mentions **task-master**, **Task Master**, **tasks**, **parse-prd**, **set-status**, **next task**, **show task**, task IDs (e.g. 1.2), **expand**, **PRD**, **sprint**, or planning/backlog workflow.
+- User wants to list tasks, get next task, update subtask, add task, or manage dependencies.
+- User refers to `.taskmaster/`, `tasks.json`, or tagged task lists.
+
+## Reference (single source of truth)
+
+Follow instructions and command reference from:
+
+- [taskmaster.instructions.md](../../../.github/instructions/taskmaster.instructions.md) — MCP tools and CLI reference
+- [dev_workflow.instructions.md](../../../.github/instructions/dev_workflow.instructions.md) — development workflow and tag-based workflows
+- [.taskmaster/CLAUDE.md](../../../.taskmaster/CLAUDE.md) — Task Master integration guide
+- Slash commands: [.claude/commands/tm/](../../commands/tm/) — individual command prompts
+
+Do not duplicate long content here; consult the references above for full procedures.

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: tdd
+description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+Before writing any code:
+
+- [ ] Confirm with user what interface changes are needed
+- [ ] Confirm with user which behaviors to test (prioritize)
+- [ ] Identify opportunities for [deep modules](deep-modules.md) (small interface, deep implementation)
+- [ ] Design interfaces for [testability](interface-design.md)
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] Get user approval on the plan
+
+Ask: "What should the public interface look like? Which behaviors are most important to test?"
+
+**You can't test everything.** Confirm with the user exactly which behaviors matter most. Focus testing effort on critical paths and complex logic, not every possible edge case.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/.claude/skills/tdd/deep-modules.md
+++ b/.claude/skills/tdd/deep-modules.md
@@ -1,0 +1,33 @@
+# Deep Modules
+
+From "A Philosophy of Software Design":
+
+**Deep module** = small interface + lots of implementation
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid)
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing interfaces, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?

--- a/.claude/skills/tdd/interface-design.md
+++ b/.claude/skills/tdd/interface-design.md
@@ -1,0 +1,31 @@
+# Interface Design for Testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area**
+ - Fewer methods = fewer tests needed
+ - Fewer params = simpler test setup

--- a/.claude/skills/tdd/mocking.md
+++ b/.claude/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.claude/skills/tdd/refactoring.md
+++ b/.claude/skills/tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/.claude/skills/tdd/tests.md
+++ b/.claude/skills/tdd/tests.md
@@ -1,0 +1,61 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```

--- a/.claude/skills/ubiquitous-language/SKILL.md
+++ b/.claude/skills/ubiquitous-language/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: ubiquitous-language
+description: Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions "domain model" or "DDD".
+---
+
+# Ubiquitous Language
+
+Extract and formalize domain terminology from the current conversation into a consistent glossary, saved to a local file.
+
+## Process
+
+1. **Scan the conversation** for domain-relevant nouns, verbs, and concepts
+2. **Identify problems**:
+   - Same word used for different concepts (ambiguity)
+   - Different words used for the same concept (synonyms)
+   - Vague or overloaded terms
+3. **Propose a canonical glossary** with opinionated term choices
+4. **Write to `UBIQUITOUS_LANGUAGE.md`** in the working directory using the format below
+5. **Output a summary** inline in the conversation
+
+## Output Format
+
+Write a `UBIQUITOUS_LANGUAGE.md` file with this structure:
+
+```md
+# Ubiquitous Language
+
+## Order lifecycle
+
+| Term | Definition | Aliases to avoid |
+|------|-----------|-----------------|
+| **Order** | A customer's request to purchase one or more items | Purchase, transaction |
+| **Invoice** | A request for payment sent to a customer after delivery | Bill, payment request |
+
+## People
+
+| Term | Definition | Aliases to avoid |
+|------|-----------|-----------------|
+| **Customer** | A person or organization that places orders | Client, buyer, account |
+| **User** | An authentication identity in the system | Login, account |
+
+## Relationships
+
+- An **Invoice** belongs to exactly one **Customer**
+- An **Order** produces one or more **Invoices**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed. A single **Order** can produce multiple **Invoices** if items ship in separate **Shipments**."
+> **Dev:** "So if a **Shipment** is cancelled before dispatch, no **Invoice** exists for it?"
+> **Domain expert:** "Exactly. The **Invoice** lifecycle is tied to the **Fulfillment**, not the **Order**."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — these are distinct concepts: a **Customer** places orders, while a **User** is an authentication identity that may or may not represent a **Customer**.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously in the conversation, call it out in the "Flagged ambiguities" section with a clear recommendation.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include domain terms.** Skip generic programming concepts (array, function, endpoint) unless they have domain-specific meaning.
+- **Group terms into multiple tables** when natural clusters emerge (e.g. by subdomain, lifecycle, or actor). Each group gets its own heading and table. If all terms belong to a single cohesive domain, one table is fine — don't force groupings.
+- **Write an example dialogue.** A short conversation (3-5 exchanges) between a dev and a domain expert that demonstrates how the terms interact naturally. The dialogue should clarify boundaries between related concepts and show terms being used precisely.
+
+## Re-running
+
+When invoked again in the same conversation:
+
+1. Read the existing `UBIQUITOUS_LANGUAGE.md`
+2. Incorporate any new terms from subsequent discussion
+3. Update definitions if understanding has evolved
+4. Mark changed entries with "(updated)" and new entries with "(new)"
+5. Re-flag any new ambiguities
+6. Rewrite the example dialogue to incorporate new terms
+
+## Post-output instruction
+
+After writing the file, state:
+
+> I've written/updated `UBIQUITOUS_LANGUAGE.md`. From this point forward I will use these terms consistently. If I drift from this language or you notice a term that should be added, let me know.
+
+**Note:** This project also has [docs/10-GLOSSARY.md](../../../docs/10-GLOSSARY.md) for domain and architectural terms. Consider syncing or cross-referencing with it when relevant.

--- a/.claude/skills/vscode-rules/SKILL.md
+++ b/.claude/skills/vscode-rules/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: vscode-rules
+description: Create or maintain VS Code/Cursor rules and instruction files. Use when the user asks about rules, globs, alwaysApply, .instructions.md, or Cursor/VS Code rule structure.
+---
+
+# VS Code / Cursor Rules
+
+## Use when
+
+- User mentions **rules**, **Cursor rules**, **VS Code rules**, **.instructions.md**, **globs**, **alwaysApply**, or rule formatting/structure.
+- User wants to add, edit, or document a rule file under `.github/instructions/` or similar.
+
+## Reference (single source of truth)
+
+Follow guidelines from:
+
+- [vscode_rules.instructions.md](../../../.github/instructions/vscode_rules.instructions.md) — required rule structure, frontmatter (description, globs, alwaysApply), file references, code examples, and maintenance
+
+Do not duplicate long content here; use the reference above for full formatting and structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,29 @@ interface IProjectRepository {
 
 ---
 
+## Skill Router (auto-load guidance)
+
+Choose which skill to follow based on the user's intent. Then read the corresponding `SKILL.md` under `.claude/skills/<skill-name>/` and apply the instructions from its **Reference** links (single source of truth).
+
+| User intent / keywords | Skill | Action |
+|------------------------|-------|--------|
+| Tasks, task-master, parse-prd, set-status, next task, show task, task ID, expand, PRD, sprint, planning, backlog, `.taskmaster/` | **task-master** | Follow [.claude/skills/task-master/SKILL.md](.claude/skills/task-master/SKILL.md); use taskmaster.instructions.md and dev_workflow.instructions.md |
+| Rules, Cursor rules, VS Code rules, .instructions.md, globs, alwaysApply, rule structure | **vscode-rules** | Follow [.claude/skills/vscode-rules/SKILL.md](.claude/skills/vscode-rules/SKILL.md); use vscode_rules.instructions.md |
+| Self-improve, improve rules, evolve rules, new patterns, update instructions from code | **self-improve** | Follow [.claude/skills/self-improve/SKILL.md](.claude/skills/self-improve/SKILL.md); use self_improve.instructions.md and vscode_rules.instructions.md |
+| TDD, red-green-refactor, test-first, integration tests, fix bugs with tests | **tdd** | Follow [.claude/skills/tdd/SKILL.md](.claude/skills/tdd/SKILL.md); vertical slices, tracer bullets, behavior-focused tests |
+| Break down PRD into phases/plan, implementation plan, tracer bullets (plan file) | **prd-to-plan** | Follow [.claude/skills/prd-to-plan/SKILL.md](.claude/skills/prd-to-plan/SKILL.md); output in `./plans/` |
+| PRD to GitHub issues, convert PRD to issues, implementation tickets, work items | **prd-to-issues** | Follow [.claude/skills/prd-to-issues/SKILL.md](.claude/skills/prd-to-issues/SKILL.md); use `gh issue create` |
+| Improve architecture, shallow modules, refactor opportunities, testability, AI-navigable | **improve-codebase-architecture** | Follow [.claude/skills/improve-codebase-architecture/SKILL.md](.claude/skills/improve-codebase-architecture/SKILL.md); deepen modules, RFC issues |
+| Grill me, stress-test plan, grill design, interview about plan | **grill-me** | Follow [.claude/skills/grill-me/SKILL.md](.claude/skills/grill-me/SKILL.md); resolve decision tree |
+| Plan refactor, refactoring RFC, tiny commits refactor, safe incremental refactor | **request-refactor-plan** | Follow [.claude/skills/request-refactor-plan/SKILL.md](.claude/skills/request-refactor-plan/SKILL.md); file as GitHub issue |
+| Git guardrails, block dangerous git, block push/reset/clean, git safety hooks | **git-guardrails-claude-code** | Follow [.claude/skills/git-guardrails-claude-code/SKILL.md](.claude/skills/git-guardrails-claude-code/SKILL.md); PreToolUse hook |
+| Ubiquitous language, domain glossary, DDD terms, domain model terminology | **ubiquitous-language** | Follow [.claude/skills/ubiquitous-language/SKILL.md](.claude/skills/ubiquitous-language/SKILL.md); output UBIQUITOUS_LANGUAGE.md |
+| Implementation, DDD, Clean Architecture, Either, Validator, Entity, VO, use case, repository, or no other skill matches | **engineering-standards** | Follow [.claude/skills/engineering-standards/SKILL.md](.claude/skills/engineering-standards/SKILL.md); use CLAUDE.md (this file), docs/INDEX.md, 02/06/08/09-*.md |
+
+Default to **engineering-standards** when the request is about writing or refactoring code and no other skill context is clear.
+
+---
+
 ## Task Master AI Instructions
 
 **Import Task Master's development workflow commands and guidelines.**


### PR DESCRIPTION
- Add .claude/skills/ with SKILL.md per capability (task-master, vscode-rules, self-improve, engineering-standards)
- Add Skill Router section in CLAUDE.md for auto-load guidance by intent
- Bring in skills from mattpocock/skills: tdd, prd-to-plan, prd-to-issues, improve-codebase-architecture, grill-me, request-refactor-plan, git-guardrails-claude-code, ubiquitous-language
- Update router table with all skills and trigger keywords