### PR TITLE
docs: add Identity bounded context plan to documentation

### DIFF
--- a/docs/03-BOUNDED-CONTEXTS.md
+++ b/docs/03-BOUNDED-CONTEXTS.md
@@ -11,6 +11,7 @@
 | **Portfolio** | Projects, experience, skills, profile, values | Project, Experience, Skill, ProfessionalValue, Language, SocialNetwork | Active |
 | **Blog** | Posts, tags, publication | BlogPost, Tag | Stub (future) |
 | **Contact** | Contact form capture and delivery | DTOs / Message entity | Stub |
+| **Identity** | Autenticação, autorização, papéis | User, Role, AccessPolicy | Planejado |
 | **Shared Kernel** | Cross-context primitives | Id, Text, DateTime, Name, Url, enums, Either, errors | Active |
 
 ```text
@@ -20,15 +21,15 @@
                     │  Entity, Errors  │
                     └────────┬─────────┘
                              │
-         ┌───────────────────┼───────────────────┐
-         │                   │                   │
-         ▼                   ▼                   ▼
-┌────────────────┐  ┌────────────────┐  ┌────────────────┐
-│   Portfolio    │  │      Blog      │  │    Contact     │
-│  Project       │  │   BlogPost     │  │  (DTOs/forms)  │
-│  Experience    │  │   Tag          │  │                │
-│  Skill, etc.   │  │                │  │                │
-└────────────────┘  └────────────────┘  └────────────────┘
+         ┌───────────────────┼───────────────────┬───────────────────┐
+         │                   │                   │                   │
+         ▼                   ▼                   ▼                   ▼
+┌────────────────┐  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐
+│   Portfolio    │  │      Blog      │  │    Contact     │  │    Identity    │
+│  Project       │  │   BlogPost     │  │  (DTOs/forms)  │  │  User, Role    │
+│  Experience    │  │   Tag          │  │                │  │  AccessPolicy  │
+│  Skill, etc.   │  │                │  │                │  │  (planejado)   │
+└────────────────┘  └────────────────┘  └────────────────┘  └────────────────┘
 ```
 
 ---
@@ -78,8 +79,8 @@ import { Slug, Either, ValidationError }  from '@repo/core/shared';
 - `Entity`, `ValueObject`, `IEntityProps`
 - `Id`, `Text`, `DateTime`, `Name`, `Url`
 - `EmploymentType`, `LocationType`, `SkillType`, `Fluency`
-- `Slug`, `Image`, `DateRange`, `LocalizedText`
-- `Either<L, R>`, `ValidationError`, `DomainError`, `NotFoundError`
+- `Slug`, `Image`, `DateRange`, `LocalizedText`, `Email` (planejado)
+- `Either<L, R>`, `ValidationError`, `DomainError`, `NotFoundError`, `UnauthorizedError` (planejado)
 - `ERROR_MESSAGE` (domain error codes with `pt-BR` / `en-US` translations)
 
 **What does not belong here:** rules specific to one context (e.g., "a post can only be published with at least one tag" belongs to Blog).
@@ -130,6 +131,23 @@ src/
 - **Project** — aggregate root with slug, cover image, period, status, and localized fields
 - **Experience** — aggregate root that owns `ExperienceSkill[]`, `DateRange`, logo, and description
 - **BlogPost** (planned) — aggregate root; `Tag` as a VO inside Blog context
+
+---
+
+## Identity Context (Planejado)
+
+**Responsabilidade:** autenticação, autorização, papéis (ADMIN | VISITOR). Supabase Auth.
+
+**Modelos previstos:**
+
+| Class | Role | Descrição |
+|-------|------|-----------|
+| `User` | Entity | auth_id, email, role |
+| `Role` | Value Object | ADMIN \| VISITOR |
+| `AccessPolicy` | Policy | canAccessAdmin, canPublish, etc. |
+| `IUserRepository` | Interface | findByAuthId, findByEmail, save |
+
+Ver [11-IDENTITY](./11-IDENTITY.md) e [plans/identity-mvp.md](../plans/identity-mvp.md).
 
 ---
 

--- a/docs/10-GLOSSARY.md
+++ b/docs/10-GLOSSARY.md
@@ -93,6 +93,26 @@ A contact form submission. Contains name, email, and message body.
 
 ---
 
+## Domain Terms — Identity Context (Planejado)
+
+### User
+
+Identidade autenticada no sistema. Possui `auth_id` (Supabase Auth), `email` e `role`. Usada para autorização de ações admin.
+
+### Role
+
+Papel do usuário. Valores: `ADMIN` (acesso total) ou `VISITOR` (apenas leitura pública).
+
+### AccessPolicy
+
+Policy que determina se um User pode executar ações protegidas (publicar, gerenciar projetos, acessar área admin). Todos os métodos delegam para `role === 'ADMIN'`.
+
+### UnauthorizedError
+
+Erro de domínio para falhas de autenticação ou autorização (usuário não logado ou sem permissão).
+
+---
+
 ## Domain Terms — Shared Kernel Value Objects
 
 ### Either
@@ -258,6 +278,7 @@ An interface defined in the application layer representing a dependency on an ex
 DomainError (abstract)
   └── ValidationError    — invariant violations, invalid input
   └── NotFoundError      — entity lookup failures
+  └── UnauthorizedError  — auth/authorization failures (planejado)
 ```
 
 All domain errors use a static `ERROR_CODE` constant in `SCREAMING_SNAKE_CASE` (e.g., `INVALID_SLUG`, `INVALID_DATE_RANGE`).

--- a/docs/11-IDENTITY.md
+++ b/docs/11-IDENTITY.md
@@ -1,0 +1,36 @@
+# 11 — Identity (Planejado)
+
+> Bounded context de autenticação e autorização. Plano detalhado para implementação futura.
+
+## Contexto
+
+Responsável por autenticação e autorização. Modelo binário: `ADMIN | VISITOR`. Supabase Auth como mecanismo; domínio em `packages/core`. Dependency rule: `core ← application ← infra ← web`.
+
+## Context Map
+
+| Context | Status | Modelos principais |
+|---------|--------|--------------------|
+| Identity | Planejado | User, Role, AccessPolicy, IUserRepository |
+
+## Modelos previstos
+
+- **User** — entidade: `auth_id`, `email`, `role`
+- **Role** — VO: `ADMIN | VISITOR`
+- **Email** — VO no Shared Kernel
+- **AccessPolicy** — policy: `canPublish`, `canManageProjects`, `canAccessAdmin`, etc.
+- **IUserRepository** — interface em core
+
+## Rotas previstas
+
+- `/[locale]/login` — página de login (email + senha)
+- `/[locale]/admin/*` — área protegida; middleware + layout com `EnsureAdminUseCase`
+
+## Plano de implementação
+
+O plano detalhado por fases está em [plans/identity-mvp.md](../plans/identity-mvp.md).
+
+## Ver também
+
+- [03-BOUNDED-CONTEXTS](./03-BOUNDED-CONTEXTS.md) — mapa de contextos
+- [ROADMAP](./ROADMAP.md) — fase Identity
+- [packages/infra/README.md](../packages/infra/README.md) — schema `users`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,6 +20,7 @@
 | Writing or reviewing tests? | [08-TESTING](./08-TESTING.md) |
 | Looking for code templates (Either, VO, Entity)? | [09-PATTERNS](./09-PATTERNS.md) |
 | Looking for a domain term? | [10-GLOSSARY](./10-GLOSSARY.md) |
+| Identity (auth, admin)? | [11-IDENTITY](./11-IDENTITY.md) |
 
 ---
 
@@ -45,6 +46,10 @@
 - **[09-PATTERNS](./09-PATTERNS.md)** — DDD patterns (Either, VO, Entity, Repository templates), GoF patterns
 - **[10-GLOSSARY](./10-GLOSSARY.md)** — Ubiquitous language: domain terms, architectural terms, process terms
 
+### Planned Features
+
+- **[11-IDENTITY](./11-IDENTITY.md)** — Identity bounded context (auth, roles, admin area) — planejado
+
 ---
 
 ## Cross-References
@@ -53,6 +58,7 @@
 - **[packages/core/README.md](../packages/core/README.md)** — Core package overview, links to 02-ARCHITECTURE and 03-BOUNDED-CONTEXTS
 - **[packages/core/decisions/](../packages/core/decisions/)** — Architectural Decision Records (ADRs)
 - **[ROADMAP.md](./ROADMAP.md)** — Product roadmap and sprint planning
+- **[plans/identity-mvp.md](../plans/identity-mvp.md)** — Plano de implementação Identity (MVP)
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,6 +10,7 @@ Evolution view for the portfolio, aligned with Clean Architecture, DDD, i18n, an
 - [Phase 1 — API and Infra](#phase-1--api-and-infra)
 - [Phase 2 — Blog and Supabase](#phase-2--blog-and-supabase)
 - [Phase 3 — Application and Contact Backend](#phase-3--application-and-contact-backend)
+- [Phase 4 — Identity (Auth)](#phase-4--identity-auth)
 - [Continuous Improvements](#continuous-improvements)
 
 ---
@@ -75,6 +76,23 @@ Evolution view for the portfolio, aligned with Clean Architecture, DDD, i18n, an
   - `POST /api/contact`; validation with Zod; rate limit and / or CAPTCHA (to be decided)
 - [ ] **Web**
   - Contact form submits to `/api/contact`; error handling uses stable codes and i18n
+
+---
+
+## Phase 4 — Identity (Auth)
+
+> **Status:** planejado. Plano detalhado em [11-IDENTITY](./11-IDENTITY.md) e [plans/identity-mvp.md](../plans/identity-mvp.md).
+
+- [ ] **Domain** (`packages/core`)
+  - User, Role, Email, AccessPolicy, IUserRepository, UnauthorizedError
+- [ ] **Infrastructure** (`packages/infra`)
+  - Migration tabela `users`; SupabaseUserRepository; seed admin
+- [ ] **Application** (`packages/application`)
+  - GetCurrentUserUseCase, EnsureAdminUseCase
+- [ ] **Web** (`apps/web`)
+  - Middleware auth; página login; layout admin; getAuthenticatedUser
+
+Modelo de papéis: `ADMIN | VISITOR`. Rotas protegidas: `/[locale]/admin/*`. Login: `/[locale]/login`.
 
 ---
 

--- a/packages/infra/README.md
+++ b/packages/infra/README.md
@@ -54,6 +54,11 @@ Visão prevista (nomes e colunas podem mudar na implementação):
 
 - **`contacts`** ou integração com serviço externo (Resend, etc.); a definir.
 
+### Identity (planejado)
+
+- **`users`**: `id`, `auth_id` (uuid, FK auth.users), `email`, `role` (ADMIN/VISITOR), `created_at`, `updated_at`, `deleted_at`
+- RLS: leitura própria; escrita apenas via service_role
+
 ---
 
 ## Repositórios e ports
@@ -63,6 +68,7 @@ Cada repositório na Infra implementa uma interface (port) da Application, por e
 - **`IProjectRepository`** → `ProjectRepositorySupabase`: `findAll()`, `findById(id)`
 - **`IPostRepository`** → `PostRepositorySupabase`: `findPublished(limit, offset, tag?)`, `findBySlug(slug)`
 - **`ITagRepository`** → `TagRepositorySupabase`: `findAll()`
+- **`IUserRepository`** → `SupabaseUserRepository`: `findByAuthId()`, `findByEmail()`, `save()`
 - **`IContactSender`** (ou similar) → adapter para Supabase/Resend/etc.
 
 Os nomes exatos dos ports e métodos serão definidos em `packages/application` ou em [docs/APPLICATION.md](../docs/APPLICATION.md).
@@ -106,6 +112,7 @@ packages/infra/
 │   ├── repositories/
 │   │   ├── ProjectRepositorySupabase.ts
 │   │   ├── PostRepositorySupabase.ts
+│   │   ├── SupabaseUserRepository.ts
 │   │   └── TagRepositorySupabase.ts
 │   ├── mappers/
 │   │   ├── ProjectMapper.ts

--- a/plans/identity-mvp.md
+++ b/plans/identity-mvp.md
@@ -1,0 +1,23 @@
+# Identity — Plano de Implementação (MVP)
+
+> Bounded context de autenticação e autorização. **Status:** planejado, não implementado.
+
+## Decisões arquiteturais
+
+- **Modelo de papéis**: binário `ADMIN | VISITOR`
+- **Auth**: Supabase Auth (`@supabase/supabase-js`, `@supabase/ssr`)
+- **Rotas protegidas**: `/[locale]/admin/*` → middleware + layout com `EnsureAdminUseCase`
+- **Rotas públicas**: login em `/[locale]/login`
+- **Fora do escopo MVP**: logout, magic link/OAuth, audit log, notification
+
+## Fases resumidas
+
+| Fase | Conteúdo |
+|------|----------|
+| 0 | Setup `packages/application` (identity), `packages/infra`, `apps/web` |
+| 1 | Core: Email, Role, User, UnauthorizedError, IUserRepository, AccessPolicy |
+| 2 | Infra: migration `users`, SupabaseUserRepository, seed admin |
+| 3 | Application: GetCurrentUserUseCase, EnsureAdminUseCase |
+| 4 | Web: getAuthenticatedUser, middleware, login, layout admin |
+
+Ver documento completo em [docs/11-IDENTITY.md](../docs/11-IDENTITY.md).


### PR DESCRIPTION
- Add plans/identity-mvp.md with implementation plan summary
- Add docs/11-IDENTITY.md as main Identity reference
- Update docs/INDEX.md with Identity links
- Update docs/03-BOUNDED-CONTEXTS.md with Identity context
- Update docs/ROADMAP.md with Phase 4 Identity (Auth)
- Update docs/10-GLOSSARY.md with User, Role, AccessPolicy, UnauthorizedError
- Update packages/infra/README.md with users schema and SupabaseUserRepository

Made-with: Cursor