### PR TITLE
refactor(core): change default locale from pt-BR to en-US

### DIFF
--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -38,14 +38,15 @@ const PROFESSIONAL_VALUES: IProfessionalValueProps[] = [
 const EXPERIENCES: IExperienceProps[] = [
   {
     id: '1',
-    company: { 'pt-BR': 'WESF Serviços de TI' },
+    company: { 'en-US': 'WESF IT Services', 'pt-BR': 'WESF Serviços de TI' },
     employment_type: 'FREELANCE',
-    location: { 'pt-BR': 'São Paulo, Brasil' },
-    position: { 'pt-BR': 'Desenvolvedor Full-Stack' },
+    location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
+    position: { 'en-US': 'Full-Stack Developer', 'pt-BR': 'Desenvolvedor Full-Stack' },
     description: {
+      'en-US': 'Full-stack solution development for clients.',
       'pt-BR': 'Desenvolvimento de soluções full-stack para clientes.',
     },
-    logo: { url: 'https://placehold.co/48x48', alt: { 'pt-BR': 'WESF logo' } },
+    logo: { url: 'https://placehold.co/48x48', alt: { 'en-US': 'WESF logo', 'pt-BR': 'WESF logo' } },
     location_type: 'REMOTE',
     skills: [],
     start_at: '2021-01-01T00:00:00.000Z',
@@ -53,16 +54,17 @@ const EXPERIENCES: IExperienceProps[] = [
   },
   {
     id: '2',
-    company: { 'pt-BR': 'Galaxies' },
+    company: { 'en-US': 'Galaxies', 'pt-BR': 'Galaxies' },
     employment_type: 'PART_TIME',
-    location: { 'pt-BR': 'São Paulo, Brasil' },
-    position: { 'pt-BR': 'Desenvolvedor Front-end' },
+    location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
+    position: { 'en-US': 'Front-end Developer', 'pt-BR': 'Desenvolvedor Front-end' },
     description: {
+      'en-US': 'Interface development for SaaS platform.',
       'pt-BR': 'Desenvolvimento de interfaces para plataforma SaaS.',
     },
     logo: {
       url: 'https://placehold.co/48x48',
-      alt: { 'pt-BR': 'Galaxies logo' },
+      alt: { 'en-US': 'Galaxies logo', 'pt-BR': 'Galaxies logo' },
     },
     location_type: 'REMOTE',
     skills: [],
@@ -72,14 +74,14 @@ const EXPERIENCES: IExperienceProps[] = [
   {
     id: '3',
     company: {
-      'pt-BR':
-        'FDTE - Fundação para o Desenvolvimento Técnológico da Engenharia',
+      'en-US': 'FDTE - Foundation for the Technological Development of Engineering',
+      'pt-BR': 'FDTE - Fundação para o Desenvolvimento Técnológico da Engenharia',
     },
     employment_type: 'FULL_TIME',
-    location: { 'pt-BR': 'São Paulo, Brasil' },
-    position: { 'pt-BR': 'Desenvolvedor Front-end' },
-    description: { 'pt-BR': 'Desenvolvimento de sistemas para engenharia.' },
-    logo: { url: 'https://placehold.co/48x48', alt: { 'pt-BR': 'FDTE logo' } },
+    location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
+    position: { 'en-US': 'Front-end Developer', 'pt-BR': 'Desenvolvedor Front-end' },
+    description: { 'en-US': 'Systems development for engineering.', 'pt-BR': 'Desenvolvimento de sistemas para engenharia.' },
+    logo: { url: 'https://placehold.co/48x48', alt: { 'en-US': 'FDTE logo', 'pt-BR': 'FDTE logo' } },
     location_type: 'HYBRID',
     skills: [],
     start_at: '2023-01-01T00:00:00.000Z',

--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -41,12 +41,18 @@ const EXPERIENCES: IExperienceProps[] = [
     company: { 'en-US': 'WESF IT Services', 'pt-BR': 'WESF Serviços de TI' },
     employment_type: 'FREELANCE',
     location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
-    position: { 'en-US': 'Full-Stack Developer', 'pt-BR': 'Desenvolvedor Full-Stack' },
+    position: {
+      'en-US': 'Full-Stack Developer',
+      'pt-BR': 'Desenvolvedor Full-Stack',
+    },
     description: {
       'en-US': 'Full-stack solution development for clients.',
       'pt-BR': 'Desenvolvimento de soluções full-stack para clientes.',
     },
-    logo: { url: 'https://placehold.co/48x48', alt: { 'en-US': 'WESF logo', 'pt-BR': 'WESF logo' } },
+    logo: {
+      url: 'https://placehold.co/48x48',
+      alt: { 'en-US': 'WESF logo', 'pt-BR': 'WESF logo' },
+    },
     location_type: 'REMOTE',
     skills: [],
     start_at: '2021-01-01T00:00:00.000Z',
@@ -57,7 +63,10 @@ const EXPERIENCES: IExperienceProps[] = [
     company: { 'en-US': 'Galaxies', 'pt-BR': 'Galaxies' },
     employment_type: 'PART_TIME',
     location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
-    position: { 'en-US': 'Front-end Developer', 'pt-BR': 'Desenvolvedor Front-end' },
+    position: {
+      'en-US': 'Front-end Developer',
+      'pt-BR': 'Desenvolvedor Front-end',
+    },
     description: {
       'en-US': 'Interface development for SaaS platform.',
       'pt-BR': 'Desenvolvimento de interfaces para plataforma SaaS.',
@@ -74,14 +83,25 @@ const EXPERIENCES: IExperienceProps[] = [
   {
     id: '3',
     company: {
-      'en-US': 'FDTE - Foundation for the Technological Development of Engineering',
-      'pt-BR': 'FDTE - Fundação para o Desenvolvimento Técnológico da Engenharia',
+      'en-US':
+        'FDTE - Foundation for the Technological Development of Engineering',
+      'pt-BR':
+        'FDTE - Fundação para o Desenvolvimento Técnológico da Engenharia',
     },
     employment_type: 'FULL_TIME',
     location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
-    position: { 'en-US': 'Front-end Developer', 'pt-BR': 'Desenvolvedor Front-end' },
-    description: { 'en-US': 'Systems development for engineering.', 'pt-BR': 'Desenvolvimento de sistemas para engenharia.' },
-    logo: { url: 'https://placehold.co/48x48', alt: { 'en-US': 'FDTE logo', 'pt-BR': 'FDTE logo' } },
+    position: {
+      'en-US': 'Front-end Developer',
+      'pt-BR': 'Desenvolvedor Front-end',
+    },
+    description: {
+      'en-US': 'Systems development for engineering.',
+      'pt-BR': 'Desenvolvimento de sistemas para engenharia.',
+    },
+    logo: {
+      url: 'https://placehold.co/48x48',
+      alt: { 'en-US': 'FDTE logo', 'pt-BR': 'FDTE logo' },
+    },
     location_type: 'HYBRID',
     skills: [],
     start_at: '2023-01-01T00:00:00.000Z',

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -11,10 +11,11 @@ const PROJECTS: IProjectProps[] = [
     slug: 'fieldlink-enterprise',
     coverImage: {
       url: 'https://cdn.pixabay.com/photo/2024/10/16/06/03/ai-generated-9123876_1280.jpg',
-      alt: { 'pt-BR': 'Imagem do projeto Fieldlink Enterprise' },
+      alt: { 'en-US': 'Fieldlink Enterprise project image', 'pt-BR': 'Imagem do projeto Fieldlink Enterprise' },
     },
-    title: { 'pt-BR': 'Fieldlink Enterprise' },
+    title: { 'en-US': 'Fieldlink Enterprise', 'pt-BR': 'Fieldlink Enterprise' },
     caption: {
+      'en-US': 'Placeholder caption for Fieldlink Enterprise project.',
       'pt-BR':
         'Ministro determinou que a Caixa regularize o pagamento à conta certa antes de a PGR analisar a volta da rede social ao ar no Brasil.',
     },
@@ -54,10 +55,11 @@ const PROJECTS: IProjectProps[] = [
     slug: 'fieldlink-form-builder',
     coverImage: {
       url: 'https://cdn.pixabay.com/photo/2024/10/16/06/03/ai-generated-9123876_1280.jpg',
-      alt: { 'pt-BR': 'Imagem do projeto Fieldlink Form Builder' },
+      alt: { 'en-US': 'Fieldlink Form Builder project image', 'pt-BR': 'Imagem do projeto Fieldlink Form Builder' },
     },
-    title: { 'pt-BR': 'Fieldlink Form Builder' },
+    title: { 'en-US': 'Fieldlink Form Builder', 'pt-BR': 'Fieldlink Form Builder' },
     caption: {
+      'en-US': 'Placeholder caption for Fieldlink Form Builder project.',
       'pt-BR':
         'Ministro determinou que a Caixa regularize o pagamento à conta certa antes de a PGR analisar a volta da rede social ao ar no Brasil.',
     },
@@ -72,10 +74,11 @@ const PROJECTS: IProjectProps[] = [
     slug: 'fieldlink-rotas',
     coverImage: {
       url: 'https://cdn.pixabay.com/photo/2024/10/16/06/03/ai-generated-9123876_1280.jpg',
-      alt: { 'pt-BR': 'Imagem do projeto Fieldlink Rotas' },
+      alt: { 'en-US': 'Fieldlink Rotas project image', 'pt-BR': 'Imagem do projeto Fieldlink Rotas' },
     },
-    title: { 'pt-BR': 'Fieldlink Rotas' },
+    title: { 'en-US': 'Fieldlink Rotas', 'pt-BR': 'Fieldlink Rotas' },
     caption: {
+      'en-US': 'Placeholder caption for Fieldlink Rotas project.',
       'pt-BR':
         'Ministro determinou que a Caixa regularize o pagamento à conta certa antes de a PGR analisar a volta da rede social ao ar no Brasil.',
     },
@@ -90,10 +93,11 @@ const PROJECTS: IProjectProps[] = [
     slug: 'portfolio-platform',
     coverImage: {
       url: 'https://cdn.pixabay.com/photo/2024/10/16/06/03/ai-generated-9123876_1280.jpg',
-      alt: { 'pt-BR': 'Imagem do projeto Portfolio Platform' },
+      alt: { 'en-US': 'Portfolio Platform project image', 'pt-BR': 'Imagem do projeto Portfolio Platform' },
     },
-    title: { 'pt-BR': 'Portfolio Platform' },
+    title: { 'en-US': 'Portfolio Platform', 'pt-BR': 'Portfolio Platform' },
     caption: {
+      'en-US': 'Placeholder caption for Portfolio Platform project.',
       'pt-BR':
         'Ministro determinou que a Caixa regularize o pagamento à conta certa antes de a PGR analisar a volta da rede social ao ar no Brasil.',
     },

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -11,7 +11,10 @@ const PROJECTS: IProjectProps[] = [
     slug: 'fieldlink-enterprise',
     coverImage: {
       url: 'https://cdn.pixabay.com/photo/2024/10/16/06/03/ai-generated-9123876_1280.jpg',
-      alt: { 'en-US': 'Fieldlink Enterprise project image', 'pt-BR': 'Imagem do projeto Fieldlink Enterprise' },
+      alt: {
+        'en-US': 'Fieldlink Enterprise project image',
+        'pt-BR': 'Imagem do projeto Fieldlink Enterprise',
+      },
     },
     title: { 'en-US': 'Fieldlink Enterprise', 'pt-BR': 'Fieldlink Enterprise' },
     caption: {
@@ -55,9 +58,15 @@ const PROJECTS: IProjectProps[] = [
     slug: 'fieldlink-form-builder',
     coverImage: {
       url: 'https://cdn.pixabay.com/photo/2024/10/16/06/03/ai-generated-9123876_1280.jpg',
-      alt: { 'en-US': 'Fieldlink Form Builder project image', 'pt-BR': 'Imagem do projeto Fieldlink Form Builder' },
+      alt: {
+        'en-US': 'Fieldlink Form Builder project image',
+        'pt-BR': 'Imagem do projeto Fieldlink Form Builder',
+      },
     },
-    title: { 'en-US': 'Fieldlink Form Builder', 'pt-BR': 'Fieldlink Form Builder' },
+    title: {
+      'en-US': 'Fieldlink Form Builder',
+      'pt-BR': 'Fieldlink Form Builder',
+    },
     caption: {
       'en-US': 'Placeholder caption for Fieldlink Form Builder project.',
       'pt-BR':
@@ -74,7 +83,10 @@ const PROJECTS: IProjectProps[] = [
     slug: 'fieldlink-rotas',
     coverImage: {
       url: 'https://cdn.pixabay.com/photo/2024/10/16/06/03/ai-generated-9123876_1280.jpg',
-      alt: { 'en-US': 'Fieldlink Rotas project image', 'pt-BR': 'Imagem do projeto Fieldlink Rotas' },
+      alt: {
+        'en-US': 'Fieldlink Rotas project image',
+        'pt-BR': 'Imagem do projeto Fieldlink Rotas',
+      },
     },
     title: { 'en-US': 'Fieldlink Rotas', 'pt-BR': 'Fieldlink Rotas' },
     caption: {
@@ -93,7 +105,10 @@ const PROJECTS: IProjectProps[] = [
     slug: 'portfolio-platform',
     coverImage: {
       url: 'https://cdn.pixabay.com/photo/2024/10/16/06/03/ai-generated-9123876_1280.jpg',
-      alt: { 'en-US': 'Portfolio Platform project image', 'pt-BR': 'Imagem do projeto Portfolio Platform' },
+      alt: {
+        'en-US': 'Portfolio Platform project image',
+        'pt-BR': 'Imagem do projeto Portfolio Platform',
+      },
     },
     title: { 'en-US': 'Portfolio Platform', 'pt-BR': 'Portfolio Platform' },
     caption: {

--- a/packages/application/test/portfolio/GetExperiences.test.ts
+++ b/packages/application/test/portfolio/GetExperiences.test.ts
@@ -85,17 +85,17 @@ describe('GetExperiences', () => {
       const oldest = makeExperience({
         start_at: '2020-01-01T00:00:00.000Z',
         end_at: '2021-01-01T00:00:00.000Z',
-        company: { 'pt-BR': 'oldest' },
+        company: { 'en-US': 'oldest', 'pt-BR': 'oldest' },
       });
       const middle = makeExperience({
         start_at: '2021-06-01T00:00:00.000Z',
         end_at: '2022-06-01T00:00:00.000Z',
-        company: { 'pt-BR': 'middle' },
+        company: { 'en-US': 'middle', 'pt-BR': 'middle' },
       });
       const newest = makeExperience({
         start_at: '2023-01-01T00:00:00.000Z',
         end_at: '2024-01-01T00:00:00.000Z',
-        company: { 'pt-BR': 'newest' },
+        company: { 'en-US': 'newest', 'pt-BR': 'newest' },
       });
 
       const repo = makeRepository({

--- a/packages/core/src/shared/i18n/Locale.ts
+++ b/packages/core/src/shared/i18n/Locale.ts
@@ -5,7 +5,7 @@ export type Locale = 'en-US' | 'es' | 'pt-BR';
 
 export const LOCALES: readonly Locale[] = ['en-US', 'pt-BR', 'es'];
 
-export const DEFAULT_LOCALE: Locale = 'pt-BR';
+export const DEFAULT_LOCALE: Locale = 'en-US';
 
 export function isLocale(value: string): value is Locale {
   return LOCALES.includes(value as Locale);

--- a/packages/core/src/shared/i18n/LocalizedText.ts
+++ b/packages/core/src/shared/i18n/LocalizedText.ts
@@ -6,15 +6,15 @@ import { ValidationError } from '../errors';
 import type { Locale } from './Locale';
 
 export type LocalizedTextValue = Readonly<{
+  'en-US': string;
+  'pt-BR'?: string;
   es?: string;
-  'en-US'?: string;
-  'pt-BR': string;
 }>;
 
 export interface ILocalizedTextInput {
+  'en-US': string;
+  'pt-BR'?: string;
   es?: string;
-  'en-US'?: string;
-  'pt-BR': string;
 }
 
 function trimOrUndefined(s: string | undefined): string | undefined {
@@ -24,13 +24,13 @@ function trimOrUndefined(s: string | undefined): string | undefined {
 }
 
 function normalizeInput(input: ILocalizedTextInput): LocalizedTextValue {
-  const ptBR = input['pt-BR']?.trim() ?? '';
-  const enUS = trimOrUndefined(input['en-US']);
+  const enUS = input['en-US']?.trim() ?? '';
+  const ptBR = trimOrUndefined(input['pt-BR']);
   const es = trimOrUndefined(input.es);
 
   return Object.freeze({
-    'pt-BR': ptBR,
-    ...(enUS !== undefined && { 'en-US': enUS }),
+    'en-US': enUS,
+    ...(ptBR !== undefined && { 'pt-BR': ptBR }),
     ...(es !== undefined && { es }),
   });
 }
@@ -45,8 +45,8 @@ export class LocalizedText extends ValueObject<LocalizedTextValue> {
   static create(
     input: ILocalizedTextInput,
   ): Either<ValidationError, LocalizedText> {
-    const { error, isValid } = Validator.of(input['pt-BR']?.trim() ?? '')
-      .notEmpty('pt-BR is required and must be non-empty after trim.')
+    const { error, isValid } = Validator.of(input['en-US']?.trim() ?? '')
+      .notEmpty('en-US is required and must be non-empty after trim.')
       .validate();
 
     if (!isValid && error)
@@ -61,7 +61,7 @@ export class LocalizedText extends ValueObject<LocalizedTextValue> {
    * Returns text for the requested locale, with optional fallback.
    * - Uses `locale` if available and non-empty.
    * - Else uses `fallback` if provided and available.
-   * - Else uses pt-BR.
+   * - Else uses en-US.
    */
   get(locale: Locale, fallback?: Locale): string {
     const v = this.value;
@@ -71,7 +71,7 @@ export class LocalizedText extends ValueObject<LocalizedTextValue> {
       const forFallback = this._getLocaleValue(v, fallback);
       if (forFallback !== undefined && forFallback !== '') return forFallback;
     }
-    return v['pt-BR'];
+    return v['en-US'];
   }
 
   private _getLocaleValue(
@@ -79,10 +79,10 @@ export class LocalizedText extends ValueObject<LocalizedTextValue> {
     locale: Locale,
   ): string | undefined {
     switch (locale) {
-      case 'pt-BR':
-        return v['pt-BR'];
       case 'en-US':
         return v['en-US'];
+      case 'pt-BR':
+        return v['pt-BR'];
       case 'es':
         return v.es;
       default:

--- a/packages/core/test/experience/Experience.test.ts
+++ b/packages/core/test/experience/Experience.test.ts
@@ -20,9 +20,9 @@ describe('Experience', () => {
 
     it('should create experience with all fields as VOs', () => {
       const company = { 'pt-BR': 'Fieldlink', 'en-US': 'Fieldlink' };
-      const position = { 'pt-BR': 'Engenheiro de Software' };
-      const location = { 'pt-BR': 'São Paulo, Brasil' };
-      const description = { 'pt-BR': 'Desenvolvimento de sistemas.' };
+      const position = { 'en-US': 'Software Engineer', 'pt-BR': 'Engenheiro de Software' };
+      const location = { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' };
+      const description = { 'en-US': 'Systems development.', 'pt-BR': 'Desenvolvimento de sistemas.' };
       const startAt = '2022-01-01T00:00:00.000Z';
       const endAt = '2022-06-01T00:00:00.000Z';
 
@@ -57,6 +57,7 @@ describe('Experience', () => {
       const result = Experience.create(
         ExperienceBuilder.build()
           .withLogo('https://example.com/logo.png', {
+            'en-US': 'Company logo',
             'pt-BR': 'Logo da empresa',
           })
           .withSkills(skillIds)

--- a/packages/core/test/helpers/builders/ExperienceBuilder.ts
+++ b/packages/core/test/helpers/builders/ExperienceBuilder.ts
@@ -15,10 +15,10 @@ export class ExperienceBuilder extends EntityBuilder<IExperienceProps> {
 
   static build(): ExperienceBuilder {
     return new ExperienceBuilder({
-      company: { 'pt-BR': 'Portfolio Inc' },
-      position: { 'pt-BR': 'Software Engineer' },
-      location: { 'pt-BR': 'São Paulo, Brazil' },
-      description: { 'pt-BR': Data.text.description() },
+      company: { 'en-US': 'Portfolio Inc', 'pt-BR': 'Portfolio Inc' },
+      position: { 'en-US': 'Software Engineer', 'pt-BR': 'Software Engineer' },
+      location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brazil' },
+      description: { 'en-US': Data.text.description(), 'pt-BR': Data.text.description() },
       logo: { url: Data.image.url(), alt: Data.image.alt() },
       employment_type: Data.employment.valid(),
       location_type: Data.location.valid(),

--- a/packages/core/test/helpers/builders/ProfileBuilder.ts
+++ b/packages/core/test/helpers/builders/ProfileBuilder.ts
@@ -11,11 +11,11 @@ export class ProfileBuilder extends EntityBuilder<IProfileProps> {
   static build(): ProfileBuilder {
     return new ProfileBuilder({
       name: 'Wallace',
-      headline: { 'pt-BR': 'Engenheiro de Software' },
-      bio: { 'pt-BR': 'Desenvolvedor apaixonado por DDD e Clean Architecture.' },
+      headline: { 'en-US': 'Software Engineer', 'pt-BR': 'Engenheiro de Software' },
+      bio: { 'en-US': 'Developer passionate about DDD and Clean Architecture.', 'pt-BR': 'Desenvolvedor apaixonado por DDD e Clean Architecture.' },
       photo: { url: Data.image.url(), alt: Data.image.alt() },
       stats: [
-        { label: { 'pt-BR': 'Anos de experiência' }, value: '5+', icon: 'briefcase' },
+        { label: { 'en-US': 'Years of experience', 'pt-BR': 'Anos de experiência' }, value: '5+', icon: 'briefcase' },
       ],
       featuredProjectSlugs: ['my-project', 'portfolio-app'],
     });

--- a/packages/core/test/helpers/builders/ProjectBuilder.ts
+++ b/packages/core/test/helpers/builders/ProjectBuilder.ts
@@ -20,8 +20,8 @@ export class ProjectBuilder extends EntityBuilder<IProjectProps> {
     return new ProjectBuilder({
       slug: Data.slug.valid(),
       coverImage: { url: Data.image.url(), alt: Data.image.alt() },
-      title: { 'pt-BR': Data.text.title() },
-      caption: { 'pt-BR': Data.text.caption() },
+      title: { 'en-US': Data.text.title(), 'pt-BR': Data.text.title() },
+      caption: { 'en-US': Data.text.caption(), 'pt-BR': Data.text.caption() },
       content: Data.text.text(),
       skills: SkillBuilder.listToProps(2),
       period: { start: '2024-01-01' },

--- a/packages/core/test/helpers/generators/ImageData.ts
+++ b/packages/core/test/helpers/generators/ImageData.ts
@@ -6,7 +6,7 @@ export class ImageData {
   }
 
   static alt(): ILocalizedTextInput {
-    return { 'pt-BR': 'Imagem de capa do projeto' };
+    return { 'en-US': 'Project cover image', 'pt-BR': 'Imagem de capa do projeto' };
   }
 
   static altMultiLocale(): ILocalizedTextInput {

--- a/packages/core/test/profile/Profile.test.ts
+++ b/packages/core/test/profile/Profile.test.ts
@@ -9,15 +9,15 @@ import { ProfileStat } from '../../src/portfolio/entities/profile/model/ProfileS
 import { Data } from '../helpers/generators';
 
 const validStat = {
-  label: { 'pt-BR': 'Anos de experiência' },
+  label: { 'en-US': 'Years of experience', 'pt-BR': 'Anos de experiência' },
   value: '5+',
   icon: 'briefcase',
 };
 
 const validProps = {
   name: 'Wallace',
-  headline: { 'pt-BR': 'Engenheiro de Software' },
-  bio: { 'pt-BR': 'Desenvolvedor apaixonado por DDD e Clean Architecture.' },
+  headline: { 'en-US': 'Software Engineer', 'pt-BR': 'Engenheiro de Software' },
+  bio: { 'en-US': 'Developer passionate about DDD and Clean Architecture.', 'pt-BR': 'Desenvolvedor apaixonado por DDD e Clean Architecture.' },
   photo: {
     url: Data.image.url(),
     alt: Data.image.alt(),
@@ -115,10 +115,10 @@ describe('Profile', () => {
       expect((result.value as ValidationError).code).toBe(Name.ERROR_CODE);
     });
 
-    it('should return Left when headline pt-BR is empty', () => {
+    it('should return Left when headline en-US is empty', () => {
       const result = Profile.create({
         ...validProps,
-        headline: { 'pt-BR': '' },
+        headline: { 'en-US': '' },
       });
 
       expect(result.isLeft()).toBe(true);
@@ -127,10 +127,10 @@ describe('Profile', () => {
       );
     });
 
-    it('should return Left when bio pt-BR is empty', () => {
+    it('should return Left when bio en-US is empty', () => {
       const result = Profile.create({
         ...validProps,
-        bio: { 'pt-BR': '' },
+        bio: { 'en-US': '' },
       });
 
       expect(result.isLeft()).toBe(true);

--- a/packages/core/test/profile/ProfileStat.test.ts
+++ b/packages/core/test/profile/ProfileStat.test.ts
@@ -2,7 +2,7 @@ import { LocalizedText, Text, ValidationError } from '../../src';
 import { ProfileStat } from '../../src/portfolio/entities/profile/model/ProfileStat';
 
 const validProps = {
-  label: { 'pt-BR': 'Anos de experiência' },
+  label: { 'en-US': 'Years of experience', 'pt-BR': 'Anos de experiência' },
   value: '5+',
   icon: 'briefcase',
 };
@@ -30,10 +30,10 @@ describe('ProfileStat', () => {
   });
 
   describe('when created from invalid props', () => {
-    it('should return Left when label pt-BR is empty', () => {
+    it('should return Left when label en-US is empty', () => {
       const result = ProfileStat.create({
         ...validProps,
-        label: { 'pt-BR': '' },
+        label: { 'en-US': '' },
       });
 
       expect(result.isLeft()).toBe(true);

--- a/packages/core/test/project/Project.test.ts
+++ b/packages/core/test/project/Project.test.ts
@@ -19,7 +19,7 @@ describe('Project', () => {
 
     it('should create project with all required fields as VOs', () => {
       const title = { 'pt-BR': 'Meu Projeto', 'en-US': 'My Project' };
-      const caption = { 'pt-BR': 'Uma legenda para o projeto.' };
+      const caption = { 'en-US': 'A caption for the project.', 'pt-BR': 'Uma legenda para o projeto.' };
       const content = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
       const skills = SkillBuilder.listToProps(2);
 
@@ -47,7 +47,7 @@ describe('Project', () => {
           .withSlug('fieldlink-form-builder')
           .withCoverImage({
             url: 'https://example.com/cover.png',
-            alt: { 'pt-BR': 'Imagem de capa' },
+            alt: { 'en-US': 'Cover image', 'pt-BR': 'Imagem de capa' },
           })
           .toProps(),
       );
@@ -80,10 +80,10 @@ describe('Project', () => {
     it('should create project with optional fields', () => {
       const result = Project.create(
         ProjectBuilder.build()
-          .withTheme({ 'pt-BR': 'Design System' })
-          .withSummary({ 'pt-BR': 'Resumo do projeto.' })
-          .withObjectives({ 'pt-BR': 'Objetivo do projeto.' })
-          .withRole({ 'pt-BR': 'Tech Lead' })
+          .withTheme({ 'en-US': 'Design System', 'pt-BR': 'Design System' })
+          .withSummary({ 'en-US': 'Project summary.', 'pt-BR': 'Resumo do projeto.' })
+          .withObjectives({ 'en-US': 'Project objective.', 'pt-BR': 'Objetivo do projeto.' })
+          .withRole({ 'en-US': 'Tech Lead', 'pt-BR': 'Tech Lead' })
           .withTeam('Squad Alpha')
           .toProps(),
       );

--- a/packages/core/test/shared/i18n/Locale.test.ts
+++ b/packages/core/test/shared/i18n/Locale.test.ts
@@ -1,8 +1,8 @@
 import { DEFAULT_LOCALE, isLocale, LOCALES } from '../../../src';
 
 describe('Locale', () => {
-  it('should export DEFAULT_LOCALE as "pt-BR"', () => {
-    expect(DEFAULT_LOCALE).toBe('pt-BR');
+  it('should export DEFAULT_LOCALE as "en-US"', () => {
+    expect(DEFAULT_LOCALE).toBe('en-US');
   });
 
   it('should export LOCALES as en-US, pt-BR, es', () => {

--- a/packages/core/test/shared/i18n/LocalizedText.test.ts
+++ b/packages/core/test/shared/i18n/LocalizedText.test.ts
@@ -25,21 +25,21 @@ describe('LocalizedText', () => {
       expect(result.value.get('es', 'pt-BR')).toBe('Olá');
     });
 
-    it('defaults to pt-BR when requested locale is missing and no fallback', () => {
+    it('defaults to en-US when requested locale is missing and no fallback', () => {
       const result = LocalizedText.create({ 'pt-BR': 'Olá', 'en-US': 'Hello' });
 
       expect(result.isRight()).toBe(true);
       if (!result.isRight()) return;
-      expect(result.value.get('es')).toBe('Olá');
+      expect(result.value.get('es')).toBe('Hello');
     });
 
-    it('defaults to pt-BR when both requested locale and fallback are missing', () => {
-      const result = LocalizedText.create({ 'pt-BR': 'Só PT-BR' });
+    it('defaults to en-US when both requested locale and fallback are missing', () => {
+      const result = LocalizedText.create({ 'en-US': 'Only EN-US' });
 
       expect(result.isRight()).toBe(true);
       if (!result.isRight()) return;
-      expect(result.value.get('en-US')).toBe('Só PT-BR');
-      expect(result.value.get('en-US', 'es')).toBe('Só PT-BR');
+      expect(result.value.get('pt-BR')).toBe('Only EN-US');
+      expect(result.value.get('pt-BR', 'es')).toBe('Only EN-US');
     });
   });
 
@@ -60,39 +60,39 @@ describe('LocalizedText', () => {
 
     it('treats empty strings as missing', () => {
       const result = LocalizedText.create({
-        'pt-BR': 'Olá',
-        'en-US': '',
+        'en-US': 'Hello',
+        'pt-BR': '',
         es: '   ',
       });
 
       expect(result.isRight()).toBe(true);
       if (!result.isRight()) return;
-      expect(result.value.get('en-US')).toBe('Olá');
-      expect(result.value.get('es')).toBe('Olá');
+      expect(result.value.get('pt-BR')).toBe('Hello');
+      expect(result.value.get('es')).toBe('Hello');
     });
   });
 
   describe('validation', () => {
-    it('should return Left when pt-BR is missing', () => {
-      const result = LocalizedText.create({ 'pt-BR': undefined as unknown as string });
+    it('should return Left when en-US is missing', () => {
+      const result = LocalizedText.create({ 'en-US': undefined as unknown as string });
 
       expect(result.isLeft()).toBe(true);
       expect(result.value).toBeInstanceOf(ValidationError);
       expect((result.value as ValidationError).code).toBe(LocalizedText.ERROR_CODE);
       expect((result.value as ValidationError).message).toBe(
-        'pt-BR is required and must be non-empty after trim.',
+        'en-US is required and must be non-empty after trim.',
       );
     });
 
-    it('should return Left for empty pt-BR string', () => {
-      const result = LocalizedText.create({ 'pt-BR': '' });
+    it('should return Left for empty en-US string', () => {
+      const result = LocalizedText.create({ 'en-US': '' });
 
       expect(result.isLeft()).toBe(true);
       expect((result.value as ValidationError).code).toBe(LocalizedText.ERROR_CODE);
     });
 
-    it('should return Left for whitespace-only pt-BR', () => {
-      const result = LocalizedText.create({ 'pt-BR': '   ' });
+    it('should return Left for whitespace-only en-US', () => {
+      const result = LocalizedText.create({ 'en-US': '   ' });
 
       expect(result.isLeft()).toBe(true);
       expect((result.value as ValidationError).code).toBe(LocalizedText.ERROR_CODE);
@@ -123,8 +123,8 @@ describe('LocalizedText', () => {
     });
 
     it('should not be equal when two LocalizedText instances have different content', () => {
-      const r1 = LocalizedText.create({ 'pt-BR': 'Olá' });
-      const r2 = LocalizedText.create({ 'pt-BR': 'Tchau' });
+      const r1 = LocalizedText.create({ 'en-US': 'Hello', 'pt-BR': 'Olá' });
+      const r2 = LocalizedText.create({ 'en-US': 'Goodbye', 'pt-BR': 'Tchau' });
 
       expect(r1.isRight() && r2.isRight()).toBe(true);
       if (!r1.isRight() || !r2.isRight()) return;

--- a/packages/core/test/shared/vo/Image.test.ts
+++ b/packages/core/test/shared/vo/Image.test.ts
@@ -1,7 +1,7 @@
 import { Image, ValidationError } from '../../../src';
 
 const validUrl = 'https://example.com/image.png';
-const validAlt = { 'pt-BR': 'Imagem de capa do projeto' };
+const validAlt = { 'en-US': 'Project cover image', 'pt-BR': 'Imagem de capa do projeto' };
 
 describe('Image', () => {
   describe('when created from valid value', () => {
@@ -58,8 +58,8 @@ describe('Image', () => {
       );
     });
 
-    it('should return Left with INVALID_LOCALIZED_TEXT when pt-BR alt is missing', () => {
-      const result = Image.create(validUrl, { 'pt-BR': '' });
+    it('should return Left with INVALID_LOCALIZED_TEXT when en-US alt is missing', () => {
+      const result = Image.create(validUrl, { 'en-US': '' });
 
       expect(result.isLeft()).toBe(true);
       expect(result.value).toBeInstanceOf(ValidationError);


### PR DESCRIPTION
## Summary

- Makes `en-US` the required locale in `LocalizedText` and `ILocalizedTextInput` (was `pt-BR`)
- Changes `DEFAULT_LOCALE` constant to `'en-US'`
- Updates fallback in `LocalizedText.get()` to return `en-US` value
- Updates all test builders and mock data in the web layer to include the required `en-US` field

## Test plan

- [x] All 233 core tests pass
- [x] All 63 application tests pass
- [x] TypeScript types clean across all packages and web app

🤖 Generated with [Claude Code](https://claude.com/claude-code)