### PR TITLE
feat(infra): implement PrismaUserRepository with migration and seed

### DIFF
--- a/packages/infra/prisma/migrations/20260328000001_add_users_table/migration.sql
+++ b/packages/infra/prisma/migrations/20260328000001_add_users_table/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'VISITOR');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'VISITOR',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE INDEX "User_email_idx" ON "User"("email");

--- a/packages/infra/prisma/schema.prisma
+++ b/packages/infra/prisma/schema.prisma
@@ -18,6 +18,12 @@ enum ProjectStatus {
   ARCHIVED
 }
 
+// Role mirrors Role enum in core/identity
+enum Role {
+  ADMIN
+  VISITOR
+}
+
 // SkillType mirrors SkillType.SKILLS in core
 enum SkillType {
   EDUCATION
@@ -174,4 +180,19 @@ model SocialNetwork {
   profile   Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)
 
   @@index([profileId])
+}
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+model User {
+  id        String   @id @default(uuid()) @db.Uuid
+  name      String
+  email     String   @unique
+  role      Role     @default(VISITOR)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([email])
 }

--- a/packages/infra/prisma/seed.ts
+++ b/packages/infra/prisma/seed.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const adminEmail =
+    process.env['ADMIN_EMAIL'] ?? 'admin@portfolio.dev';
+  const adminName = process.env['ADMIN_NAME'] ?? 'Admin';
+
+  await prisma.user.upsert({
+    where: { email: adminEmail },
+    update: {},
+    create: { email: adminEmail, name: adminName, role: 'ADMIN' },
+  });
+
+  console.log(`Admin user seeded: ${adminEmail}`);
+}
+
+main()
+  .catch((e) => {
+    console.error('Seed failed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/infra/src/container.ts
+++ b/packages/infra/src/container.ts
@@ -1,5 +1,6 @@
 import { Resend } from 'resend';
 
+import { IUserRepository } from '@repo/core/identity';
 import { IExperienceRepository } from '@repo/core/portfolio';
 import { IProfileRepository } from '@repo/core/portfolio';
 import { IProjectRepository } from '@repo/core/portfolio';
@@ -11,6 +12,7 @@ import { prisma } from './prisma/client';
 import { PrismaExperienceRepository } from './repositories/experience/PrismaExperienceRepository';
 import { PrismaProfileRepository } from './repositories/profile/PrismaProfileRepository';
 import { PrismaProjectRepository } from './repositories/project/PrismaProjectRepository';
+import { PrismaUserRepository } from './repositories/user/PrismaUserRepository';
 import { ResendEmailService } from './services/ResendEmailService';
 
 export interface Container {
@@ -18,6 +20,7 @@ export interface Container {
   experienceRepository: IExperienceRepository;
   profileRepository: IProfileRepository;
   emailService: IEmailService;
+  userRepository: IUserRepository;
 }
 
 export function makeContainer(): Container {
@@ -33,6 +36,7 @@ export function makeContainer(): Container {
       recipientEmail: env.CONTACT_EMAIL_TO,
       senderEmail: env.CONTACT_EMAIL_FROM,
     }),
+    userRepository: new PrismaUserRepository(prisma),
   };
 }
 

--- a/packages/infra/src/env.ts
+++ b/packages/infra/src/env.ts
@@ -8,4 +8,7 @@ export const env = {
   get CONTACT_EMAIL_FROM() {
     return process.env['CONTACT_EMAIL_FROM']!;
   },
+  get ADMIN_EMAIL() {
+    return process.env['ADMIN_EMAIL'] ?? 'admin@portfolio.dev';
+  },
 };

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -11,3 +11,5 @@ export { ProfileMapper } from './repositories/profile/ProfileMapper';
 export { PrismaProfileRepository } from './repositories/profile/PrismaProfileRepository';
 export { ResendEmailService } from './services/ResendEmailService';
 export type { IResendEmailServiceConfig } from './services/ResendEmailService';
+export { UserMapper } from './repositories/user/UserMapper';
+export { PrismaUserRepository } from './repositories/user/PrismaUserRepository';

--- a/packages/infra/src/repositories/user/PrismaUserRepository.ts
+++ b/packages/infra/src/repositories/user/PrismaUserRepository.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+
+import { IUserRepository, User } from '@repo/core/identity';
+import { Email, Id } from '@repo/core/shared';
+
+import { UserMapper } from './UserMapper';
+
+export class PrismaUserRepository implements IUserRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async findById(id: Id): Promise<User | null> {
+    const row = await this.db.user.findUnique({ where: { id: id.value } });
+    return row ? UserMapper.toDomain(row) : null;
+  }
+
+  async findByEmail(email: Email): Promise<User | null> {
+    const row = await this.db.user.findUnique({
+      where: { email: email.value },
+    });
+    return row ? UserMapper.toDomain(row) : null;
+  }
+
+  async save(user: User): Promise<void> {
+    const { id, ...rest } = UserMapper.toPrisma(user);
+    await this.db.user.upsert({
+      where: { id },
+      create: { id, ...rest },
+      update: rest,
+    });
+  }
+}

--- a/packages/infra/src/repositories/user/UserMapper.ts
+++ b/packages/infra/src/repositories/user/UserMapper.ts
@@ -1,0 +1,41 @@
+import { Prisma, User as PrismaUser } from '@prisma/client';
+
+import { IUserProps, Role, User } from '@repo/core/identity';
+
+import { InfrastructureError } from '../../errors/InfrastructureError';
+
+type UserScalarData = Omit<Prisma.UserUncheckedCreateInput, never>;
+
+export class UserMapper {
+  static toDomain(raw: PrismaUser): User {
+    const props: IUserProps = {
+      id: raw.id,
+      name: raw.name,
+      email: raw.email,
+      role: raw.role as Role,
+      created_at: raw.createdAt.toISOString(),
+      updated_at: raw.updatedAt.toISOString(),
+    };
+
+    const result = User.create(props);
+    if (result.isLeft()) {
+      throw new InfrastructureError(
+        `Failed to map user ${raw.id} to domain: ${result.value.message}`,
+        result.value,
+      );
+    }
+
+    return result.value;
+  }
+
+  static toPrisma(user: User): UserScalarData {
+    return {
+      id: user.id.value,
+      name: user.name.value,
+      email: user.email.value,
+      role: user.role,
+      createdAt: new Date(user.created_at.value),
+      updatedAt: new Date(user.updated_at.value),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add `Role` enum and `User` model to Prisma schema
- Create migration `20260328000001_add_users_table` (manual — sem conexão live ao DB)
- Implement `UserMapper` (`toDomain` / `toPrisma`)
- Implement `PrismaUserRepository` (`findById`, `findByEmail`, `save` com upsert)
- Add `ADMIN_EMAIL` env var e seed script para criar o admin inicial
- Wire `PrismaUserRepository` no `Container`

## Test plan

- [ ] Rodar `pnpm --filter @repo/infra db:migrate` após merge para aplicar a migration
- [ ] Rodar `pnpm --filter @repo/infra db:seed` e verificar criação do admin
- [ ] Executar seed duas vezes e confirmar idempotência (upsert)
- [ ] `pnpm --filter @repo/infra types` — sem erros TypeScript

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)