### PR TITLE
[T-19] Document VO vs primitive+Validator rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,38 @@ if (!anotherRule(value)) return left(new ValidationError({ ... }));
 
 See also [`docs/06-VALIDATION.md`](./docs/06-VALIDATION.md).
 
+### Entity properties: VO vs primitive + Validator
+
+- Prefer **Value Objects** for domain properties when the concept is rich or reused
+  (e.g. `Slug`, `Name`, `Url`, `LocalizedText`, `DateRange`). Entities should expose
+  such attributes as VOs, not as raw strings/numbers.
+- For **simple cases** (stable enums, booleans, or a single simple rule), keep the
+  property as **primitive or enum**. Do not create a dedicated VO just for consistency.
+  Instead, validate in the entity's `create()` using **Validator**
+  (e.g. `.in([...])`, `.refine(...)`), returning a single `left` on failure.
+- Boundary: rich or reused concept → VO; simple, entity-local value →
+  primitive/enum + Validator in `create()`.
+
+```typescript
+// ✅ VO — rich, reused concept
+public readonly slug: Slug;          // Slug.create(props.slug)
+public readonly period: DateRange;   // DateRange.create(start, end)
+
+// ✅ primitive + Validator — stable enum, entity-local
+public readonly status: ProjectStatus;
+// in create():
+{
+  const { error, isValid } = Validator.of(props.status)
+    .in(Object.values(ProjectStatus), 'Invalid status.')
+    .validate();
+  if (!isValid && error)
+    return left(new ValidationError({ code: Project.ERROR_CODE, message: error }));
+}
+
+// ❌ avoid — no VO and no Validator check for a domain-meaningful value
+public readonly status: ProjectStatus; // assigned directly with no validation
+```
+
 ### Repository Interface
 
 ```typescript


### PR DESCRIPTION
Closes #364

## Summary

- Add subsection **"Entity properties: VO vs primitive + Validator"** inside **"🧩 DDD Code Templates"** in `CLAUDE.md`, after **"Domain Validation (core)"**
- Documents the decision boundary: rich/reused concept → VO; simple, entity-local value → primitive/enum + Validator in `create()`
- Includes code examples for both correct patterns and what to avoid

## Test plan

- [ ] Subsection visible in `CLAUDE.md` within "🧩 DDD Code Templates"
- [ ] Rule is unambiguous and consistent with T-18 implementation (PR #369)

🤖 Generated with [Claude Code](https://claude.com/claude-code)