### PR TITLE
feat(infra): implement PrismaProfileRepository with ProfileMapper

### DIFF
--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -4,3 +4,5 @@ export { ProjectMapper } from './repositories/project/ProjectMapper';
 export { PrismaProjectRepository } from './repositories/project/PrismaProjectRepository';
 export { ExperienceMapper } from './repositories/experience/ExperienceMapper';
 export { PrismaExperienceRepository } from './repositories/experience/PrismaExperienceRepository';
+export { ProfileMapper } from './repositories/profile/ProfileMapper';
+export { PrismaProfileRepository } from './repositories/profile/PrismaProfileRepository';

--- a/packages/infra/src/repositories/profile/PrismaProfileRepository.ts
+++ b/packages/infra/src/repositories/profile/PrismaProfileRepository.ts
@@ -1,0 +1,37 @@
+import { PrismaClient } from '@prisma/client';
+
+import { IProfileRepository, Profile } from '@repo/core/portfolio';
+
+import { ProfileMapper } from './ProfileMapper';
+
+const INCLUDE = {
+  stats: { orderBy: { order: 'asc' as const } },
+  socialNetworks: true,
+} as const;
+
+export class PrismaProfileRepository implements IProfileRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async find(): Promise<Profile | null> {
+    const row = await this.db.profile.findFirst({ include: INCLUDE });
+    return row ? ProfileMapper.toDomain(row) : null;
+  }
+
+  async save(profile: Profile): Promise<void> {
+    const { stats, ...data } = ProfileMapper.toPrisma(profile);
+    const { id, ...rest } = data;
+
+    await this.db.profile.upsert({
+      where: { id },
+      create: {
+        ...rest,
+        id,
+        stats: { create: stats },
+      },
+      update: {
+        ...rest,
+        stats: { deleteMany: {}, create: stats },
+      },
+    });
+  }
+}

--- a/packages/infra/src/repositories/profile/ProfileMapper.ts
+++ b/packages/infra/src/repositories/profile/ProfileMapper.ts
@@ -1,0 +1,83 @@
+import { Prisma } from '@prisma/client';
+
+import { IProfileProps, IProfileStatProps, Profile } from '@repo/core/portfolio';
+import { ILocalizedTextInput } from '@repo/core/shared';
+
+import { InfrastructureError } from '../../errors/InfrastructureError';
+
+type PrismaProfileWithRelations = Prisma.ProfileGetPayload<{
+  include: {
+    stats: true;
+    socialNetworks: true;
+  };
+}>;
+
+type ProfileStatData = {
+  label: Prisma.InputJsonValue;
+  value: string;
+  icon: string;
+  order: number;
+};
+
+export class ProfileMapper {
+  static toDomain(raw: PrismaProfileWithRelations): Profile {
+    const asLocalized = (v: unknown) => v as ILocalizedTextInput;
+
+    const stats: IProfileStatProps[] = raw.stats
+      .sort((a, b) => a.order - b.order)
+      .map((s) => ({
+        label: asLocalized(s.label),
+        value: s.value,
+        icon: s.icon,
+      }));
+
+    const props: IProfileProps = {
+      id: raw.id,
+      name: raw.name,
+      headline: asLocalized(raw.headline),
+      bio: asLocalized(raw.bio),
+      photo: {
+        url: raw.photoUrl,
+        alt: asLocalized(raw.photoAlt),
+      },
+      stats,
+      featuredProjectSlugs: raw.featuredProjectSlugs,
+      created_at: raw.createdAt.toISOString(),
+      updated_at: raw.updatedAt.toISOString(),
+    };
+
+    const result = Profile.create(props);
+    if (result.isLeft()) {
+      throw new InfrastructureError(
+        `Failed to map profile ${raw.id} to domain: ${result.value.message}`,
+        result.value,
+      );
+    }
+
+    return result.value;
+  }
+
+  static toPrisma(
+    profile: Profile,
+  ): Omit<Prisma.ProfileUncheckedCreateInput, 'stats' | 'socialNetworks'> & {
+    stats: ProfileStatData[];
+  } {
+    return {
+      id: profile.id.value,
+      name: profile.name.value,
+      headline: profile.headline.value,
+      bio: profile.bio.value,
+      photoUrl: profile.photo.url.value,
+      photoAlt: profile.photo.alt.value,
+      featuredProjectSlugs: profile.featuredProjectSlugs.map((s) => s.value),
+      createdAt: new Date(profile.created_at.value),
+      updatedAt: new Date(profile.updated_at.value),
+      stats: profile.stats.map((s, index) => ({
+        label: s.label.value,
+        value: s.value,
+        icon: s.icon.value,
+        order: index,
+      })),
+    };
+  }
+}

--- a/packages/infra/test/factories/prisma-profile.factory.ts
+++ b/packages/infra/test/factories/prisma-profile.factory.ts
@@ -1,0 +1,78 @@
+import { Prisma } from '@prisma/client';
+
+type PrismaProfileStat = {
+  id: string;
+  profileId: string;
+  label: Prisma.JsonValue;
+  value: string;
+  icon: string;
+  order: number;
+};
+
+type PrismaProfileSocialNetwork = {
+  id: string;
+  profileId: string;
+  name: string;
+  url: string;
+  icon: string;
+};
+
+export type PrismaProfileWithRelations = {
+  id: string;
+  name: string;
+  headline: Prisma.JsonValue;
+  bio: Prisma.JsonValue;
+  photoUrl: string;
+  photoAlt: Prisma.JsonValue;
+  featuredProjectSlugs: string[];
+  createdAt: Date;
+  updatedAt: Date;
+  stats: PrismaProfileStat[];
+  socialNetworks: PrismaProfileSocialNetwork[];
+};
+
+export function buildPrismaProfile(
+  overrides?: Partial<PrismaProfileWithRelations>,
+): PrismaProfileWithRelations {
+  const id = overrides?.id ?? crypto.randomUUID();
+
+  return {
+    id,
+    name: 'Wallace Ferreira',
+    headline: { 'pt-BR': 'Desenvolvedor Full-Stack' },
+    bio: { 'pt-BR': 'Apaixonado por tecnologia e boas práticas.' },
+    photoUrl: 'https://example.com/photo.jpg',
+    photoAlt: { 'pt-BR': 'Foto de Wallace' },
+    featuredProjectSlugs: ['project-a', 'project-b'],
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    stats: [
+      {
+        id: crypto.randomUUID(),
+        profileId: id,
+        label: { 'pt-BR': 'Projetos' },
+        value: '10+',
+        icon: 'folder',
+        order: 0,
+      },
+      {
+        id: crypto.randomUUID(),
+        profileId: id,
+        label: { 'pt-BR': 'Anos de experiência' },
+        value: '5+',
+        icon: 'clock',
+        order: 1,
+      },
+    ],
+    socialNetworks: [
+      {
+        id: crypto.randomUUID(),
+        profileId: id,
+        name: 'GitHub',
+        url: 'https://github.com/wallace-sf',
+        icon: 'github',
+      },
+    ],
+    ...overrides,
+  };
+}

--- a/packages/infra/test/repositories/profile/PrismaProfileRepository.test.ts
+++ b/packages/infra/test/repositories/profile/PrismaProfileRepository.test.ts
@@ -1,0 +1,122 @@
+import { PrismaClient } from '@prisma/client';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ProfileMapper } from '../../../src/repositories/profile/ProfileMapper';
+import { PrismaProfileRepository } from '../../../src/repositories/profile/PrismaProfileRepository';
+import { buildPrismaProfile } from '../../factories/prisma-profile.factory';
+
+// Use DIRECT_URL to bypass PgBouncer — prepared statements don't work with the pooler
+const db = new PrismaClient({
+  datasourceUrl: process.env.DIRECT_URL,
+});
+const repo = new PrismaProfileRepository(db);
+
+afterEach(async () => {
+  await db.profile.deleteMany({});
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+});
+
+describe('PrismaProfileRepository', () => {
+  describe('find', () => {
+    it('should return null when no profile exists', async () => {
+      const profile = await repo.find();
+      expect(profile).toBeNull();
+    });
+
+    it('should return the profile with stats ordered by order ASC', async () => {
+      const raw = buildPrismaProfile();
+      await db.profile.create({
+        data: {
+          id: raw.id,
+          name: raw.name,
+          headline: raw.headline,
+          bio: raw.bio,
+          photoUrl: raw.photoUrl,
+          photoAlt: raw.photoAlt,
+          featuredProjectSlugs: raw.featuredProjectSlugs,
+          stats: {
+            create: [
+              { label: { 'pt-BR': 'B' }, value: '2', icon: 'b-icon', order: 1 },
+              { label: { 'pt-BR': 'A' }, value: '1', icon: 'a-icon', order: 0 },
+            ],
+          },
+        },
+      });
+
+      const profile = await repo.find();
+
+      expect(profile).not.toBeNull();
+      expect(profile!.id.value).toBe(raw.id);
+      expect(profile!.stats[0]!.label.value).toEqual({ 'pt-BR': 'A' });
+      expect(profile!.stats[1]!.label.value).toEqual({ 'pt-BR': 'B' });
+    });
+
+    it('should return the profile with featuredProjectSlugs', async () => {
+      const raw = buildPrismaProfile({ stats: [] });
+      await db.profile.create({
+        data: {
+          id: raw.id,
+          name: raw.name,
+          headline: raw.headline,
+          bio: raw.bio,
+          photoUrl: raw.photoUrl,
+          photoAlt: raw.photoAlt,
+          featuredProjectSlugs: ['project-a', 'project-b'],
+        },
+      });
+
+      const profile = await repo.find();
+
+      expect(profile!.featuredProjectSlugs).toHaveLength(2);
+      expect(profile!.featuredProjectSlugs[0]!.value).toBe('project-a');
+    });
+  });
+
+  describe('save', () => {
+    it('should create a new profile', async () => {
+      const raw = buildPrismaProfile();
+      const profile = ProfileMapper.toDomain(raw);
+
+      await repo.save(profile);
+
+      const found = await repo.find();
+      expect(found).not.toBeNull();
+      expect(found!.id.value).toBe(raw.id);
+      expect(found!.stats).toHaveLength(2);
+    });
+
+    it('should update an existing profile on upsert', async () => {
+      const raw = buildPrismaProfile();
+      const profile = ProfileMapper.toDomain(raw);
+      await repo.save(profile);
+
+      const updatedRaw = buildPrismaProfile({
+        ...raw,
+        name: 'Wallace Updated',
+        stats: [
+          { id: crypto.randomUUID(), profileId: raw.id, label: { 'pt-BR': 'Novo stat' }, value: '99', icon: 'star', order: 0 },
+        ],
+      });
+      const updated = ProfileMapper.toDomain(updatedRaw);
+      await repo.save(updated);
+
+      const found = await repo.find();
+      expect(found!.name.value).toBe('Wallace Updated');
+      expect(found!.stats).toHaveLength(1);
+    });
+
+    it('should replace stats on update', async () => {
+      const raw = buildPrismaProfile();
+      await repo.save(ProfileMapper.toDomain(raw));
+
+      const updatedRaw = buildPrismaProfile({ ...raw, stats: [] });
+      await repo.save(ProfileMapper.toDomain(updatedRaw));
+
+      const found = await repo.find();
+      expect(found!.stats).toHaveLength(0);
+    });
+  });
+});

--- a/packages/infra/test/repositories/profile/ProfileMapper.test.ts
+++ b/packages/infra/test/repositories/profile/ProfileMapper.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { InfrastructureError } from '../../../src/errors/InfrastructureError';
+import { ProfileMapper } from '../../../src/repositories/profile/ProfileMapper';
+import { buildPrismaProfile } from '../../factories/prisma-profile.factory';
+
+describe('ProfileMapper', () => {
+  describe('toDomain', () => {
+    it('should map a prisma row to a domain Profile', () => {
+      const raw = buildPrismaProfile();
+
+      const profile = ProfileMapper.toDomain(raw);
+
+      expect(profile.id.value).toBe(raw.id);
+      expect(profile.name.value).toBe(raw.name);
+      expect(profile.headline.value).toEqual(raw.headline);
+      expect(profile.bio.value).toEqual(raw.bio);
+      expect(profile.photo.url.value).toBe(raw.photoUrl);
+      expect(profile.stats).toHaveLength(2);
+      expect(profile.featuredProjectSlugs).toHaveLength(2);
+    });
+
+    it('should order stats by the order field', () => {
+      const raw = buildPrismaProfile({
+        stats: [
+          { id: crypto.randomUUID(), profileId: crypto.randomUUID(), label: { 'pt-BR': 'B' }, value: '2', icon: 'b-icon', order: 1 },
+          { id: crypto.randomUUID(), profileId: crypto.randomUUID(), label: { 'pt-BR': 'A' }, value: '1', icon: 'a-icon', order: 0 },
+        ],
+      });
+
+      const profile = ProfileMapper.toDomain(raw);
+
+      expect(profile.stats[0]!.label.value).toEqual({ 'pt-BR': 'A' });
+      expect(profile.stats[1]!.label.value).toEqual({ 'pt-BR': 'B' });
+    });
+
+    it('should map featuredProjectSlugs to Slug VOs', () => {
+      const raw = buildPrismaProfile({ featuredProjectSlugs: ['my-project'] });
+
+      const profile = ProfileMapper.toDomain(raw);
+
+      expect(profile.featuredProjectSlugs[0]!.value).toBe('my-project');
+    });
+
+    it('should map empty stats and featuredProjectSlugs', () => {
+      const raw = buildPrismaProfile({ stats: [], featuredProjectSlugs: [] });
+
+      const profile = ProfileMapper.toDomain(raw);
+
+      expect(profile.stats).toHaveLength(0);
+      expect(profile.featuredProjectSlugs).toHaveLength(0);
+    });
+
+    it('should throw InfrastructureError when data is invalid', () => {
+      const raw = buildPrismaProfile({ name: '' });
+
+      expect(() => ProfileMapper.toDomain(raw)).toThrow(InfrastructureError);
+    });
+
+    it('should throw InfrastructureError when too many featured projects', () => {
+      const raw = buildPrismaProfile({
+        featuredProjectSlugs: ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((s) => `project-${s}`),
+      });
+
+      expect(() => ProfileMapper.toDomain(raw)).toThrow(InfrastructureError);
+    });
+  });
+
+  describe('toPrisma', () => {
+    it('should map a domain Profile to prisma data', () => {
+      const raw = buildPrismaProfile();
+      const profile = ProfileMapper.toDomain(raw);
+
+      const data = ProfileMapper.toPrisma(profile);
+
+      expect(data.id).toBe(raw.id);
+      expect(data.name).toBe(raw.name);
+      expect(data.photoUrl).toBe(raw.photoUrl);
+      expect(data.featuredProjectSlugs).toEqual(['project-a', 'project-b']);
+    });
+
+    it('should serialize stats with order index', () => {
+      const raw = buildPrismaProfile();
+      const profile = ProfileMapper.toDomain(raw);
+
+      const data = ProfileMapper.toPrisma(profile);
+
+      expect(data.stats).toHaveLength(2);
+      expect(data.stats[0]!.order).toBe(0);
+      expect(data.stats[1]!.order).toBe(1);
+    });
+
+    it('should serialize featuredProjectSlugs as string array', () => {
+      const raw = buildPrismaProfile({ featuredProjectSlugs: ['project-x'] });
+      const profile = ProfileMapper.toDomain(raw);
+
+      const data = ProfileMapper.toPrisma(profile);
+
+      expect(data.featuredProjectSlugs).toEqual(['project-x']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `ProfileMapper.toDomain` — converte Prisma row para domínio: `Name`, `LocalizedText` (headline/bio), `Image`, `ProfileStat[]` (ordenados por `order`), `featuredProjectSlugs` como `Slug[]`
- `ProfileMapper.toPrisma` — caminho inverso, serializa stats com índice de ordem
- `PrismaProfileRepository.find()` — `findFirst` (perfil singleton) com stats ordenadas por `order ASC`
- `PrismaProfileRepository.save()` — upsert com `deleteMany + create` para substituir stats

## Test plan

- [x] 9 unit tests para `ProfileMapper`
- [x] 6 integration tests para `PrismaProfileRepository` contra Supabase cloud dev
- [x] TypeScript sem erros (`tsc --noEmit`)
- [x] 61 testes passando no total (`packages/infra`)

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)