### PR TITLE
feat(infra): implement ResendEmailService

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@
 # "Session" mode for DIRECT_URL (port 5432)
 DATABASE_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true"
 DIRECT_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres"
+
+# Resend (email service)
+# Create a free account at https://resend.com and get your API key from the dashboard.
+RESEND_API_KEY="re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# The email address that will receive contact form submissions.
+CONTACT_EMAIL_TO="your@email.com"
+# The sender email address (must be a verified domain in Resend).
+CONTACT_EMAIL_FROM="onboarding@resend.dev"

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -3152,7 +3152,7 @@
         "dependencies": [
           "1"
         ],
-        "status": "pending",
+        "status": "in-progress",
         "subtasks": [
           {
             "id": 1,
@@ -3203,7 +3203,8 @@
         ],
         "complexity": 3,
         "recommendedSubtasks": 4,
-        "expansionPrompt": "Break down ResendEmailService into subtasks: (1) Install resend dependency and set up types, (2) Implement ResendEmailService class with injected Resend client, constructor accepting config (API key, recipient email), (3) Implement send() method wrapping resend.emails.send with proper error handling, Either pattern (right on success, left(DomainError) on API failure), and email template with name/email/message fields, (4) Create unit tests with mocked Resend client testing success/failure paths and correct parameter passing."
+        "expansionPrompt": "Break down ResendEmailService into subtasks: (1) Install resend dependency and set up types, (2) Implement ResendEmailService class with injected Resend client, constructor accepting config (API key, recipient email), (3) Implement send() method wrapping resend.emails.send with proper error handling, Either pattern (right on success, left(DomainError) on API failure), and email template with name/email/message fields, (4) Create unit tests with mocked Resend client testing success/failure paths and correct parameter passing.",
+        "updatedAt": "2026-03-28T03:29:15.033Z"
       },
       {
         "id": "6",
@@ -3448,7 +3449,7 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-03-23T03:49:55.820Z",
+      "lastModified": "2026-03-28T03:29:15.033Z",
       "taskCount": 8,
       "completedCount": 5,
       "tags": [

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -3152,7 +3152,7 @@
         "dependencies": [
           "1"
         ],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -3204,7 +3204,7 @@
         "complexity": 3,
         "recommendedSubtasks": 4,
         "expansionPrompt": "Break down ResendEmailService into subtasks: (1) Install resend dependency and set up types, (2) Implement ResendEmailService class with injected Resend client, constructor accepting config (API key, recipient email), (3) Implement send() method wrapping resend.emails.send with proper error handling, Either pattern (right on success, left(DomainError) on API failure), and email template with name/email/message fields, (4) Create unit tests with mocked Resend client testing success/failure paths and correct parameter passing.",
-        "updatedAt": "2026-03-28T03:29:15.033Z"
+        "updatedAt": "2026-03-28T03:47:46.649Z"
       },
       {
         "id": "6",
@@ -3449,9 +3449,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-03-28T03:29:15.033Z",
+      "lastModified": "2026-03-28T03:47:46.649Z",
       "taskCount": 8,
-      "completedCount": 5,
+      "completedCount": 6,
       "tags": [
         "sprint-2"
       ]

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -27,7 +27,8 @@
     "@prisma/client": "^6.0.0",
     "@repo/application": "workspace:*",
     "@repo/core": "workspace:*",
-    "@repo/utils": "workspace:*"
+    "@repo/utils": "workspace:*",
+    "resend": "^6.9.4"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -20,6 +20,7 @@
     "db:studio": "dotenv -e ../../.env -- prisma studio",
     "db:seed": "tsx prisma/seed.ts",
     "test": "dotenv -e ../../.env -- vitest run",
+    "send:email:manual": "dotenv -e ../../.env -- tsx scripts/send-email-manual.ts",
     "test:watch": "dotenv -e ../../.env -- vitest",
     "test:coverage": "dotenv -e ../../.env -- vitest run --coverage"
   },

--- a/packages/infra/scripts/send-email-manual.ts
+++ b/packages/infra/scripts/send-email-manual.ts
@@ -1,0 +1,34 @@
+import { Resend } from 'resend';
+
+import { ResendEmailService } from '../src/services/ResendEmailService';
+
+const requiredVars = ['RESEND_API_KEY', 'CONTACT_EMAIL_TO', 'CONTACT_EMAIL_FROM'] as const;
+for (const key of requiredVars) {
+  if (!process.env[key]) {
+    console.error(`Missing environment variable: ${key}`);
+    process.exit(1);
+  }
+}
+
+async function main() {
+  const client = new Resend(process.env.RESEND_API_KEY!);
+  const service = new ResendEmailService(client, {
+    recipientEmail: process.env.CONTACT_EMAIL_TO!,
+    senderEmail: process.env.CONTACT_EMAIL_FROM!,
+  });
+
+  const result = await service.send({
+    name: 'Test User',
+    email: 'test@example.com',
+    message: 'This is a manual integration test of ResendEmailService.',
+  });
+
+  if (result.isLeft()) {
+    console.error('FAILED:', result.value.code, '-', result.value.message);
+    process.exit(1);
+  }
+
+  console.log('SUCCESS: email sent to', process.env.CONTACT_EMAIL_TO);
+}
+
+main();

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -6,3 +6,5 @@ export { ExperienceMapper } from './repositories/experience/ExperienceMapper';
 export { PrismaExperienceRepository } from './repositories/experience/PrismaExperienceRepository';
 export { ProfileMapper } from './repositories/profile/ProfileMapper';
 export { PrismaProfileRepository } from './repositories/profile/PrismaProfileRepository';
+export { ResendEmailService } from './services/ResendEmailService';
+export type { IResendEmailServiceConfig } from './services/ResendEmailService';

--- a/packages/infra/src/services/ResendEmailService.ts
+++ b/packages/infra/src/services/ResendEmailService.ts
@@ -1,0 +1,53 @@
+import { Resend } from 'resend';
+
+import { IContactMessageDTO } from '@repo/application/contact';
+import { DomainError, Either, left, right } from '@repo/core/shared';
+import { IEmailService } from '@repo/application/contact';
+
+export interface IResendEmailServiceConfig {
+  recipientEmail: string;
+  senderEmail: string;
+}
+
+function formatEmailHtml(name: string, email: string, message: string): string {
+  return `
+    <table width="100%" cellpadding="0" cellspacing="0" style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;">
+      <tr>
+        <td style="padding:24px;background:#f9f9f9;border-bottom:2px solid #e0e0e0;">
+          <h2 style="margin:0;color:#111;">New contact message</h2>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:24px;">
+          <p style="margin:0 0 8px;"><strong>Name:</strong> ${name}</p>
+          <p style="margin:0 0 8px;"><strong>Email:</strong> ${email}</p>
+          <p style="margin:0 0 8px;"><strong>Message:</strong></p>
+          <p style="margin:0;white-space:pre-wrap;padding:12px;background:#f4f4f4;border-radius:4px;">${message}</p>
+        </td>
+      </tr>
+    </table>
+  `;
+}
+
+export class ResendEmailService implements IEmailService {
+  constructor(
+    private readonly client: Resend,
+    private readonly config: IResendEmailServiceConfig,
+  ) {}
+
+  async send(message: IContactMessageDTO): Promise<Either<DomainError, void>> {
+    try {
+      await this.client.emails.send({
+        from: this.config.senderEmail,
+        to: this.config.recipientEmail,
+        replyTo: message.email,
+        subject: `Contact from ${message.name}`,
+        html: formatEmailHtml(message.name, message.email, message.message),
+      });
+      return right(undefined);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+      return left(new DomainError('EMAIL_SEND_FAILED', { message: errorMessage }));
+    }
+  }
+}

--- a/packages/infra/src/services/ResendEmailService.ts
+++ b/packages/infra/src/services/ResendEmailService.ts
@@ -37,13 +37,16 @@ export class ResendEmailService implements IEmailService {
 
   async send(message: IContactMessageDTO): Promise<Either<DomainError, void>> {
     try {
-      await this.client.emails.send({
+      const { error } = await this.client.emails.send({
         from: this.config.senderEmail,
         to: this.config.recipientEmail,
         replyTo: message.email,
         subject: `Contact from ${message.name}`,
         html: formatEmailHtml(message.name, message.email, message.message),
       });
+      if (error) {
+        return left(new DomainError('EMAIL_SEND_FAILED', { message: error.message }));
+      }
       return right(undefined);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error';

--- a/packages/infra/test/services/ResendEmailService.test.ts
+++ b/packages/infra/test/services/ResendEmailService.test.ts
@@ -1,0 +1,93 @@
+import { Resend } from 'resend';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { DomainError } from '@repo/core/shared';
+
+import { ResendEmailService, IResendEmailServiceConfig } from '../../src/services/ResendEmailService';
+
+const config: IResendEmailServiceConfig = {
+  recipientEmail: 'owner@example.com',
+  senderEmail: 'onboarding@resend.dev',
+};
+
+const validMessage = {
+  name: 'John Doe',
+  email: 'john@example.com',
+  message: 'Hello, I would like to get in touch.',
+};
+
+function makeService(sendMock: ReturnType<typeof vi.fn>) {
+  const client = { emails: { send: sendMock } } as unknown as Resend;
+  return new ResendEmailService(client, config);
+}
+
+describe('ResendEmailService', () => {
+  let sendMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendMock = vi.fn();
+  });
+
+  describe('send', () => {
+    it('should return right when email sends successfully', async () => {
+      sendMock.mockResolvedValueOnce({ id: 'email-id-123' });
+      const service = makeService(sendMock);
+
+      const result = await service.send(validMessage);
+
+      expect(result.isRight()).toBe(true);
+      expect(result.value).toBeUndefined();
+    });
+
+    it('should call resend with correct parameters', async () => {
+      sendMock.mockResolvedValueOnce({ id: 'email-id-123' });
+      const service = makeService(sendMock);
+
+      await service.send(validMessage);
+
+      expect(sendMock).toHaveBeenCalledOnce();
+      expect(sendMock).toHaveBeenCalledWith({
+        from: config.senderEmail,
+        to: config.recipientEmail,
+        replyTo: validMessage.email,
+        subject: `Contact from ${validMessage.name}`,
+        html: expect.stringContaining(validMessage.name),
+      });
+    });
+
+    it('should include all message fields in the email html', async () => {
+      sendMock.mockResolvedValueOnce({ id: 'email-id-123' });
+      const service = makeService(sendMock);
+
+      await service.send(validMessage);
+
+      const [call] = sendMock.mock.calls;
+      const html = call[0].html as string;
+      expect(html).toContain(validMessage.name);
+      expect(html).toContain(validMessage.email);
+      expect(html).toContain(validMessage.message);
+    });
+
+    it('should return left with DomainError when Resend API throws', async () => {
+      sendMock.mockRejectedValueOnce(new Error('API rate limit exceeded'));
+      const service = makeService(sendMock);
+
+      const result = await service.send(validMessage);
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+      expect((result.value as DomainError).code).toBe('EMAIL_SEND_FAILED');
+      expect((result.value as DomainError).message).toContain('API rate limit exceeded');
+    });
+
+    it('should return left with DomainError for unknown errors', async () => {
+      sendMock.mockRejectedValueOnce('unexpected string error');
+      const service = makeService(sendMock);
+
+      const result = await service.send(validMessage);
+
+      expect(result.isLeft()).toBe(true);
+      expect((result.value as DomainError).code).toBe('EMAIL_SEND_FAILED');
+    });
+  });
+});

--- a/packages/infra/test/services/ResendEmailService.test.ts
+++ b/packages/infra/test/services/ResendEmailService.test.ts
@@ -30,7 +30,7 @@ describe('ResendEmailService', () => {
 
   describe('send', () => {
     it('should return right when email sends successfully', async () => {
-      sendMock.mockResolvedValueOnce({ id: 'email-id-123' });
+      sendMock.mockResolvedValueOnce({ data: { id: 'email-id-123' }, error: null });
       const service = makeService(sendMock);
 
       const result = await service.send(validMessage);
@@ -40,7 +40,7 @@ describe('ResendEmailService', () => {
     });
 
     it('should call resend with correct parameters', async () => {
-      sendMock.mockResolvedValueOnce({ id: 'email-id-123' });
+      sendMock.mockResolvedValueOnce({ data: { id: 'email-id-123' }, error: null });
       const service = makeService(sendMock);
 
       await service.send(validMessage);
@@ -56,7 +56,7 @@ describe('ResendEmailService', () => {
     });
 
     it('should include all message fields in the email html', async () => {
-      sendMock.mockResolvedValueOnce({ id: 'email-id-123' });
+      sendMock.mockResolvedValueOnce({ data: { id: 'email-id-123' }, error: null });
       const service = makeService(sendMock);
 
       await service.send(validMessage);
@@ -68,8 +68,8 @@ describe('ResendEmailService', () => {
       expect(html).toContain(validMessage.message);
     });
 
-    it('should return left with DomainError when Resend API throws', async () => {
-      sendMock.mockRejectedValueOnce(new Error('API rate limit exceeded'));
+    it('should return left with DomainError when Resend returns an error object', async () => {
+      sendMock.mockResolvedValueOnce({ data: null, error: { message: 'You can only send testing emails to your own email address.' } });
       const service = makeService(sendMock);
 
       const result = await service.send(validMessage);
@@ -77,10 +77,21 @@ describe('ResendEmailService', () => {
       expect(result.isLeft()).toBe(true);
       expect(result.value).toBeInstanceOf(DomainError);
       expect((result.value as DomainError).code).toBe('EMAIL_SEND_FAILED');
-      expect((result.value as DomainError).message).toContain('API rate limit exceeded');
+      expect((result.value as DomainError).message).toContain('You can only send testing emails');
     });
 
-    it('should return left with DomainError for unknown errors', async () => {
+    it('should return left with DomainError when Resend throws unexpectedly', async () => {
+      sendMock.mockRejectedValueOnce(new Error('Network failure'));
+      const service = makeService(sendMock);
+
+      const result = await service.send(validMessage);
+
+      expect(result.isLeft()).toBe(true);
+      expect((result.value as DomainError).code).toBe('EMAIL_SEND_FAILED');
+      expect((result.value as DomainError).message).toContain('Network failure');
+    });
+
+    it('should return left with DomainError for unknown thrown values', async () => {
       sendMock.mockRejectedValueOnce('unexpected string error');
       const service = makeService(sendMock);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,6 +332,9 @@ importers:
       '@repo/utils':
         specifier: workspace:*
         version: link:../utils
+      resend:
+        specifier: ^6.9.4
+        version: 6.9.4
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -3938,6 +3941,10 @@ packages:
     dependencies:
       '@sinonjs/commons': 3.0.1
     dev: true
+
+  /@stablelib/base64@1.0.1:
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+    dev: false
 
   /@standard-schema/spec@1.1.0:
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -8203,6 +8210,10 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+    dev: false
+
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
@@ -11486,6 +11497,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /postal-mime@2.7.3:
+    resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
+    dev: false
+
   /postcss-import@15.1.0(postcss@8.4.47):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -12215,6 +12230,19 @@ packages:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
     dev: true
 
+  /resend@6.9.4:
+    resolution: {integrity: sha512-/M3dsJzu5OgozqVsA4Psd/1L7EdePgOIIxClas453GOQYFG3VHc2ZyCHZFlvqsc9aZCCd2BJRRqZgWC8D9c7/g==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+    dependencies:
+      postal-mime: 2.7.3
+      svix: 1.86.0
+    dev: false
+
   /resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -12712,6 +12740,13 @@ packages:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
     dev: true
 
+  /standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+    dev: false
+
   /std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
     dev: true
@@ -13012,6 +13047,13 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /svix@1.86.0:
+    resolution: {integrity: sha512-/HTvXwjLJe1l/MsLXAO1ddCYxElJk4eNR4DzOjDOEmGrPN/3BtBE8perGwMAaJ2sT5T172VkBYzmHcjUfM1JRQ==}
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
+    dev: false
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}


### PR DESCRIPTION
Closes #287

## Summary

- Instala dependência `resend` em `packages/infra`
- Implementa `ResendEmailService` com injeção de `Resend` client e config (`recipientEmail`, `senderEmail`) — sem acesso direto a env vars na classe
- Retorna `Either<DomainError, void>` seguindo o padrão Either do projeto
- Template HTML de e-mail simples com nome, email e mensagem do remetente
- Documenta `RESEND_API_KEY`, `CONTACT_EMAIL_TO` e `CONTACT_EMAIL_FROM` no `.env.example`
- 5 testes unitários com Resend client mockado

## Test plan

- [x] `pnpm --filter @repo/infra test` — 66 testes passando (5 novos)
- [x] TypeScript compila sem erros
- [x] Teste manual enviando e-mail real com chave Resend configurada

🤖 Generated with [Claude Code](https://claude.com/claude-code)