### PR TITLE
fix(infra): correct users migration and fix db:seed env loading

### DIFF
--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -18,7 +18,7 @@
     "db:migrate:deploy": "dotenv -e ../../.env -- prisma migrate deploy",
     "db:push": "dotenv -e ../../.env -- prisma db push",
     "db:studio": "dotenv -e ../../.env -- prisma studio",
-    "db:seed": "tsx prisma/seed.ts",
+    "db:seed": "dotenv -e ../../.env -- tsx prisma/seed.ts",
     "test": "dotenv -e ../../.env -- vitest run",
     "send:email:manual": "dotenv -e ../../.env -- tsx scripts/send-email-manual.ts",
     "test:watch": "dotenv -e ../../.env -- vitest",

--- a/packages/infra/prisma/migrations/20260329010228_add_users_table/migration.sql
+++ b/packages/infra/prisma/migrations/20260329010228_add_users_table/migration.sql
@@ -3,7 +3,7 @@ CREATE TYPE "Role" AS ENUM ('ADMIN', 'VISITOR');
 
 -- CreateTable
 CREATE TABLE "User" (
-    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "id" UUID NOT NULL,
     "name" TEXT NOT NULL,
     "email" TEXT NOT NULL,
     "role" "Role" NOT NULL DEFAULT 'VISITOR',


### PR DESCRIPTION
## Summary

Correções após execução real das migrations:

- **Migration**: substitui a migration manual `20260328000001` pela gerada pelo Prisma `20260329010228_add_users_table` — o SQL correto não inclui `DEFAULT` no `id` (Prisma gera UUID na aplicação, não no banco)
- **db:seed**: adiciona `dotenv -e ../../.env --` ao script, alinhado com os demais scripts `db:*`

## Por que aconteceu

A migration foi criada manualmente antes de haver conexão com o banco. O SQL manual usava `DEFAULT gen_random_uuid()` (DB-level), mas o Prisma usa `@default(uuid())` que gera o UUID na aplicação. O checksum divergiu causando conflito na tabela `_prisma_migrations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)