### PR TITLE
feat(web): response envelope and GET /api/v1/projects/:slug

### DIFF
--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -9,6 +9,9 @@ const jestConfig: JestConfigWithTsJest = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
+  moduleNameMapper: {
+    '^~(.*)$': '<rootDir>/src$1',
+  },
 };
 
 export default jestConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,9 @@
     "types": "tsc -p ./tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@repo/application": "workspace:*",
     "@repo/core": "workspace:*",
+    "@repo/infra": "workspace:*",
     "@repo/ui": "workspace:*",
     "@repo/utils": "workspace:*",
     "classnames": "^2.5.1",

--- a/apps/web/src/app/api/v1/projects/[slug]/route.test.ts
+++ b/apps/web/src/app/api/v1/projects/[slug]/route.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ */
+import { DomainError, NotFoundError, ValidationError, right, left } from '@repo/core/shared';
+
+const mockExecute = jest.fn();
+
+jest.mock('@repo/infra', () => ({
+  getContainer: jest.fn(() => ({
+    projectRepository: {},
+  })),
+}));
+
+jest.mock('@repo/application/portfolio', () => ({
+  GetProjectBySlug: jest.fn().mockImplementation(() => ({
+    execute: mockExecute,
+  })),
+}));
+
+describe('GET /api/v1/projects/[slug]', () => {
+  const makeRequest = (slug: string, locale?: string) => {
+    const url = `http://localhost/api/v1/projects/${slug}${locale ? `?locale=${locale}` : ''}`;
+    return new Request(url);
+  };
+
+  it('should return 200 with project data when found', async () => {
+    const projectData = { id: '1', slug: 'my-project', title: 'My Project' };
+    mockExecute.mockResolvedValueOnce(right(projectData));
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('my-project', 'en-US'), {
+      params: { slug: 'my-project' },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: projectData });
+  });
+
+  it('should return 404 when project is not found', async () => {
+    mockExecute.mockResolvedValueOnce(left(new NotFoundError({ slug: 'unknown' })));
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('unknown'), { params: { slug: 'unknown' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('should return 422 when slug is invalid', async () => {
+    mockExecute.mockResolvedValueOnce(
+      left(new ValidationError({ code: 'INVALID_SLUG', message: 'Invalid slug' })),
+    );
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('INVALID SLUG'), { params: { slug: 'INVALID SLUG' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('INVALID_SLUG');
+  });
+
+  it('should return 500 on unexpected domain error', async () => {
+    mockExecute.mockResolvedValueOnce(
+      left(new DomainError('FETCH_FAILED', { message: 'DB down' })),
+    );
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('my-project'), { params: { slug: 'my-project' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.error.message).toBe('Internal server error');
+  });
+
+  it('should default to DEFAULT_LOCALE when locale param is missing', async () => {
+    const projectData = { id: '1', slug: 'my-project' };
+    mockExecute.mockResolvedValueOnce(right(projectData));
+
+    const { GET } = await import('./route');
+    await GET(makeRequest('my-project'), { params: { slug: 'my-project' } });
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: 'pt-BR' }),
+    );
+  });
+
+  it('should use provided locale when valid', async () => {
+    const projectData = { id: '1', slug: 'my-project' };
+    mockExecute.mockResolvedValueOnce(right(projectData));
+
+    const { GET } = await import('./route');
+    await GET(makeRequest('my-project', 'en-US'), { params: { slug: 'my-project' } });
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: 'en-US' }),
+    );
+  });
+});

--- a/apps/web/src/app/api/v1/projects/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[slug]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getContainer } from '@repo/infra';
+import { GetProjectBySlug } from '@repo/application/portfolio';
+import { DEFAULT_LOCALE, isLocale } from '@repo/core/shared';
+
+import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { slug: string } },
+) {
+  const { projectRepository } = getContainer();
+  const useCase = new GetProjectBySlug(projectRepository);
+
+  const { searchParams } = new URL(request.url);
+  const localeParam = searchParams.get('locale') ?? '';
+  const locale = isLocale(localeParam) ? localeParam : DEFAULT_LOCALE;
+
+  const result = await useCase.execute({ slug: params.slug, locale });
+
+  if (result.isLeft()) {
+    const { status, code, message } = mapDomainErrorToHttp(result.value);
+    return NextResponse.json(errorResponse(code, message), { status });
+  }
+
+  return NextResponse.json(successResponse(result.value));
+}

--- a/apps/web/src/lib/api/envelope.test.ts
+++ b/apps/web/src/lib/api/envelope.test.ts
@@ -1,0 +1,35 @@
+import { errorResponse, successResponse } from './envelope';
+
+describe('successResponse', () => {
+  it('should return success shape with data', () => {
+    const result = successResponse({ id: '1', name: 'Project' });
+
+    expect(result).toEqual({ success: true, data: { id: '1', name: 'Project' } });
+  });
+
+  it('should work with primitive data types', () => {
+    expect(successResponse(42)).toEqual({ success: true, data: 42 });
+    expect(successResponse('hello')).toEqual({ success: true, data: 'hello' });
+    expect(successResponse(null)).toEqual({ success: true, data: null });
+  });
+});
+
+describe('errorResponse', () => {
+  it('should return error shape with code and message', () => {
+    const result = errorResponse('NOT_FOUND', 'Resource not found');
+
+    expect(result).toEqual({
+      success: false,
+      error: { code: 'NOT_FOUND', message: 'Resource not found' },
+    });
+  });
+
+  it('should preserve the error code exactly', () => {
+    const result = errorResponse('VALIDATION_ERROR', 'Invalid slug');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('VALIDATION_ERROR');
+    }
+  });
+});

--- a/apps/web/src/lib/api/envelope.ts
+++ b/apps/web/src/lib/api/envelope.ts
@@ -1,0 +1,11 @@
+export type ApiResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: { code: string; message: string } };
+
+export function successResponse<T>(data: T): ApiResponse<T> {
+  return { success: true, data };
+}
+
+export function errorResponse(code: string, message: string): ApiResponse<never> {
+  return { success: false, error: { code, message } };
+}

--- a/apps/web/src/lib/api/error-mapper.test.ts
+++ b/apps/web/src/lib/api/error-mapper.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { mapDomainErrorToHttp } from './error-mapper';
+
+describe('mapDomainErrorToHttp', () => {
+  it('should map NotFoundError to 404', () => {
+    const error = new NotFoundError({ slug: 'missing-project' });
+
+    const result = mapDomainErrorToHttp(error);
+
+    expect(result.status).toBe(404);
+    expect(result.code).toBe('NOT_FOUND');
+  });
+
+  it('should map ValidationError to 422', () => {
+    const error = new ValidationError({ code: 'INVALID_SLUG', message: 'Slug must be kebab-case.' });
+
+    const result = mapDomainErrorToHttp(error);
+
+    expect(result.status).toBe(422);
+    expect(result.code).toBe('INVALID_SLUG');
+    expect(result.message).toBe('Slug must be kebab-case.');
+  });
+
+  it('should map generic DomainError to 500 with opaque message', () => {
+    const error = new DomainError('FETCH_FAILED', { message: 'DB connection refused' });
+
+    const result = mapDomainErrorToHttp(error);
+
+    expect(result.status).toBe(500);
+    expect(result.code).toBe('FETCH_FAILED');
+    expect(result.message).toBe('Internal server error');
+  });
+});

--- a/apps/web/src/lib/api/error-mapper.ts
+++ b/apps/web/src/lib/api/error-mapper.ts
@@ -1,0 +1,17 @@
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+export interface HttpErrorResult {
+  status: number;
+  code: string;
+  message: string;
+}
+
+export function mapDomainErrorToHttp(error: DomainError): HttpErrorResult {
+  if (error instanceof NotFoundError) {
+    return { status: 404, code: error.code, message: error.message };
+  }
+  if (error instanceof ValidationError) {
+    return { status: 422, code: error.code, message: error.message };
+  }
+  return { status: 500, code: error.code, message: 'Internal server error' };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@repo/application':
+        specifier: workspace:*
+        version: link:../../packages/application
       '@repo/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@repo/infra':
+        specifier: workspace:*
+        version: link:../../packages/infra
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -5194,7 +5200,7 @@ packages:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.14.2)(tsx@4.21.0)
+      vitest: 3.2.4(@types/node@20.14.2)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
## Summary

- Add `ApiResponse<T>` discriminated union type with `successResponse`/`errorResponse` helpers (`src/lib/api/envelope.ts`)
- Add `mapDomainErrorToHttp` mapping `NotFoundError→404`, `ValidationError→422`, `DomainError→500` (`src/lib/api/error-mapper.ts`)
- Add `GET /api/v1/projects/[slug]` Next.js route handler using `GetProjectBySlug` use case with locale negotiation via `?locale=` query param (defaults to `pt-BR`)
- Add `@repo/application` and `@repo/infra` workspace dependencies to `apps/web`
- Add `moduleNameMapper` for `~` path aliases in `jest.config.ts`

## Test plan

- [x] `envelope.test.ts` — `successResponse` and `errorResponse` shape assertions
- [x] `error-mapper.test.ts` — 404/422/500 mapping for each error subclass
- [x] `route.test.ts` — 200 success, 404 not found, 422 invalid slug, 500 domain error, locale defaulting and negotiation
- [x] All 15 tests pass (`pnpm --filter web test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)