### PR TITLE
[T-18] Enforce ProjectStatus validation in Project.create()

### DIFF
--- a/packages/core/src/portfolio/entities/project/model/Project.ts
+++ b/packages/core/src/portfolio/entities/project/model/Project.ts
@@ -99,6 +99,19 @@ export class Project extends Entity<Project, IProjectProps> {
   }
 
   static create(props: IProjectProps): Either<ValidationError, Project> {
+    {
+      const { error, isValid } = Validator.of(props.status)
+        .in(
+          Object.values(ProjectStatus),
+          `Status must be one of: ${Object.values(ProjectStatus).join(', ')}.`,
+        )
+        .validate();
+      if (!isValid && error)
+        return left(
+          new ValidationError({ code: Project.ERROR_CODE, message: error }),
+        );
+    }
+
     const fieldsResult = collect([
       Slug.create(props.slug),
       Image.create(props.coverImage?.url, props.coverImage?.alt),

--- a/packages/core/test/project/Project.test.ts
+++ b/packages/core/test/project/Project.test.ts
@@ -242,5 +242,16 @@ describe('Project', () => {
       expect(result.isLeft()).toBe(true);
       expect((result.value as ValidationError).code).toBe(Project.ERROR_CODE);
     });
+
+    it('should return Left when status is invalid', () => {
+      const result = Project.create(
+        ProjectBuilder.build()
+          .withStatus('INVALID' as ProjectStatus)
+          .toProps(),
+      );
+
+      expect(result.isLeft()).toBe(true);
+      expect((result.value as ValidationError).code).toBe(Project.ERROR_CODE);
+    });
   });
 });


### PR DESCRIPTION
Closes #363

## Summary

- Audit all entities in `packages/core/src/portfolio/entities/` for primitive/enum properties without domain validation
- Found one gap: `Project.status: ProjectStatus` had no `Validator` check in `create()`
- Added `Validator.of(props.status).in(Object.values(ProjectStatus), ...)` before the `collect` call
- Added test case: invalid status returns `Left` with `Project.ERROR_CODE`

All other entities were already fully validated (enums via dedicated VOs like `EmploymentType`, `LocationType`, `SkillType`, `Fluency`; primitives via `Text`, `Name`, `Url`, etc.).

## Test plan

- [x] `pnpm -C packages/core test` — 218 tests passing (28 test files)
- [x] New test: `should return Left when status is invalid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)