### PR TITLE
chore(turbo): add globalEnv vars and .env to globalDependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["**/.env.*local"],
+  "globalDependencies": ["**/.env.*local", "**/.env"],
+  "globalEnv": [
+    "DATABASE_URL",
+    "DIRECT_URL",
+    "RESEND_API_KEY",
+    "CONTACT_EMAIL_TO",
+    "CONTACT_EMAIL_FROM",
+    "ADMIN_EMAIL"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Adiciona `globalEnv` com todas as variáveis de ambiente usadas no monorepo, garantindo que o cache do Turborepo seja invalidado quando elas mudam
- Adiciona `.env` ao `globalDependencies` (o projeto usa `.env` diretamente, não `.env.local`)

## Variáveis adicionadas

| Variável | Usado em |
|---|---|
| `DATABASE_URL` | `@repo/infra` — conexão Prisma (pooler) |
| `DIRECT_URL` | `@repo/infra` — conexão Prisma direta (seed, migrations) |
| `RESEND_API_KEY` | `@repo/infra` — serviço de email |
| `CONTACT_EMAIL_TO` | `@repo/infra` — destinatário do formulário de contato |
| `CONTACT_EMAIL_FROM` | `@repo/infra` — remetente do formulário de contato |
| `ADMIN_EMAIL` | `@repo/infra` — email do admin criado pelo seed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)