### PR TITLE
docs(env): add ADMIN_EMAIL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ RESEND_API_KEY="re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 CONTACT_EMAIL_TO="your@email.com"
 # The sender email address (must be a verified domain in Resend).
 CONTACT_EMAIL_FROM="onboarding@resend.dev"
+
+# Identity
+# Email address of the initial admin user created by the seed script.
+# Defaults to "admin@portfolio.dev" if not set.
+ADMIN_EMAIL="admin@portfolio.dev"


### PR DESCRIPTION
## Summary

- Adiciona `ADMIN_EMAIL` ao `.env.example` com comentário explicativo
- Variável usada pelo seed script para criar o usuário admin inicial
- Valor default: `admin@portfolio.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)