### PR TITLE
[T-19] feat(infra): implement PrismaProjectRepository

### DIFF
--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -18,7 +18,10 @@
     "db:migrate:deploy": "dotenv -e ../../.env -- prisma migrate deploy",
     "db:push": "dotenv -e ../../.env -- prisma db push",
     "db:studio": "dotenv -e ../../.env -- prisma studio",
-    "db:seed": "tsx prisma/seed.ts"
+    "db:seed": "tsx prisma/seed.ts",
+    "test": "dotenv -e ../../.env -- vitest run",
+    "test:watch": "dotenv -e ../../.env -- vitest",
+    "test:coverage": "dotenv -e ../../.env -- vitest run --coverage"
   },
   "dependencies": {
     "@prisma/client": "^6.0.0",
@@ -30,8 +33,10 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/prettier-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@vitest/coverage-v8": "^3.0.0",
     "dotenv-cli": "^11.0.0",
     "prisma": "^6.0.0",
-    "tsx": "^4.0.0"
+    "tsx": "^4.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/infra/src/errors/InfrastructureError.ts
+++ b/packages/infra/src/errors/InfrastructureError.ts
@@ -1,0 +1,9 @@
+export class InfrastructureError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'InfrastructureError';
+  }
+}

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -1,1 +1,4 @@
 export { prisma } from './prisma/client';
+export { InfrastructureError } from './errors/InfrastructureError';
+export { ProjectMapper } from './repositories/project/ProjectMapper';
+export { PrismaProjectRepository } from './repositories/project/PrismaProjectRepository';

--- a/packages/infra/src/repositories/project/PrismaProjectRepository.ts
+++ b/packages/infra/src/repositories/project/PrismaProjectRepository.ts
@@ -1,0 +1,118 @@
+import { PrismaClient } from '@prisma/client';
+
+import { IProjectRepository, Project, ProjectStatus } from '@repo/core/portfolio';
+import { Id, Slug } from '@repo/core/shared';
+
+import { InfrastructureError } from '../../errors/InfrastructureError';
+import { ProjectMapper } from './ProjectMapper';
+
+const INCLUDE = {
+  skills: { include: { skill: true } },
+} as const;
+
+export class PrismaProjectRepository implements IProjectRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async findAll(): Promise<Project[]> {
+    const rows = await this.db.project.findMany({
+      where: { deletedAt: null },
+      include: INCLUDE,
+      orderBy: { periodStart: 'desc' },
+    });
+    return rows.map(ProjectMapper.toDomain);
+  }
+
+  async findPublished(): Promise<Project[]> {
+    const rows = await this.db.project.findMany({
+      where: { status: ProjectStatus.PUBLISHED, deletedAt: null },
+      include: INCLUDE,
+      orderBy: { periodStart: 'desc' },
+    });
+    return rows.map(ProjectMapper.toDomain);
+  }
+
+  async findFeatured(): Promise<Project[]> {
+    const rows = await this.db.project.findMany({
+      where: {
+        featured: true,
+        status: ProjectStatus.PUBLISHED,
+        deletedAt: null,
+      },
+      include: INCLUDE,
+      orderBy: { periodStart: 'desc' },
+    });
+    return rows.map(ProjectMapper.toDomain);
+  }
+
+  async findById(id: Id): Promise<Project | null> {
+    const row = await this.db.project.findUnique({
+      where: { id: id.value },
+      include: INCLUDE,
+    });
+    return row ? ProjectMapper.toDomain(row) : null;
+  }
+
+  async findBySlug(slug: Slug): Promise<Project | null> {
+    const row = await this.db.project.findUnique({
+      where: { slug: slug.value },
+      include: INCLUDE,
+    });
+    return row ? ProjectMapper.toDomain(row) : null;
+  }
+
+  async findRelated(id: Id, limit = 3): Promise<Project[]> {
+    const current = await this.db.project.findUnique({
+      where: { id: id.value },
+      select: { relatedProjectSlugs: true },
+    });
+
+    if (!current || current.relatedProjectSlugs.length === 0) return [];
+
+    const rows = await this.db.project.findMany({
+      where: {
+        slug: { in: current.relatedProjectSlugs },
+        id: { not: id.value },
+        status: ProjectStatus.PUBLISHED,
+        deletedAt: null,
+      },
+      include: INCLUDE,
+      take: limit,
+    });
+
+    return rows.map(ProjectMapper.toDomain);
+  }
+
+  async save(project: Project): Promise<void> {
+    const data = ProjectMapper.toPrisma(project);
+    const { id, ...rest } = data;
+
+    const skillsCreate = project.skills.map((skill) => ({
+      skillId: skill.id.value,
+    }));
+
+    await this.db.project.upsert({
+      where: { id },
+      create: { ...rest, id, skills: { create: skillsCreate } },
+      update: {
+        ...rest,
+        skills: { deleteMany: {}, create: skillsCreate },
+      },
+    });
+  }
+
+  async delete(id: Id): Promise<void> {
+    const existing = await this.db.project.findUnique({
+      where: { id: id.value },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      throw new InfrastructureError(`Project not found: ${id.value}`);
+    }
+
+    await this.db.project.update({
+      where: { id: id.value },
+      data: { deletedAt: new Date() },
+    });
+  }
+}

--- a/packages/infra/src/repositories/project/PrismaProjectRepository.ts
+++ b/packages/infra/src/repositories/project/PrismaProjectRepository.ts
@@ -45,16 +45,16 @@ export class PrismaProjectRepository implements IProjectRepository {
   }
 
   async findById(id: Id): Promise<Project | null> {
-    const row = await this.db.project.findUnique({
-      where: { id: id.value },
+    const row = await this.db.project.findFirst({
+      where: { id: id.value, deletedAt: null },
       include: INCLUDE,
     });
     return row ? ProjectMapper.toDomain(row) : null;
   }
 
   async findBySlug(slug: Slug): Promise<Project | null> {
-    const row = await this.db.project.findUnique({
-      where: { slug: slug.value },
+    const row = await this.db.project.findFirst({
+      where: { slug: slug.value, deletedAt: null },
       include: INCLUDE,
     });
     return row ? ProjectMapper.toDomain(row) : null;

--- a/packages/infra/src/repositories/project/ProjectMapper.ts
+++ b/packages/infra/src/repositories/project/ProjectMapper.ts
@@ -1,0 +1,92 @@
+import { Prisma } from '@prisma/client';
+
+import { IProjectProps, Project, ProjectStatus } from '@repo/core/portfolio';
+import { ILocalizedTextInput } from '@repo/core/shared';
+
+import { InfrastructureError } from '../../errors/InfrastructureError';
+
+type PrismaProjectWithSkills = Prisma.ProjectGetPayload<{
+  include: { skills: { include: { skill: true } } };
+}>;
+
+type ProjectScalarData = Omit<Prisma.ProjectUncheckedCreateInput, 'skills'>;
+
+export class ProjectMapper {
+  static toDomain(raw: PrismaProjectWithSkills): Project {
+    const asLocalized = (v: unknown) => v as ILocalizedTextInput;
+
+    const props: IProjectProps = {
+      id: raw.id,
+      slug: raw.slug,
+      coverImage: {
+        url: raw.coverImageUrl,
+        alt: asLocalized(raw.coverImageAlt),
+      },
+      title: asLocalized(raw.title),
+      caption: asLocalized(raw.caption),
+      content: raw.content,
+      theme: raw.theme ? asLocalized(raw.theme) : undefined,
+      summary: raw.summary ? asLocalized(raw.summary) : undefined,
+      objectives: raw.objectives ? asLocalized(raw.objectives) : undefined,
+      role: raw.role ? asLocalized(raw.role) : undefined,
+      team: raw.team ?? undefined,
+      period: {
+        start: raw.periodStart.toISOString(),
+        end: raw.periodEnd?.toISOString(),
+      },
+      featured: raw.featured,
+      status: raw.status as ProjectStatus,
+      relatedProjects: raw.relatedProjectSlugs,
+      skills: raw.skills.map((ps) => ({
+        id: ps.skill.id,
+        description: ps.skill.description as string,
+        icon: ps.skill.icon,
+        type: ps.skill.type,
+        created_at: ps.skill.createdAt.toISOString(),
+        updated_at: ps.skill.updatedAt.toISOString(),
+      })),
+      created_at: raw.createdAt.toISOString(),
+      updated_at: raw.updatedAt.toISOString(),
+      deleted_at: raw.deletedAt?.toISOString() ?? null,
+    };
+
+    const result = Project.create(props);
+    if (result.isLeft()) {
+      throw new InfrastructureError(
+        `Failed to map project ${raw.id} to domain: ${result.value.message}`,
+        result.value,
+      );
+    }
+
+    return result.value;
+  }
+
+  static toPrisma(project: Project): ProjectScalarData {
+    return {
+      id: project.id.value,
+      slug: project.slug.value,
+      coverImageUrl: project.coverImage.url.value,
+      coverImageAlt: project.coverImage.alt.value,
+      title: project.title.value,
+      caption: project.caption.value,
+      content: project.content.value,
+      theme: project.theme?.value ?? Prisma.JsonNull,
+      summary: project.summary?.value ?? Prisma.JsonNull,
+      objectives: project.objectives?.value ?? Prisma.JsonNull,
+      role: project.role?.value ?? Prisma.JsonNull,
+      team: project.team ?? null,
+      periodStart: new Date(project.period.startAt.value),
+      periodEnd: project.period.endAt
+        ? new Date(project.period.endAt.value)
+        : null,
+      featured: project.featured,
+      status: project.status,
+      relatedProjectSlugs: project.relatedProjects.map((s) => s.value),
+      createdAt: new Date(project.created_at.value),
+      updatedAt: new Date(project.updated_at.value),
+      deletedAt: project.deleted_at
+        ? new Date(project.deleted_at.value)
+        : null,
+    };
+  }
+}

--- a/packages/infra/test/factories/prisma-project.factory.ts
+++ b/packages/infra/test/factories/prisma-project.factory.ts
@@ -1,0 +1,81 @@
+import { Prisma, ProjectStatus, SkillType } from '@prisma/client';
+
+type PrismaSkillOnProject = {
+  projectId: string;
+  skillId: string;
+  skill: {
+    id: string;
+    description: Prisma.JsonValue;
+    icon: string;
+    type: SkillType;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+};
+
+export type PrismaProjectWithSkills = {
+  id: string;
+  slug: string;
+  coverImageUrl: string;
+  coverImageAlt: Prisma.JsonValue;
+  title: Prisma.JsonValue;
+  caption: Prisma.JsonValue;
+  content: string;
+  theme: Prisma.JsonValue | null;
+  summary: Prisma.JsonValue | null;
+  objectives: Prisma.JsonValue | null;
+  role: Prisma.JsonValue | null;
+  team: string | null;
+  periodStart: Date;
+  periodEnd: Date | null;
+  featured: boolean;
+  status: ProjectStatus;
+  relatedProjectSlugs: string[];
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  skills: PrismaSkillOnProject[];
+};
+
+export function buildPrismaSkill(overrides?: Partial<PrismaSkillOnProject['skill']>): PrismaSkillOnProject['skill'] {
+  const id = overrides?.id ?? crypto.randomUUID();
+  return {
+    id,
+    description: 'TypeScript development',
+    icon: 'code',
+    type: 'TECHNOLOGY',
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+export function buildPrismaProject(overrides?: Partial<PrismaProjectWithSkills>): PrismaProjectWithSkills {
+  const id = overrides?.id ?? crypto.randomUUID();
+  const skill = buildPrismaSkill();
+
+  return {
+    id,
+    slug: 'my-test-project',
+    coverImageUrl: 'https://example.com/cover.jpg',
+    coverImageAlt: { 'pt-BR': 'Capa do projeto' },
+    title: { 'pt-BR': 'Meu Projeto' },
+    caption: { 'pt-BR': 'Uma breve descrição' },
+    content: 'Conteúdo detalhado do projeto.',
+    theme: null,
+    summary: null,
+    objectives: null,
+    role: null,
+    team: null,
+    periodStart: new Date('2024-01-01T00:00:00.000Z'),
+    periodEnd: null,
+    featured: false,
+    status: 'DRAFT',
+    relatedProjectSlugs: [],
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    deletedAt: null,
+    skills: [{ projectId: id, skillId: skill.id, skill }],
+    ...overrides,
+  };
+}

--- a/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
+++ b/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
@@ -1,0 +1,293 @@
+import { PrismaClient, SkillType } from '@prisma/client';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { ProjectStatus } from '@repo/core/portfolio';
+import { Id, Slug } from '@repo/core/shared';
+
+import { InfrastructureError } from '../../../src/errors/InfrastructureError';
+import { ProjectMapper } from '../../../src/repositories/project/ProjectMapper';
+import { PrismaProjectRepository } from '../../../src/repositories/project/PrismaProjectRepository';
+import { buildPrismaProject } from '../../factories/prisma-project.factory';
+
+// Use DIRECT_URL to bypass PgBouncer — prepared statements don't work with the pooler
+const db = new PrismaClient({
+  datasourceUrl: process.env.DIRECT_URL,
+});
+const repo = new PrismaProjectRepository(db);
+
+const TEST_SLUG_PREFIX = 'test-';
+
+// Shared skill created once for all tests
+let sharedSkillId: string;
+
+async function seedProject(overrides?: Partial<ReturnType<typeof buildPrismaProject>>) {
+  const raw = buildPrismaProject({
+    slug: `${TEST_SLUG_PREFIX}${crypto.randomUUID()}`,
+    ...overrides,
+    skills: [],
+  });
+
+  await db.project.create({
+    data: {
+      id: raw.id,
+      slug: raw.slug,
+      coverImageUrl: raw.coverImageUrl,
+      coverImageAlt: raw.coverImageAlt,
+      title: raw.title,
+      caption: raw.caption,
+      content: raw.content,
+      theme: raw.theme ?? undefined,
+      summary: raw.summary ?? undefined,
+      objectives: raw.objectives ?? undefined,
+      role: raw.role ?? undefined,
+      team: raw.team,
+      periodStart: raw.periodStart,
+      periodEnd: raw.periodEnd,
+      featured: raw.featured,
+      status: raw.status,
+      relatedProjectSlugs: raw.relatedProjectSlugs,
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+      deletedAt: raw.deletedAt,
+      skills: { create: [{ skillId: sharedSkillId }] },
+    },
+  });
+
+  return raw;
+}
+
+beforeAll(async () => {
+  const skill = await db.skill.create({
+    data: {
+      description: 'TypeScript',
+      icon: 'code',
+      type: SkillType.TECHNOLOGY,
+    },
+  });
+  sharedSkillId = skill.id;
+});
+
+afterAll(async () => {
+  await db.project.deleteMany({ where: { slug: { startsWith: TEST_SLUG_PREFIX } } });
+  await db.skill.delete({ where: { id: sharedSkillId } });
+  await db.$disconnect();
+});
+
+afterEach(async () => {
+  await db.project.deleteMany({ where: { slug: { startsWith: TEST_SLUG_PREFIX } } });
+});
+
+describe('PrismaProjectRepository', () => {
+  describe('findAll', () => {
+    it('should return all non-deleted projects', async () => {
+      await seedProject({ status: 'DRAFT' });
+      await seedProject({ status: 'PUBLISHED' });
+      await seedProject({ deletedAt: new Date() });
+
+      const projects = await repo.findAll();
+      const slugs = projects.map((p) => p.slug.value);
+      const testSlugs = slugs.filter((s) => s.startsWith(TEST_SLUG_PREFIX));
+
+      expect(testSlugs).toHaveLength(2);
+    });
+
+    it('should not include soft-deleted projects', async () => {
+      const deleted = await seedProject({ deletedAt: new Date() });
+
+      const projects = await repo.findAll();
+      const found = projects.find((p) => p.slug.value === deleted.slug);
+
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe('findPublished', () => {
+    it('should return only published projects', async () => {
+      const published = await seedProject({ status: 'PUBLISHED' });
+      await seedProject({ status: 'DRAFT' });
+
+      const projects = await repo.findPublished();
+      const testProjects = projects.filter((p) => p.slug.value.startsWith(TEST_SLUG_PREFIX));
+
+      expect(testProjects).toHaveLength(1);
+      expect(testProjects[0]!.slug.value).toBe(published.slug);
+      expect(testProjects[0]!.status).toBe(ProjectStatus.PUBLISHED);
+    });
+  });
+
+  describe('findFeatured', () => {
+    it('should return only featured published projects', async () => {
+      const featured = await seedProject({ status: 'PUBLISHED', featured: true });
+      await seedProject({ status: 'PUBLISHED', featured: false });
+      await seedProject({ status: 'DRAFT', featured: true });
+
+      const projects = await repo.findFeatured();
+      const testProjects = projects.filter((p) => p.slug.value.startsWith(TEST_SLUG_PREFIX));
+
+      expect(testProjects).toHaveLength(1);
+      expect(testProjects[0]!.slug.value).toBe(featured.slug);
+      expect(testProjects[0]!.featured).toBe(true);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return the project when found', async () => {
+      const seeded = await seedProject();
+
+      const idResult = Id.create(seeded.id);
+      if (idResult.isLeft()) throw idResult.value;
+
+      const project = await repo.findById(idResult.value);
+
+      expect(project).not.toBeNull();
+      expect(project!.id.value).toBe(seeded.id);
+    });
+
+    it('should return null when not found', async () => {
+      const idResult = Id.create(crypto.randomUUID());
+      if (idResult.isLeft()) throw idResult.value;
+
+      const project = await repo.findById(idResult.value);
+
+      expect(project).toBeNull();
+    });
+  });
+
+  describe('findBySlug', () => {
+    it('should return the project when found', async () => {
+      const seeded = await seedProject();
+
+      const slugResult = Slug.create(seeded.slug);
+      if (slugResult.isLeft()) throw slugResult.value;
+
+      const project = await repo.findBySlug(slugResult.value);
+
+      expect(project).not.toBeNull();
+      expect(project!.slug.value).toBe(seeded.slug);
+    });
+
+    it('should return null when slug does not exist', async () => {
+      const slugResult = Slug.create('test-nonexistent-slug');
+      if (slugResult.isLeft()) throw slugResult.value;
+
+      const project = await repo.findBySlug(slugResult.value);
+
+      expect(project).toBeNull();
+    });
+  });
+
+  describe('findRelated', () => {
+    it('should return related published projects by slug', async () => {
+      const related = await seedProject({ status: 'PUBLISHED' });
+      const main = await seedProject({ relatedProjectSlugs: [related.slug] });
+
+      const idResult = Id.create(main.id);
+      if (idResult.isLeft()) throw idResult.value;
+
+      const projects = await repo.findRelated(idResult.value);
+
+      expect(projects).toHaveLength(1);
+      expect(projects[0]!.slug.value).toBe(related.slug);
+    });
+
+    it('should return empty array when project has no related slugs', async () => {
+      const seeded = await seedProject({ relatedProjectSlugs: [] });
+
+      const idResult = Id.create(seeded.id);
+      if (idResult.isLeft()) throw idResult.value;
+
+      const projects = await repo.findRelated(idResult.value);
+
+      expect(projects).toHaveLength(0);
+    });
+  });
+
+  describe('save', () => {
+    it('should persist a new project and retrieve it', async () => {
+      const projectId = crypto.randomUUID();
+      const raw = buildPrismaProject({
+        id: projectId,
+        slug: `${TEST_SLUG_PREFIX}${crypto.randomUUID()}`,
+        skills: [
+          {
+            projectId,
+            skillId: sharedSkillId,
+            skill: {
+              id: sharedSkillId,
+              description: 'TypeScript',
+              icon: 'code',
+              type: 'TECHNOLOGY',
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          },
+        ],
+      });
+      const project = ProjectMapper.toDomain(raw);
+
+      await repo.save(project);
+
+      const slugResult = Slug.create(raw.slug);
+      if (slugResult.isLeft()) throw slugResult.value;
+      const found = await repo.findBySlug(slugResult.value);
+
+      expect(found).not.toBeNull();
+      expect(found!.slug.value).toBe(raw.slug);
+    });
+
+    it('should update an existing project on upsert', async () => {
+      const seeded = await seedProject({ status: 'DRAFT' });
+
+      const slugResult = Slug.create(seeded.slug);
+      if (slugResult.isLeft()) throw slugResult.value;
+      const project = await repo.findBySlug(slugResult.value);
+      if (!project) throw new Error('Project not found');
+
+      const updatedRaw = buildPrismaProject({
+        ...seeded,
+        status: 'PUBLISHED',
+        skills: [
+          {
+            projectId: seeded.id,
+            skillId: sharedSkillId,
+            skill: {
+              id: sharedSkillId,
+              description: 'TypeScript',
+              icon: 'code',
+              type: 'TECHNOLOGY',
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          },
+        ],
+      });
+      const updatedProject = ProjectMapper.toDomain(updatedRaw);
+
+      await repo.save(updatedProject);
+
+      const found = await repo.findBySlug(slugResult.value);
+      expect(found!.status).toBe(ProjectStatus.PUBLISHED);
+    });
+  });
+
+  describe('delete', () => {
+    it('should soft-delete a project', async () => {
+      const seeded = await seedProject();
+
+      const idResult = Id.create(seeded.id);
+      if (idResult.isLeft()) throw idResult.value;
+
+      await repo.delete(idResult.value);
+
+      const project = await repo.findById(idResult.value);
+      expect(project).toBeNull();
+    });
+
+    it('should throw InfrastructureError when project does not exist', async () => {
+      const idResult = Id.create(crypto.randomUUID());
+      if (idResult.isLeft()) throw idResult.value;
+
+      await expect(repo.delete(idResult.value)).rejects.toThrow(InfrastructureError);
+    });
+  });
+});

--- a/packages/infra/test/repositories/project/ProjectMapper.test.ts
+++ b/packages/infra/test/repositories/project/ProjectMapper.test.ts
@@ -1,0 +1,176 @@
+import { Prisma } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+
+import { ProjectStatus } from '@repo/core/portfolio';
+
+import { InfrastructureError } from '../../../src/errors/InfrastructureError';
+import { ProjectMapper } from '../../../src/repositories/project/ProjectMapper';
+import { buildPrismaProject, buildPrismaSkill } from '../../factories/prisma-project.factory';
+
+describe('ProjectMapper', () => {
+  describe('toDomain', () => {
+    it('should map a minimal prisma row to a domain Project', () => {
+      const raw = buildPrismaProject();
+
+      const project = ProjectMapper.toDomain(raw);
+
+      expect(project.id.value).toBe(raw.id);
+      expect(project.slug.value).toBe(raw.slug);
+      expect(project.coverImage.url.value).toBe(raw.coverImageUrl);
+      expect(project.title.value).toEqual(raw.title);
+      expect(project.caption.value).toEqual(raw.caption);
+      expect(project.content.value).toBe(raw.content);
+      expect(project.featured).toBe(raw.featured);
+      expect(project.status).toBe(ProjectStatus.DRAFT);
+      expect(project.relatedProjects).toHaveLength(0);
+      expect(project.skills).toHaveLength(1);
+    });
+
+    it('should map optional fields when present', () => {
+      const raw = buildPrismaProject({
+        theme: { 'pt-BR': 'dark' },
+        summary: { 'pt-BR': 'Resumo' },
+        objectives: { 'pt-BR': 'Objetivos' },
+        role: { 'pt-BR': 'Desenvolvedor' },
+        team: 'Time A',
+        periodEnd: new Date('2024-12-31T00:00:00.000Z'),
+        relatedProjectSlugs: ['other-project'],
+      });
+
+      const project = ProjectMapper.toDomain(raw);
+
+      expect(project.theme?.value).toEqual({ 'pt-BR': 'dark' });
+      expect(project.summary?.value).toEqual({ 'pt-BR': 'Resumo' });
+      expect(project.objectives?.value).toEqual({ 'pt-BR': 'Objetivos' });
+      expect(project.role?.value).toEqual({ 'pt-BR': 'Desenvolvedor' });
+      expect(project.team).toBe('Time A');
+      expect(project.period.endAt?.value).toBe('2024-12-31T00:00:00.000Z');
+      expect(project.relatedProjects).toHaveLength(1);
+      expect(project.relatedProjects[0]!.value).toBe('other-project');
+    });
+
+    it('should map multiple skills', () => {
+      const skill1 = buildPrismaSkill({ description: 'TypeScript' });
+      const skill2 = buildPrismaSkill({ description: 'React', icon: 'react', type: 'TECHNOLOGY' });
+      const raw = buildPrismaProject({
+        skills: [
+          { projectId: crypto.randomUUID(), skillId: skill1.id, skill: skill1 },
+          { projectId: crypto.randomUUID(), skillId: skill2.id, skill: skill2 },
+        ],
+      });
+
+      const project = ProjectMapper.toDomain(raw);
+
+      expect(project.skills).toHaveLength(2);
+      expect(project.skills[0]!.id.value).toBe(skill1.id);
+      expect(project.skills[1]!.id.value).toBe(skill2.id);
+    });
+
+    it('should map a PUBLISHED project status', () => {
+      const raw = buildPrismaProject({ status: 'PUBLISHED' });
+
+      const project = ProjectMapper.toDomain(raw);
+
+      expect(project.status).toBe(ProjectStatus.PUBLISHED);
+    });
+
+    it('should set theme, summary, objectives, role to undefined when null in DB', () => {
+      const raw = buildPrismaProject({
+        theme: null,
+        summary: null,
+        objectives: null,
+        role: null,
+      });
+
+      const project = ProjectMapper.toDomain(raw);
+
+      expect(project.theme).toBeUndefined();
+      expect(project.summary).toBeUndefined();
+      expect(project.objectives).toBeUndefined();
+      expect(project.role).toBeUndefined();
+    });
+
+    it('should throw InfrastructureError when raw data produces an invalid domain object', () => {
+      const raw = buildPrismaProject({ slug: '' });
+
+      expect(() => ProjectMapper.toDomain(raw)).toThrow(InfrastructureError);
+    });
+  });
+
+  describe('toPrisma', () => {
+    it('should map a domain Project to prisma scalar data', () => {
+      const raw = buildPrismaProject({
+        id: crypto.randomUUID(),
+        status: 'PUBLISHED',
+        featured: true,
+      });
+      const project = ProjectMapper.toDomain(raw);
+
+      const data = ProjectMapper.toPrisma(project);
+
+      expect(data.id).toBe(raw.id);
+      expect(data.slug).toBe(raw.slug);
+      expect(data.coverImageUrl).toBe(raw.coverImageUrl);
+      expect(data.featured).toBe(true);
+      expect(data.status).toBe('PUBLISHED');
+    });
+
+    it('should set optional json fields to Prisma.JsonNull when absent', () => {
+      const raw = buildPrismaProject({
+        theme: null,
+        summary: null,
+        objectives: null,
+        role: null,
+      });
+      const project = ProjectMapper.toDomain(raw);
+
+      const data = ProjectMapper.toPrisma(project);
+
+      expect(data.theme).toBe(Prisma.JsonNull);
+      expect(data.summary).toBe(Prisma.JsonNull);
+      expect(data.objectives).toBe(Prisma.JsonNull);
+      expect(data.role).toBe(Prisma.JsonNull);
+    });
+
+    it('should include optional json fields when present', () => {
+      const raw = buildPrismaProject({
+        theme: { 'pt-BR': 'dark' },
+        summary: { 'pt-BR': 'Resumo' },
+      });
+      const project = ProjectMapper.toDomain(raw);
+
+      const data = ProjectMapper.toPrisma(project);
+
+      expect(data.theme).toEqual({ 'pt-BR': 'dark' });
+      expect(data.summary).toEqual({ 'pt-BR': 'Resumo' });
+    });
+
+    it('should set periodEnd to null when project has no end date', () => {
+      const raw = buildPrismaProject({ periodEnd: null });
+      const project = ProjectMapper.toDomain(raw);
+
+      const data = ProjectMapper.toPrisma(project);
+
+      expect(data.periodEnd).toBeNull();
+    });
+
+    it('should include periodEnd when project has an end date', () => {
+      const end = new Date('2024-12-31T00:00:00.000Z');
+      const raw = buildPrismaProject({ periodEnd: end });
+      const project = ProjectMapper.toDomain(raw);
+
+      const data = ProjectMapper.toPrisma(project);
+
+      expect(data.periodEnd).toEqual(end);
+    });
+
+    it('should map relatedProjectSlugs as string array', () => {
+      const raw = buildPrismaProject({ relatedProjectSlugs: ['project-a', 'project-b'] });
+      const project = ProjectMapper.toDomain(raw);
+
+      const data = ProjectMapper.toPrisma(project);
+
+      expect(data.relatedProjectSlugs).toEqual(['project-a', 'project-b']);
+    });
+  });
+});

--- a/packages/infra/vitest.config.ts
+++ b/packages/infra/vitest.config.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/index.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '~': path.resolve(__dirname, './src'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@vitest/coverage-v8':
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4)
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
@@ -351,6 +354,9 @@ importers:
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@20.14.2)(tsx@4.21.0)
 
   packages/prettier-config: {}
 
@@ -5181,7 +5187,7 @@ packages:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.14.2)
+      vitest: 3.2.4(@types/node@20.14.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5219,7 +5225,7 @@ packages:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 7.3.1(@types/node@20.14.2)
+      vite: 7.3.1(@types/node@20.14.2)(tsx@4.21.0)
     dev: true
 
   /@vitest/pretty-format@2.0.5:
@@ -6232,7 +6238,7 @@ packages:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.2
+      loupe: 3.2.1
       pathval: 2.0.0
     dev: true
 
@@ -13877,7 +13883,7 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
-  /vite-node@3.2.4(@types/node@20.14.2):
+  /vite-node@3.2.4(@types/node@20.14.2)(tsx@4.21.0):
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -13886,7 +13892,7 @@ packages:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@20.14.2)
+      vite: 7.3.1(@types/node@20.14.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13902,7 +13908,7 @@ packages:
       - yaml
     dev: true
 
-  /vite@7.3.1(@types/node@20.14.2):
+  /vite@7.3.1(@types/node@20.14.2)(tsx@4.21.0):
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
@@ -13949,6 +13955,7 @@ packages:
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
+      tsx: 4.21.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -14002,8 +14009,75 @@ packages:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@20.14.2)
-      vite-node: 3.2.4(@types/node@20.14.2)
+      vite: 7.3.1(@types/node@20.14.2)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@20.14.2)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
+  /vitest@3.2.4(@types/node@20.14.2)(tsx@4.21.0):
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 5.2.3
+      '@types/node': 20.14.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@20.14.2)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@20.14.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## Contexto

Implementa o repositório concreto de projetos na camada de infraestrutura, conectando o domínio ao banco via Prisma.

Closes #284

## Mudanças

### `InfrastructureError`
Classe de erro para falhas na camada de infraestrutura (ex: mapping inválido, registro não encontrado).

### `ProjectMapper`
- `toDomain(raw)` — converte resultado do Prisma (com campos `Json` e relação `skills`) para entidade de domínio `Project`
- `toPrisma(project)` — converte entidade `Project` para dados escalares prontos para upsert

### `PrismaProjectRepository`
Implementa `IProjectRepository` com todos os métodos:
| Método | Comportamento |
|---|---|
| `findAll` | Todos os projetos não deletados, ordenados por `periodStart desc` |
| `findPublished` | Filtro `PUBLISHED + deletedAt null` |
| `findFeatured` | Filtro `featured + PUBLISHED + deletedAt null` |
| `findById` | `findUnique` por ID (inclui deletados) |
| `findBySlug` | `findUnique` por slug (inclui deletados) |
| `findRelated` | Busca projetos pelos slugs do campo `relatedProjectSlugs`, excluindo o próprio |
| `save` | Upsert com sync de skills (delete + recreate na relação) |
| `delete` | Soft-delete via `deletedAt = now()` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)