### PR TITLE
chore(taskmaster): setup sprint-2 tag with infrastructure tasks

### DIFF
--- a/.taskmaster/docs/prd-sprint-2.md
+++ b/.taskmaster/docs/prd-sprint-2.md
@@ -1,0 +1,241 @@
+# PRD — Sprint 2: Infrastructure Layer
+
+## Overview
+
+This sprint implements the Infrastructure Layer (`packages/infra`) on top of the Application Layer built in Sprint 1. The goal is to connect all use cases to real data sources (Prisma + Supabase) and external services (Resend), and expose the first API endpoint.
+
+## Project Context
+
+- **Repository**: https://github.com/wallace-sf/portfolio
+- **Package**: `packages/infra` (Infrastructure Layer) + `apps/web` (API Routes)
+- **Architecture**: DDD + Clean Architecture
+- **Monorepo**: Turborepo + pnpm + TypeScript strict
+
+## Stack
+
+- TypeScript (strict mode)
+- Prisma ORM (database access)
+- Supabase (Postgres hosted)
+- Resend (transactional email)
+- Next.js API Routes (thin HTTP layer)
+
+## Background
+
+Sprint 1 delivered a complete Application Layer with all use cases, DTOs, and port interfaces in `packages/application`. Sprint 2 implements the concrete infrastructure — Prisma repositories, email service, DI container, and the first API endpoint.
+
+The `packages/infra` package:
+- Imports from `packages/core` (domain) and `packages/application` (ports)
+- Implements repository interfaces with Prisma
+- Implements `IEmailService` with Resend
+- Must never import React, Next.js UI components, or application business logic
+
+## Goals
+
+1. Configure `packages/infra` with Prisma + Supabase
+2. Implement `PrismaProjectRepository`
+3. Implement `PrismaExperienceRepository`
+4. Implement `PrismaProfileRepository`
+5. Implement `ResendEmailService`
+6. Create the dependency injection container
+7. Define the response envelope and implement `GET /api/v1/projects/:slug`
+
+## Out of Scope
+
+- Frontend / Next.js pages (Sprint 3)
+- Remaining API endpoints beyond `GET /api/v1/projects/:slug` (Sprint 3)
+- CI/CD (Sprint 4)
+
+---
+
+## Tasks
+
+### T-25 — Configure packages/infra with Prisma + Supabase
+
+**GitHub Issue**: #283
+**Priority**: High
+**Dependencies**: none
+
+Configure the `packages/infra` package from scratch with Prisma ORM connected to Supabase (Postgres). Create the complete schema and initial migration.
+
+**Acceptance Criteria**:
+
+- `packages/infra/package.json` configured with Prisma
+- `schema.prisma` with models: `Project`, `Experience`, `Skill`, `ExperienceSkill`, `Profile`, `ProfileStat`, `SocialNetwork`
+- Initial migration created and applied on Supabase
+- `prisma/client.ts` exports a singleton PrismaClient instance
+- `.env.example` updated with `DATABASE_URL` and `DIRECT_URL`
+- `pnpm run db:migrate` and `pnpm run db:generate` working
+
+**Files**:
+
+- `packages/infra/package.json` ← create
+- `packages/infra/tsconfig.json` ← create
+- `packages/infra/prisma/schema.prisma` ← create
+- `packages/infra/src/prisma/client.ts` ← create
+- `.env.example` ← create/update
+
+---
+
+### T-26 — Implement PrismaProjectRepository
+
+**GitHub Issue**: #284
+**Priority**: High
+**Dependencies**: T-25
+
+Implement `IProjectRepository` using Prisma + Supabase, including a mapper from Prisma model to domain entity.
+
+**Acceptance Criteria**:
+
+- Implements all methods of `IProjectRepository`
+- `ProjectMapper` converts `PrismaProject` → `Project` entity
+- `findFeatured()` filters by `featured: true` and `status: PUBLISHED`
+- `findBySlug()` searches by unique slug
+- `findRelated()` returns related projects excluding the current one
+
+**Files**:
+
+- `packages/infra/src/repositories/PrismaProjectRepository.ts` ← create
+- `packages/infra/src/mappers/ProjectMapper.ts` ← create
+
+---
+
+### T-27 — Implement PrismaExperienceRepository
+
+**GitHub Issue**: #285
+**Priority**: High
+**Dependencies**: T-25
+
+Implement `IExperienceRepository` with Prisma, including the join with `ExperienceSkill` to return skills with `workDescription`.
+
+**Acceptance Criteria**:
+
+- Implements all methods of `IExperienceRepository`
+- `findAll()` includes skills via join (`include: { experienceSkills: { include: { skill: true } } }`)
+- `ExperienceMapper` converts Prisma result → `Experience` entity with `ExperienceSkill[]`
+- Results ordered by `startAt DESC`
+
+**Files**:
+
+- `packages/infra/src/repositories/PrismaExperienceRepository.ts` ← create
+- `packages/infra/src/mappers/ExperienceMapper.ts` ← create
+
+---
+
+### T-28 — Implement PrismaProfileRepository
+
+**GitHub Issue**: #286
+**Priority**: High
+**Dependencies**: T-25
+
+Implement `IProfileRepository` with Prisma, including stats and social networks.
+
+**Acceptance Criteria**:
+
+- `find()` returns the single profile including `stats` and `socialNetworks`
+- `ProfileMapper` converts Prisma result → `Profile` entity
+- Returns `null` if not found (use case handles as `NotFoundError`)
+
+**Files**:
+
+- `packages/infra/src/repositories/PrismaProfileRepository.ts` ← create
+- `packages/infra/src/mappers/ProfileMapper.ts` ← create
+
+---
+
+### T-29 — Implement ResendEmailService
+
+**GitHub Issue**: #287
+**Priority**: Medium
+**Dependencies**: T-25
+
+Implement `IEmailService` using the Resend API for sending contact form emails.
+
+**Acceptance Criteria**:
+
+- Implements `IEmailService.send(ContactMessageDTO)`
+- Email template includes sender's name, email, and message
+- `RESEND_API_KEY` environment variable documented in `.env.example`
+- Returns `Either<DomainError, void>`
+
+**Files**:
+
+- `packages/infra/src/services/ResendEmailService.ts` ← create
+- `.env.example` ← update with `RESEND_API_KEY`
+
+---
+
+### T-30 — Create dependency injection container
+
+**GitHub Issue**: #288
+**Priority**: High
+**Dependencies**: T-26, T-27, T-28, T-29
+
+Create a factory/container that resolves concrete implementations of the port interfaces. Exported for consumption in `apps/web` Server Components.
+
+**Acceptance Criteria**:
+
+- `container.ts` exports a `makeContainer()` function with resolved repositories
+- Resolves: `IProjectRepository` → `PrismaProjectRepository`
+- Resolves: `IExperienceRepository` → `PrismaExperienceRepository`
+- Resolves: `IProfileRepository` → `PrismaProfileRepository`
+- Resolves: `IEmailService` → `ResendEmailService`
+- `packages/infra/src/index.ts` exports the container
+
+**Files**:
+
+- `packages/infra/src/container.ts` ← create
+- `packages/infra/src/index.ts` ← create
+
+---
+
+### T-31 — Define Response Envelope and GET /api/v1/projects/:slug endpoint
+
+**GitHub Issue**: #289
+**Priority**: Medium
+**Dependencies**: T-30
+
+Introduce a consistent REST response envelope and implement the minimum projects endpoint. The API layer must be thin — only calls use cases and maps errors to HTTP.
+
+**Acceptance Criteria**:
+
+- Response envelope defined and used in all endpoints:
+  - Success: `{ data: T, error: null, meta?: {...} }`
+  - Failure: `{ data: null, error: { code: string, message: string, details?: unknown }, meta?: {...} }`
+- Endpoint implemented: `GET /api/v1/projects/:slug`
+- Handler:
+  - calls `GetProjectBySlug` use case
+  - maps `NotFoundError` → HTTP 404
+  - maps `ValidationError` / `DomainError` → HTTP 400
+  - maps unexpected errors → HTTP 500
+- Error message localized based on request locale
+- No domain logic in the handler
+
+**Files**:
+
+- `apps/web/src/app/api/v1/projects/[slug]/route.ts` ← create
+- `apps/web/src/lib/api/envelope.ts` ← create envelope helper
+- `apps/web/src/lib/api/error-mapper.ts` ← create error mapping
+
+---
+
+## Execution Order
+
+```
+T-25 (packages/infra scaffold + Prisma schema)
+  ├── T-26 (PrismaProjectRepository)
+  ├── T-27 (PrismaExperienceRepository)
+  ├── T-28 (PrismaProfileRepository)
+  └── T-29 (ResendEmailService)
+        └── T-30 (DI container)
+              └── T-31 (Response Envelope + GET /api/v1/projects/:slug)
+```
+
+## Definition of Done
+
+- [ ] `packages/infra` package configured and building
+- [ ] All Prisma repositories implemented and returning domain entities
+- [ ] `ResendEmailService` implemented and functional
+- [ ] DI container wiring all dependencies
+- [ ] `GET /api/v1/projects/:slug` endpoint responding with correct envelope
+- [ ] `.env.example` documents all required environment variables
+- [ ] Ready to start Sprint 3 (Presentation Layer)

--- a/.taskmaster/state.json
+++ b/.taskmaster/state.json
@@ -1,6 +1,6 @@
 {
-  "currentTag": "sprint-1",
-  "lastSwitched": "2026-03-15T23:30:37.488Z",
+  "currentTag": "sprint-2",
+  "lastSwitched": "2026-03-19T02:09:32.539Z",
   "branchTagMapping": {},
   "migrationNoticeShown": true
 }

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -2975,5 +2975,106 @@
       "description": "Tasks for sprint-1 context",
       "updated": "2026-03-19T00:28:35.581Z"
     }
+  },
+  "sprint-2": {
+    "tasks": [
+      {
+        "id": 1,
+        "title": "Configure packages/infra with Prisma + Supabase",
+        "description": "Set up the infrastructure package with Prisma ORM connected to Supabase Postgres, including complete schema definition and initial migration.",
+        "details": "1. Initialize packages/infra with package.json and tsconfig.json\n2. Install dependencies: prisma, @prisma/client\n3. Create schema.prisma with datasource db (provider: postgresql, url from env DATABASE_URL, directUrl from env DIRECT_URL)\n4. Define models following the domain entities:\n   - Project: id (uuid @id @default(uuid())), slug (unique), coverImageUrl, coverImageAlt (jsonb for LocalizedText), title (jsonb), caption (jsonb), content (text), skills (relation), theme (jsonb optional), summary (jsonb optional), objectives (jsonb optional), role (jsonb optional), team (string optional), periodStart (datetime), periodEnd (datetime optional), featured (boolean), status (enum: DRAFT, PUBLISHED, ARCHIVED), relatedProjectSlugs (string[]), createdAt, updatedAt, deletedAt (optional)\n   - Skill: id (uuid), description (jsonb), icon (string), type (enum: TECHNICAL, SOFT, LANGUAGE, TOOL)\n   - Experience: id (uuid), company (jsonb), position (jsonb), location (jsonb), description (jsonb), logoUrl, logoAlt (jsonb), employmentType (enum), locationType (enum), startAt (datetime), endAt (datetime optional), createdAt, updatedAt\n   - ExperienceSkill: experienceId, skillId, workDescription (jsonb), @@id([experienceId, skillId])\n   - Profile: id (uuid), name (string), headline (jsonb), bio (jsonb), photoUrl, photoAlt (jsonb), featuredProjectSlugs (string[])\n   - ProfileStat: id (uuid), profileId, label (jsonb), value (string), order (int)\n   - SocialNetwork: id (uuid), profileId, name (string), url (string), icon (string)\n5. Create src/prisma/client.ts with singleton PrismaClient export\n6. Add scripts to package.json: db:generate (prisma generate), db:migrate (prisma migrate dev), db:studio (prisma studio)\n7. Run prisma migrate dev --name init to create first migration\n8. Update .env.example with DATABASE_URL and DIRECT_URL placeholders",
+        "testStrategy": "1. Verify prisma generate succeeds without errors\n2. Verify migration applies cleanly on fresh database\n3. Verify PrismaClient singleton can be imported and instantiated\n4. Run prisma studio to visually inspect schema\n5. Test connection with simple query: prisma.project.findMany()",
+        "priority": "high",
+        "dependencies": [],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 2,
+        "title": "Implement PrismaProjectRepository",
+        "description": "Create concrete implementation of IProjectRepository using Prisma, including mapper from Prisma model to domain Project entity.",
+        "details": "1. Create ProjectMapper.ts with methods:\n   - toDomain(prismaProject): Project - converts Prisma result to domain entity\n     - Parse JSONB fields to LocalizedText VOs\n     - Parse slug to Slug VO\n     - Parse coverImage to Image VO\n     - Parse periodStart/End to DateRange VO\n     - Parse skills relation to Skill[] entities\n     - Parse relatedProjectSlugs to Slug[] VOs\n     - Use Project.create() to validate and instantiate\n   - toPrisma(project): Prisma.ProjectCreateInput - converts domain to Prisma input\n2. Implement PrismaProjectRepository implementing IProjectRepository:\n   - findAll(): Promise<Project[]> - prisma.project.findMany() with include skills, map with ProjectMapper\n   - findPublished(): Promise<Project[]> - where: { status: PUBLISHED, deletedAt: null }\n   - findFeatured(): Promise<Project[]> - where: { featured: true, status: PUBLISHED, deletedAt: null }\n   - findById(id: Id): Promise<Project | null> - prisma.project.findUnique({ where: { id: id.value } })\n   - findBySlug(slug: Slug): Promise<Project | null> - prisma.project.findUnique({ where: { slug: slug.value } })\n   - findRelated(id: Id, limit = 3): Promise<Project[]> - fetch project, then query where slug in relatedProjectSlugs and id != current, limit\n   - save(project): Promise<void> - upsert logic\n   - delete(id): Promise<void> - soft delete (set deletedAt)\n3. Handle Either errors from domain mappers appropriately (throw infrastructure exceptions if mapping fails)",
+        "testStrategy": "1. Unit tests for ProjectMapper with mock Prisma data\n2. Integration tests with test database:\n   - Create project via save, verify findById returns same\n   - Test findPublished filters correctly\n   - Test findFeatured with featured=true projects\n   - Test findRelated returns correct related projects\n   - Test soft delete sets deletedAt\n3. Test error handling when Prisma query fails\n4. Test mapping errors propagate correctly",
+        "priority": "high",
+        "dependencies": [
+          1
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 3,
+        "title": "Implement PrismaExperienceRepository",
+        "description": "Create concrete implementation of IExperienceRepository using Prisma, including join with ExperienceSkill to return skills with workDescription.",
+        "details": "1. Create ExperienceMapper.ts with methods:\n   - toDomain(prismaExperience): Experience\n     - Parse JSONB fields (company, position, location, description) to LocalizedText VOs\n     - Parse logo to Image VO\n     - Parse employmentType to EmploymentType VO\n     - Parse locationType to LocationType VO\n     - Parse startAt/endAt to DateRange VO\n     - Parse experienceSkills relation to ExperienceSkill[] entities (each includes skill and workDescription)\n     - Use Experience.create() to validate\n   - toPrisma(experience): Prisma.ExperienceCreateInput\n2. Implement PrismaExperienceRepository implementing IExperienceRepository:\n   - findAll(): Promise<Experience[]>\n     - prisma.experience.findMany({\n         include: {\n           experienceSkills: {\n             include: { skill: true }\n           }\n         },\n         orderBy: { startAt: 'desc' }\n       })\n     - Map results with ExperienceMapper\n   - findById(id: Id): Promise<Experience | null> - similar include pattern\n   - save(experience): Promise<void> - upsert with nested experienceSkills\n   - delete(id): Promise<void> - hard delete (cascade to experienceSkills)\n3. Handle relation mapping correctly for ExperienceSkill join table",
+        "testStrategy": "1. Unit tests for ExperienceMapper\n2. Integration tests:\n   - Create experience with skills via save\n   - Verify findAll returns experiences ordered by startAt DESC\n   - Verify experienceSkills include both skill and workDescription\n   - Test findById with nested relations\n   - Test delete cascades to join table\n3. Test error cases (missing required fields, invalid enums)",
+        "priority": "high",
+        "dependencies": [
+          1
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 4,
+        "title": "Implement PrismaProfileRepository",
+        "description": "Create concrete implementation of IProfileRepository using Prisma, including stats and social networks relations.",
+        "details": "1. Create ProfileMapper.ts with methods:\n   - toDomain(prismaProfile): Profile\n     - Parse name to Name VO\n     - Parse JSONB fields (headline, bio) to LocalizedText VOs\n     - Parse photo to Image VO\n     - Parse stats relation to ProfileStat[] entities (each with label LocalizedText VO)\n     - Parse socialNetworks relation to SocialNetwork[] entities\n     - Parse featuredProjectSlugs to Slug[] VOs\n     - Use Profile.create() to validate (max 6 featured projects)\n   - toPrisma(profile): Prisma.ProfileCreateInput\n2. Implement PrismaProfileRepository implementing IProfileRepository:\n   - find(): Promise<Profile | null>\n     - prisma.profile.findFirst({\n         include: {\n           stats: { orderBy: { order: 'asc' } },\n           socialNetworks: true\n         }\n       })\n     - Assumes single profile (take first)\n     - Map with ProfileMapper\n     - Return null if not found\n   - save(profile): Promise<void> - upsert with nested stats and socialNetworks\n3. Handle single-profile assumption (findFirst instead of findUnique)",
+        "testStrategy": "1. Unit tests for ProfileMapper\n2. Integration tests:\n   - Create profile with stats and social networks\n   - Verify find() returns profile with relations\n   - Verify stats ordered by order field\n   - Test save updates existing profile\n   - Test find() returns null when no profile exists\n3. Test validation (max 6 featured projects enforced by domain)",
+        "priority": "high",
+        "dependencies": [
+          1
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 5,
+        "title": "Implement ResendEmailService",
+        "description": "Create concrete implementation of IEmailService using Resend API for sending contact form emails.",
+        "details": "1. Install dependency: resend\n2. Create ResendEmailService.ts implementing IEmailService:\n   - Constructor accepts Resend API client (injected)\n   - send(message: IContactMessageDTO): Promise<Either<DomainError, void>>\n     - Use resend.emails.send({\n         from: 'onboarding@resend.dev' (or configured sender),\n         to: process.env.CONTACT_EMAIL_TO,\n         replyTo: message.email,\n         subject: `Contact from ${message.name}`,\n         html: template with message.name, message.email, message.message\n       })\n     - Wrap in try/catch\n     - On success: return right(undefined)\n     - On error: return left(new DomainError({ code: 'EMAIL_SEND_FAILED', message: error.message }))\n3. Create simple HTML email template (inline styles)\n4. Update .env.example with RESEND_API_KEY and CONTACT_EMAIL_TO",
+        "testStrategy": "1. Unit tests with mocked Resend client:\n   - Test successful send returns right(undefined)\n   - Test API error returns left(DomainError)\n   - Verify email.send called with correct parameters\n2. Integration test with Resend test mode (if available)\n3. Manual test sending to real email address",
+        "priority": "medium",
+        "dependencies": [
+          1
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 6,
+        "title": "Create dependency injection container",
+        "description": "Build factory/container that resolves concrete implementations of port interfaces for consumption in apps/web Server Components.",
+        "details": "1. Create src/container.ts with makeContainer() function:\n   - Initialize PrismaClient singleton\n   - Initialize Resend client with RESEND_API_KEY from env\n   - Instantiate repositories:\n     - projectRepository = new PrismaProjectRepository(prisma)\n     - experienceRepository = new PrismaExperienceRepository(prisma)\n     - profileRepository = new PrismaProfileRepository(prisma)\n   - Instantiate services:\n     - emailService = new ResendEmailService(resend, { to: process.env.CONTACT_EMAIL_TO })\n   - Return object: { projectRepository, experienceRepository, profileRepository, emailService }\n2. Create src/index.ts:\n   - export { makeContainer } from './container'\n   - export type { Container } from './container'\n   - Re-export repositories and services for convenience\n3. Ensure container is singleton (call once, cache result)\n4. Add environment validation (throw if required env vars missing)",
+        "testStrategy": "1. Unit test container creation:\n   - Mock environment variables\n   - Verify all dependencies instantiated correctly\n   - Verify repositories receive PrismaClient\n   - Verify emailService receives Resend client\n2. Test env validation throws on missing vars\n3. Integration test: call makeContainer(), use returned repos in real queries",
+        "priority": "high",
+        "dependencies": [
+          2,
+          3,
+          4,
+          5
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 7,
+        "title": "Define Response Envelope and implement GET /api/v1/projects/:slug",
+        "description": "Introduce consistent REST response envelope and implement the first API endpoint with thin handler that calls use cases and maps errors to HTTP.",
+        "details": "1. Create apps/web/src/lib/api/envelope.ts:\n   - Define ApiResponse<T> type:\n     - Success: { data: T, error: null, meta?: { timestamp: string, ... } }\n     - Error: { data: null, error: { code: string, message: string, details?: unknown }, meta?: { ... } }\n   - Helper functions:\n     - successResponse<T>(data: T, meta?): ApiResponse<T>\n     - errorResponse(code, message, details?, meta?): ApiResponse<never>\n2. Create apps/web/src/lib/api/error-mapper.ts:\n   - mapDomainErrorToHttp(error: DomainError, locale: string): { status: number, response: ApiResponse<never> }\n     - NotFoundError → 404\n     - ValidationError → 400\n     - Generic DomainError → 400\n     - Unknown error → 500\n   - Localize error messages based on locale (use i18n if available, or default English)\n3. Implement apps/web/src/app/api/v1/projects/[slug]/route.ts:\n   - export async GET(request: NextRequest, { params }: { params: { slug: string } }):\n     - Extract locale from request headers (Accept-Language) or use default\n     - Get container from makeContainer()\n     - Create GetProjectBySlug use case: new GetProjectBySlug(container.projectRepository)\n     - Create Slug VO from params.slug\n     - Execute use case: const result = await useCase.execute(slug)\n     - If result.isLeft(): map error with mapDomainErrorToHttp, return NextResponse.json(response, { status })\n     - If result.isRight(): return NextResponse.json(successResponse(result.value.toDTO()), { status: 200 })\n   - No business logic in handler - only orchestration\n4. Set CORS headers if needed\n5. Add Next.js route config: export const dynamic = 'force-dynamic' (or 'auto' depending on caching strategy)",
+        "testStrategy": "1. Unit tests for envelope helpers\n2. Unit tests for error mapper (each error type → correct status)\n3. Integration tests for route:\n   - Test with valid slug returns 200 + project data\n   - Test with invalid slug returns 400 + validation error\n   - Test with non-existent slug returns 404 + not found error\n   - Test error localization works\n4. Manual test with curl/Postman\n5. Test response structure matches envelope format",
+        "priority": "medium",
+        "dependencies": [
+          6
+        ],
+        "status": "pending",
+        "subtasks": []
+      }
+    ],
+    "metadata": {
+      "created": "2026-03-19T02:05:21.651Z",
+      "updated": "2026-03-19T02:05:21.651Z",
+      "description": "Tasks for sprint-2 context"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add `prd-sprint-2.md` with 7 tasks covering the Infrastructure Layer (T-25 through T-31, issues #283–#289)
- Parse PRD and generate tasks under the `sprint-2` tag in `tasks.json`
- Activate `sprint-2` as the current tag in `state.json`

## Tasks created

| ID | Title | GitHub Issue |
|----|-------|-------------|
| 1  | Configure packages/infra with Prisma + Supabase | #283 |
| 2  | Implement PrismaProjectRepository | #284 |
| 3  | Implement PrismaExperienceRepository | #285 |
| 4  | Implement PrismaProfileRepository | #286 |
| 5  | Implement ResendEmailService | #287 |
| 6  | Create dependency injection container | #288 |
| 7  | Define Response Envelope + GET /api/v1/projects/:slug | #289 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)