### PR TITLE
feat(core): introduce AggregateRoot base class

### DIFF
--- a/packages/core/src/portfolio/entities/experience/model/Experience.ts
+++ b/packages/core/src/portfolio/entities/experience/model/Experience.ts
@@ -4,7 +4,7 @@ import {
   Either,
   EmploymentType,
   EmploymentTypeValue,
-  Entity,
+  AggregateRoot,
   IEntityProps,
   ILocalizedTextInput,
   Image,
@@ -35,7 +35,7 @@ export interface IExperienceProps extends IEntityProps {
   end_at?: string;
 }
 
-export class Experience extends Entity<Experience, IExperienceProps> {
+export class Experience extends AggregateRoot<Experience, IExperienceProps> {
   static readonly ERROR_CODE = 'INVALID_EXPERIENCE';
 
   public readonly company: LocalizedText;

--- a/packages/core/src/portfolio/entities/profile/model/Profile.ts
+++ b/packages/core/src/portfolio/entities/profile/model/Profile.ts
@@ -3,7 +3,7 @@ import { Validator } from '@repo/utils/validator';
 import {
   collect,
   Either,
-  Entity,
+  AggregateRoot,
   IEntityProps,
   Image,
   left,
@@ -27,7 +27,7 @@ export interface IProfileProps extends IEntityProps {
   featuredProjectSlugs: string[];
 }
 
-export class Profile extends Entity<Profile, IProfileProps> {
+export class Profile extends AggregateRoot<Profile, IProfileProps> {
   static readonly ERROR_CODE = 'TOO_MANY_FEATURED_PROJECTS';
   private static readonly MAX_FEATURED_PROJECTS = 6;
 

--- a/packages/core/src/portfolio/entities/project/model/Project.ts
+++ b/packages/core/src/portfolio/entities/project/model/Project.ts
@@ -4,7 +4,7 @@ import {
   collect,
   DateRange,
   Either,
-  Entity,
+  AggregateRoot,
   IEntityProps,
   ILocalizedTextInput,
   Image,
@@ -46,7 +46,7 @@ export interface IProjectProps extends IEntityProps {
   relatedProjects?: string[];
 }
 
-export class Project extends Entity<Project, IProjectProps> {
+export class Project extends AggregateRoot<Project, IProjectProps> {
   static readonly ERROR_CODE = 'INVALID_PROJECT';
 
   public readonly slug: Slug;

--- a/packages/core/src/portfolio/entities/skill/model/Skill.ts
+++ b/packages/core/src/portfolio/entities/skill/model/Skill.ts
@@ -1,7 +1,7 @@
 import {
   collect,
   Either,
-  Entity,
+  AggregateRoot,
   IEntityProps,
   left,
   right,
@@ -17,7 +17,7 @@ export interface ISkillProps extends IEntityProps {
   type: SkillTypeValue;
 }
 
-export class Skill extends Entity<Skill, ISkillProps> {
+export class Skill extends AggregateRoot<Skill, ISkillProps> {
   public readonly description: Text;
   public readonly icon: Text;
   public readonly type: SkillType;

--- a/packages/core/src/shared/base/AggregateRoot.ts
+++ b/packages/core/src/shared/base/AggregateRoot.ts
@@ -1,0 +1,11 @@
+import { Entity, IEntityProps } from './Entity';
+
+/**
+ * Marks entities that serve as transactional consistency boundaries
+ * and have their own repositories for persistence.
+ * Distinct aggregates reference each other by Id, not by object.
+ */
+export abstract class AggregateRoot<
+  TEntity,
+  TProps extends IEntityProps,
+> extends Entity<TEntity, TProps> {}

--- a/packages/core/src/shared/base/index.ts
+++ b/packages/core/src/shared/base/index.ts
@@ -1,2 +1,3 @@
+export * from './AggregateRoot';
 export * from './Entity';
 export * from './ValueObject';


### PR DESCRIPTION
## Summary

- Cria `AggregateRoot<TEntity, TProps>` estendendo `Entity` (corpo vazio — semântica por ora)
- Exporta de `shared/base/index.ts`
- `Project`, `Experience`, `Skill`, `Profile` passam a estender `AggregateRoot`
- `Language`, `ProfessionalValue`, `SocialNetwork` permanecem como `Entity` (objetos internos ao aggregate de `Profile`)
- `ProfileStat` permanece como classe simples (sem identidade própria)

## Test plan

- [x] `pnpm --filter @repo/core types` — sem erros de compilação
- [x] `pnpm --filter @repo/core test` — 218 testes passando

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)