### PR TITLE
feat(infra): implement dependency injection container

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -3219,7 +3219,7 @@
           "4",
           "5"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -3283,7 +3283,8 @@
         ],
         "complexity": 4,
         "recommendedSubtasks": 5,
-        "expansionPrompt": "Break down DI container creation into subtasks: (1) Create container.ts with makeContainer() factory function initializing PrismaClient and Resend client singletons, (2) Instantiate all four repositories (PrismaProjectRepository, PrismaExperienceRepository, PrismaProfileRepository, PrismaSkillRepository if needed) with PrismaClient injection, (3) Instantiate ResendEmailService with Resend client and email config from env, (4) Implement env var validation throwing descriptive errors for missing required vars (DATABASE_URL, DIRECT_URL, RESEND_API_KEY, CONTACT_EMAIL_TO), (5) Export Container type and makeContainer, ensure singleton pattern, add integration test calling container and using repos."
+        "expansionPrompt": "Break down DI container creation into subtasks: (1) Create container.ts with makeContainer() factory function initializing PrismaClient and Resend client singletons, (2) Instantiate all four repositories (PrismaProjectRepository, PrismaExperienceRepository, PrismaProfileRepository, PrismaSkillRepository if needed) with PrismaClient injection, (3) Instantiate ResendEmailService with Resend client and email config from env, (4) Implement env var validation throwing descriptive errors for missing required vars (DATABASE_URL, DIRECT_URL, RESEND_API_KEY, CONTACT_EMAIL_TO), (5) Export Container type and makeContainer, ensure singleton pattern, add integration test calling container and using repos.",
+        "updatedAt": "2026-03-28T17:21:54.937Z"
       },
       {
         "id": "7",
@@ -3449,9 +3450,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-03-28T03:47:46.649Z",
+      "lastModified": "2026-03-28T17:21:54.938Z",
       "taskCount": 8,
-      "completedCount": 6,
+      "completedCount": 7,
       "tags": [
         "sprint-2"
       ]

--- a/packages/infra/scripts/send-email-manual.ts
+++ b/packages/infra/scripts/send-email-manual.ts
@@ -2,20 +2,21 @@ import { Resend } from 'resend';
 
 import { validateEnv } from '@repo/utils/env';
 
+import { env } from '../src/env';
 import { ResendEmailService } from '../src/services/ResendEmailService';
 
 try {
-  validateEnv(['RESEND_API_KEY', 'CONTACT_EMAIL_TO', 'CONTACT_EMAIL_FROM']);
+  validateEnv(Object.keys(env));
 } catch (err) {
   console.error(err instanceof Error ? err.message : err);
   process.exit(1);
 }
 
 async function main() {
-  const client = new Resend(process.env.RESEND_API_KEY!);
+  const client = new Resend(env.RESEND_API_KEY);
   const service = new ResendEmailService(client, {
-    recipientEmail: process.env.CONTACT_EMAIL_TO!,
-    senderEmail: process.env.CONTACT_EMAIL_FROM!,
+    recipientEmail: env.CONTACT_EMAIL_TO,
+    senderEmail: env.CONTACT_EMAIL_FROM,
   });
 
   const result = await service.send({
@@ -29,7 +30,7 @@ async function main() {
     process.exit(1);
   }
 
-  console.log('SUCCESS: email sent to', process.env.CONTACT_EMAIL_TO);
+  console.log('SUCCESS: email sent to', env.CONTACT_EMAIL_TO);
 }
 
 main();

--- a/packages/infra/scripts/send-email-manual.ts
+++ b/packages/infra/scripts/send-email-manual.ts
@@ -1,13 +1,14 @@
 import { Resend } from 'resend';
 
+import { validateEnv } from '@repo/utils/env';
+
 import { ResendEmailService } from '../src/services/ResendEmailService';
 
-const requiredVars = ['RESEND_API_KEY', 'CONTACT_EMAIL_TO', 'CONTACT_EMAIL_FROM'] as const;
-for (const key of requiredVars) {
-  if (!process.env[key]) {
-    console.error(`Missing environment variable: ${key}`);
-    process.exit(1);
-  }
+try {
+  validateEnv(['RESEND_API_KEY', 'CONTACT_EMAIL_TO', 'CONTACT_EMAIL_FROM']);
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
 }
 
 async function main() {

--- a/packages/infra/src/container.ts
+++ b/packages/infra/src/container.ts
@@ -6,6 +6,7 @@ import { IProjectRepository } from '@repo/core/portfolio';
 import { IEmailService } from '@repo/application/contact';
 import { validateEnv } from '@repo/utils/env';
 
+import { env } from './env';
 import { prisma } from './prisma/client';
 import { PrismaExperienceRepository } from './repositories/experience/PrismaExperienceRepository';
 import { PrismaProfileRepository } from './repositories/profile/PrismaProfileRepository';
@@ -19,20 +20,18 @@ export interface Container {
   emailService: IEmailService;
 }
 
-const REQUIRED_ENV_VARS = ['RESEND_API_KEY', 'CONTACT_EMAIL_TO', 'CONTACT_EMAIL_FROM'] as const;
-
 export function makeContainer(): Container {
-  validateEnv(REQUIRED_ENV_VARS);
+  validateEnv(Object.keys(env));
 
-  const resend = new Resend(process.env['RESEND_API_KEY']!);
+  const resend = new Resend(env.RESEND_API_KEY);
 
   return {
     projectRepository: new PrismaProjectRepository(prisma),
     experienceRepository: new PrismaExperienceRepository(prisma),
     profileRepository: new PrismaProfileRepository(prisma),
     emailService: new ResendEmailService(resend, {
-      recipientEmail: process.env['CONTACT_EMAIL_TO']!,
-      senderEmail: process.env['CONTACT_EMAIL_FROM']!,
+      recipientEmail: env.CONTACT_EMAIL_TO,
+      senderEmail: env.CONTACT_EMAIL_FROM,
     }),
   };
 }

--- a/packages/infra/src/container.ts
+++ b/packages/infra/src/container.ts
@@ -1,0 +1,55 @@
+import { Resend } from 'resend';
+
+import { IExperienceRepository } from '@repo/core/portfolio';
+import { IProfileRepository } from '@repo/core/portfolio';
+import { IProjectRepository } from '@repo/core/portfolio';
+import { IEmailService } from '@repo/application/contact';
+
+import { prisma } from './prisma/client';
+import { PrismaExperienceRepository } from './repositories/experience/PrismaExperienceRepository';
+import { PrismaProfileRepository } from './repositories/profile/PrismaProfileRepository';
+import { PrismaProjectRepository } from './repositories/project/PrismaProjectRepository';
+import { ResendEmailService } from './services/ResendEmailService';
+
+export interface Container {
+  projectRepository: IProjectRepository;
+  experienceRepository: IExperienceRepository;
+  profileRepository: IProfileRepository;
+  emailService: IEmailService;
+}
+
+const REQUIRED_ENV_VARS = ['RESEND_API_KEY', 'CONTACT_EMAIL_TO', 'CONTACT_EMAIL_FROM'] as const;
+
+function validateEnv(): void {
+  const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}. Please set them in your .env file.`,
+    );
+  }
+}
+
+export function makeContainer(): Container {
+  validateEnv();
+
+  const resend = new Resend(process.env['RESEND_API_KEY']!);
+
+  return {
+    projectRepository: new PrismaProjectRepository(prisma),
+    experienceRepository: new PrismaExperienceRepository(prisma),
+    profileRepository: new PrismaProfileRepository(prisma),
+    emailService: new ResendEmailService(resend, {
+      recipientEmail: process.env['CONTACT_EMAIL_TO']!,
+      senderEmail: process.env['CONTACT_EMAIL_FROM']!,
+    }),
+  };
+}
+
+let containerInstance: Container | null = null;
+
+export function getContainer(): Container {
+  if (!containerInstance) {
+    containerInstance = makeContainer();
+  }
+  return containerInstance;
+}

--- a/packages/infra/src/container.ts
+++ b/packages/infra/src/container.ts
@@ -4,6 +4,7 @@ import { IExperienceRepository } from '@repo/core/portfolio';
 import { IProfileRepository } from '@repo/core/portfolio';
 import { IProjectRepository } from '@repo/core/portfolio';
 import { IEmailService } from '@repo/application/contact';
+import { validateEnv } from '@repo/utils/env';
 
 import { prisma } from './prisma/client';
 import { PrismaExperienceRepository } from './repositories/experience/PrismaExperienceRepository';
@@ -20,17 +21,8 @@ export interface Container {
 
 const REQUIRED_ENV_VARS = ['RESEND_API_KEY', 'CONTACT_EMAIL_TO', 'CONTACT_EMAIL_FROM'] as const;
 
-function validateEnv(): void {
-  const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
-  if (missing.length > 0) {
-    throw new Error(
-      `Missing required environment variables: ${missing.join(', ')}. Please set them in your .env file.`,
-    );
-  }
-}
-
 export function makeContainer(): Container {
-  validateEnv();
+  validateEnv(REQUIRED_ENV_VARS);
 
   const resend = new Resend(process.env['RESEND_API_KEY']!);
 

--- a/packages/infra/src/env.ts
+++ b/packages/infra/src/env.ts
@@ -1,0 +1,11 @@
+export const env = {
+  get RESEND_API_KEY() {
+    return process.env['RESEND_API_KEY']!;
+  },
+  get CONTACT_EMAIL_TO() {
+    return process.env['CONTACT_EMAIL_TO']!;
+  },
+  get CONTACT_EMAIL_FROM() {
+    return process.env['CONTACT_EMAIL_FROM']!;
+  },
+};

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -1,3 +1,5 @@
+export { makeContainer, getContainer } from './container';
+export type { Container } from './container';
 export { prisma } from './prisma/client';
 export { InfrastructureError } from './errors/InfrastructureError';
 export { ProjectMapper } from './repositories/project/ProjectMapper';

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -1,3 +1,4 @@
+export { env } from './env';
 export { makeContainer, getContainer } from './container';
 export type { Container } from './container';
 export { prisma } from './prisma/client';

--- a/packages/infra/test/container.test.ts
+++ b/packages/infra/test/container.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../src/prisma/client', () => ({
+  prisma: {},
+}));
+
+vi.mock('resend', () => ({
+  Resend: vi.fn().mockImplementation(() => ({ emails: { send: vi.fn() } })),
+}));
+
+vi.mock('../src/repositories/project/PrismaProjectRepository', () => ({
+  PrismaProjectRepository: vi.fn().mockImplementation(() => ({ findAll: vi.fn() })),
+}));
+
+vi.mock('../src/repositories/experience/PrismaExperienceRepository', () => ({
+  PrismaExperienceRepository: vi.fn().mockImplementation(() => ({ findAll: vi.fn() })),
+}));
+
+vi.mock('../src/repositories/profile/PrismaProfileRepository', () => ({
+  PrismaProfileRepository: vi.fn().mockImplementation(() => ({ find: vi.fn() })),
+}));
+
+vi.mock('../src/services/ResendEmailService', () => ({
+  ResendEmailService: vi.fn().mockImplementation(() => ({ send: vi.fn() })),
+}));
+
+const VALID_ENV = {
+  RESEND_API_KEY: 're_test_key',
+  CONTACT_EMAIL_TO: 'owner@example.com',
+  CONTACT_EMAIL_FROM: 'onboarding@resend.dev',
+};
+
+describe('container', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    Object.assign(process.env, VALID_ENV);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('makeContainer', () => {
+    it('should return a container with all dependencies', async () => {
+      const { makeContainer } = await import('../src/container');
+
+      const container = makeContainer();
+
+      expect(container.projectRepository).toBeDefined();
+      expect(container.experienceRepository).toBeDefined();
+      expect(container.profileRepository).toBeDefined();
+      expect(container.emailService).toBeDefined();
+    });
+
+    it('should throw when RESEND_API_KEY is missing', async () => {
+      delete process.env['RESEND_API_KEY'];
+      const { makeContainer } = await import('../src/container');
+
+      expect(() => makeContainer()).toThrow('RESEND_API_KEY');
+    });
+
+    it('should throw when CONTACT_EMAIL_TO is missing', async () => {
+      delete process.env['CONTACT_EMAIL_TO'];
+      const { makeContainer } = await import('../src/container');
+
+      expect(() => makeContainer()).toThrow('CONTACT_EMAIL_TO');
+    });
+
+    it('should throw when CONTACT_EMAIL_FROM is missing', async () => {
+      delete process.env['CONTACT_EMAIL_FROM'];
+      const { makeContainer } = await import('../src/container');
+
+      expect(() => makeContainer()).toThrow('CONTACT_EMAIL_FROM');
+    });
+
+    it('should list all missing variables in a single error', async () => {
+      delete process.env['RESEND_API_KEY'];
+      delete process.env['CONTACT_EMAIL_TO'];
+      delete process.env['CONTACT_EMAIL_FROM'];
+      const { makeContainer } = await import('../src/container');
+
+      expect(() => makeContainer()).toThrow(
+        /RESEND_API_KEY.*CONTACT_EMAIL_TO.*CONTACT_EMAIL_FROM/,
+      );
+    });
+  });
+
+  describe('getContainer', () => {
+    it('should return the same instance on subsequent calls', async () => {
+      const { getContainer } = await import('../src/container');
+
+      const first = getContainer();
+      const second = getContainer();
+
+      expect(first).toBe(second);
+    });
+  });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,8 @@
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./validator": "./src/validator/index.ts"
+    "./validator": "./src/validator/index.ts",
+    "./env": "./src/env/index.ts"
   },
   "scripts": {
     "test": "jest",

--- a/packages/utils/src/env/index.ts
+++ b/packages/utils/src/env/index.ts
@@ -1,0 +1,1 @@
+export * from './validateEnv';

--- a/packages/utils/src/env/validateEnv.ts
+++ b/packages/utils/src/env/validateEnv.ts
@@ -1,0 +1,8 @@
+export function validateEnv(vars: readonly string[]): void {
+  const missing = vars.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}. Please set them in your .env file.`,
+    );
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './constants';
+export * from './env';
 export * from './formatters';
 export * from './hooks';
 export * from './types';

--- a/packages/utils/test/node/validateEnv.test.ts
+++ b/packages/utils/test/node/validateEnv.test.ts
@@ -1,0 +1,39 @@
+import { validateEnv } from '../../src/env/validateEnv';
+
+describe('validateEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should not throw when all required variables are set', () => {
+    process.env['FOO'] = 'foo';
+    process.env['BAR'] = 'bar';
+
+    expect(() => validateEnv(['FOO', 'BAR'])).not.toThrow();
+  });
+
+  it('should throw when a single variable is missing', () => {
+    delete process.env['MISSING_VAR'];
+
+    expect(() => validateEnv(['MISSING_VAR'])).toThrow('MISSING_VAR');
+  });
+
+  it('should list all missing variables in a single error', () => {
+    delete process.env['FIRST_VAR'];
+    delete process.env['SECOND_VAR'];
+
+    expect(() => validateEnv(['FIRST_VAR', 'SECOND_VAR'])).toThrow(
+      /FIRST_VAR.*SECOND_VAR/,
+    );
+  });
+
+  it('should not throw when given an empty array', () => {
+    expect(() => validateEnv([])).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #288

## Summary

- Adiciona `makeContainer()` em `packages/infra/src/container.ts` que instancia e retorna todos os repositórios e serviços com suas dependências injetadas
- Adiciona `getContainer()` como wrapper singleton — cria o container uma única vez e reutiliza nas chamadas seguintes
- Valida as variáveis de ambiente obrigatórias (`RESEND_API_KEY`, `CONTACT_EMAIL_TO`, `CONTACT_EMAIL_FROM`) na inicialização, listando todas as ausentes em um único erro descritivo
- Exporta `makeContainer`, `getContainer` e o tipo `Container` via `src/index.ts`
- 6 testes unitários cobrindo: container completo, cada env var ausente individualmente, erro agregado para múltiplas ausentes e singleton

## Test plan

- [x] `pnpm --filter @repo/infra test` — 73 testes passando (6 novos)
- [x] TypeScript compila sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)