### PR TITLE
[T-20] Update docs/ to reflect VO vs primitive+Validator rule

### DIFF
--- a/docs/06-VALIDATION.md
+++ b/docs/06-VALIDATION.md
@@ -83,6 +83,25 @@ static create(raw?: string): Either<ValidationError, Slug> {
 
 ---
 
+### Enum and primitive invariants in entities
+
+For simple enum or primitive properties that do not warrant a dedicated VO, validate directly in `create()` using `Validator` — no need to wrap in a VO:
+
+```typescript
+// ✅ enum validated in entity create() — no VO needed
+{
+  const { error, isValid } = Validator.of(props.status)
+    .in(Object.values(ProjectStatus), 'Invalid status.')
+    .validate();
+  if (!isValid && error)
+    return left(new ValidationError({ code: Project.ERROR_CODE, message: error }));
+}
+```
+
+See [CLAUDE.md — Entity properties: VO vs primitive + Validator](../CLAUDE.md) for the full decision rule.
+
+---
+
 ## What Not To Do
 
 - Do **not** add Zod as a dependency of `@repo/core`

--- a/docs/09-PATTERNS.md
+++ b/docs/09-PATTERNS.md
@@ -161,6 +161,7 @@ class Project extends Entity<Project, IProjectProps> {
 - No public setters — expose business-semantic methods (`publish()`, `archive()`)
 - Compose Value Objects with `collect()` for independent fields; use manual loops for children arrays
 - `Profile` supports at most 6 featured projects
+- **VO vs primitive/enum:** expose rich or reused concepts as VOs (`Slug`, `Name`, `DateRange`); keep stable enums and simple primitives as-is and validate them directly in `create()` with `Validator.of(value).in([...])` or `.refine()`. See [CLAUDE.md — Entity properties: VO vs primitive + Validator](../CLAUDE.md).
 
 ---
 


### PR DESCRIPTION
Closes #365

## Summary

- `docs/09-PATTERNS.md`: add bullet to **Rules for Entities** referencing the VO vs primitive+Validator decision boundary with link to CLAUDE.md
- `docs/06-VALIDATION.md`: add subsection **"Enum and primitive invariants in entities"** showing how to validate enums directly in `create()` without a dedicated VO

No content duplicated from CLAUDE.md — only reinforcement and cross-references.

## Test plan

- [x] `docs/09-PATTERNS.md` contains reference to VO vs primitive+Validator rule
- [x] `docs/06-VALIDATION.md` mentions Validator usage for enum invariants in `create()`
- [x] Only 20 lines added, no deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)