### PR TITLE
refactor(project): remove team field from Project aggregate

### DIFF
--- a/packages/application/src/portfolio/dtos/ProjectDetailDTO.ts
+++ b/packages/application/src/portfolio/dtos/ProjectDetailDTO.ts
@@ -5,7 +5,6 @@ export type ProjectDetailDTO = ProjectSummaryDTO & {
   summary?: string;
   objectives?: string;
   role?: string;
-  team?: string;
   period: { startAt: string; endAt?: string };
   relatedProjects: ProjectSummaryDTO[];
 };

--- a/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
+++ b/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
@@ -68,7 +68,6 @@ export class GetProjectBySlug extends UseCase<
       summary: project.summary?.get(locale),
       objectives: project.objectives?.get(locale),
       role: project.role?.get(locale),
-      team: project.team,
       period: {
         startAt: project.period.startAt.value,
         endAt: project.period.endAt?.value,

--- a/packages/application/test/portfolio/GetProjectBySlug.test.ts
+++ b/packages/application/test/portfolio/GetProjectBySlug.test.ts
@@ -74,7 +74,6 @@ describe('GetProjectBySlug', () => {
         summary: { 'pt-BR': 'Resumo PT', 'en-US': 'Summary EN' },
         objectives: { 'pt-BR': 'Objetivos PT', 'en-US': 'Objectives EN' },
         role: { 'pt-BR': 'Papel PT', 'en-US': 'Role EN' },
-        team: 'Team A',
         period: { start: '2023-01-01T00:00:00.000Z', end: '2023-12-31T00:00:00.000Z' },
       });
       const repo = makeRepository({
@@ -98,7 +97,6 @@ describe('GetProjectBySlug', () => {
       expect(dto.summary).toBe('Resumo PT');
       expect(dto.objectives).toBe('Objetivos PT');
       expect(dto.role).toBe('Papel PT');
-      expect(dto.team).toBe('Team A');
       expect(dto.period.startAt).toBe('2023-01-01T00:00:00.000Z');
       expect(dto.period.endAt).toBe('2023-12-31T00:00:00.000Z');
       expect(dto.relatedProjects).toEqual([]);
@@ -121,7 +119,6 @@ describe('GetProjectBySlug', () => {
       expect(dto.summary).toBeUndefined();
       expect(dto.objectives).toBeUndefined();
       expect(dto.role).toBeUndefined();
-      expect(dto.team).toBeUndefined();
       expect(dto.period.endAt).toBeUndefined();
     });
 

--- a/packages/core/src/portfolio/entities/project/model/Project.ts
+++ b/packages/core/src/portfolio/entities/project/model/Project.ts
@@ -39,7 +39,6 @@ export interface IProjectProps extends IEntityProps {
   summary?: ILocalizedTextInput;
   objectives?: ILocalizedTextInput;
   role?: ILocalizedTextInput;
-  team?: string;
   period: IProjectPeriod;
   featured: boolean;
   status: ProjectStatus;
@@ -59,7 +58,6 @@ export class Project extends AggregateRoot<Project, IProjectProps> {
   public readonly summary: LocalizedText | undefined;
   public readonly objectives: LocalizedText | undefined;
   public readonly role: LocalizedText | undefined;
-  public readonly team: string | undefined;
   public readonly period: DateRange;
   public readonly featured: boolean;
   public readonly status: ProjectStatus;
@@ -91,7 +89,6 @@ export class Project extends AggregateRoot<Project, IProjectProps> {
     this.summary = summary;
     this.objectives = objectives;
     this.role = role;
-    this.team = props.team;
     this.period = period;
     this.featured = props.featured;
     this.status = props.status;

--- a/packages/core/test/helpers/builders/ProjectBuilder.ts
+++ b/packages/core/test/helpers/builders/ProjectBuilder.ts
@@ -91,11 +91,6 @@ export class ProjectBuilder extends EntityBuilder<IProjectProps> {
     return this;
   }
 
-  public withTeam(team: string): ProjectBuilder {
-    this._props.team = team;
-    return this;
-  }
-
   public withPeriod(period: IProjectPeriod): ProjectBuilder {
     this._props.period = period;
     return this;

--- a/packages/core/test/project/Project.test.ts
+++ b/packages/core/test/project/Project.test.ts
@@ -84,7 +84,6 @@ describe('Project', () => {
           .withSummary({ 'en-US': 'Project summary.', 'pt-BR': 'Resumo do projeto.' })
           .withObjectives({ 'en-US': 'Project objective.', 'pt-BR': 'Objetivo do projeto.' })
           .withRole({ 'en-US': 'Tech Lead', 'pt-BR': 'Tech Lead' })
-          .withTeam('Squad Alpha')
           .toProps(),
       );
 
@@ -96,7 +95,6 @@ describe('Project', () => {
         'Objetivo do projeto.',
       );
       expect(result.value.role?.get('pt-BR')).toBe('Tech Lead');
-      expect(result.value.team).toBe('Squad Alpha');
     });
 
     it('should create project with related projects', () => {
@@ -131,7 +129,6 @@ describe('Project', () => {
       expect(result.value.summary).toBeUndefined();
       expect(result.value.objectives).toBeUndefined();
       expect(result.value.role).toBeUndefined();
-      expect(result.value.team).toBeUndefined();
     });
   });
 

--- a/packages/infra/prisma/migrations/20260331233531_drop_project_team_column/migration.sql
+++ b/packages/infra/prisma/migrations/20260331233531_drop_project_team_column/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `team` on the `Project` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Project" DROP COLUMN "team";

--- a/packages/infra/prisma/schema.prisma
+++ b/packages/infra/prisma/schema.prisma
@@ -85,7 +85,6 @@ model Project {
   summary             Json?
   objectives          Json?
   role                Json?
-  team                String?
   periodStart         DateTime
   periodEnd           DateTime?
   featured            Boolean       @default(false)

--- a/packages/infra/src/repositories/project/ProjectMapper.ts
+++ b/packages/infra/src/repositories/project/ProjectMapper.ts
@@ -29,7 +29,6 @@ export class ProjectMapper {
       summary: raw.summary ? asLocalized(raw.summary) : undefined,
       objectives: raw.objectives ? asLocalized(raw.objectives) : undefined,
       role: raw.role ? asLocalized(raw.role) : undefined,
-      team: raw.team ?? undefined,
       period: {
         start: raw.periodStart.toISOString(),
         end: raw.periodEnd?.toISOString(),
@@ -74,7 +73,6 @@ export class ProjectMapper {
       summary: project.summary?.value ?? Prisma.JsonNull,
       objectives: project.objectives?.value ?? Prisma.JsonNull,
       role: project.role?.value ?? Prisma.JsonNull,
-      team: project.team ?? null,
       periodStart: new Date(project.period.startAt.value),
       periodEnd: project.period.endAt
         ? new Date(project.period.endAt.value)

--- a/packages/infra/test/factories/prisma-project.factory.ts
+++ b/packages/infra/test/factories/prisma-project.factory.ts
@@ -25,7 +25,6 @@ export type PrismaProjectWithSkills = {
   summary: Prisma.JsonValue | null;
   objectives: Prisma.JsonValue | null;
   role: Prisma.JsonValue | null;
-  team: string | null;
   periodStart: Date;
   periodEnd: Date | null;
   featured: boolean;
@@ -66,7 +65,6 @@ export function buildPrismaProject(overrides?: Partial<PrismaProjectWithSkills>)
     summary: null,
     objectives: null,
     role: null,
-    team: null,
     periodStart: new Date('2024-01-01T00:00:00.000Z'),
     periodEnd: null,
     featured: false,

--- a/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
+++ b/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
@@ -40,7 +40,6 @@ async function seedProject(overrides?: Partial<ReturnType<typeof buildPrismaProj
       summary: raw.summary ?? undefined,
       objectives: raw.objectives ?? undefined,
       role: raw.role ?? undefined,
-      team: raw.team,
       periodStart: raw.periodStart,
       periodEnd: raw.periodEnd,
       featured: raw.featured,

--- a/packages/infra/test/repositories/project/ProjectMapper.test.ts
+++ b/packages/infra/test/repositories/project/ProjectMapper.test.ts
@@ -32,7 +32,6 @@ describe('ProjectMapper', () => {
         summary: { 'pt-BR': 'Resumo' },
         objectives: { 'pt-BR': 'Objetivos' },
         role: { 'pt-BR': 'Desenvolvedor' },
-        team: 'Time A',
         periodEnd: new Date('2024-12-31T00:00:00.000Z'),
         relatedProjectSlugs: ['other-project'],
       });
@@ -43,7 +42,6 @@ describe('ProjectMapper', () => {
       expect(project.summary?.value).toEqual({ 'pt-BR': 'Resumo' });
       expect(project.objectives?.value).toEqual({ 'pt-BR': 'Objetivos' });
       expect(project.role?.value).toEqual({ 'pt-BR': 'Desenvolvedor' });
-      expect(project.team).toBe('Time A');
       expect(project.period.endAt?.value).toBe('2024-12-31T00:00:00.000Z');
       expect(project.relatedProjects).toHaveLength(1);
       expect(project.relatedProjects[0]!.value).toBe('other-project');


### PR DESCRIPTION
## Summary

- Remove `team` field from `Project` aggregate — field had no domain meaning or business rules
- Drop `team` column from Prisma schema and create migration `drop_project_team_column`
- Remove all references across core, application, and infra layers (mapper, DTOs, use cases, tests, builders)

## Test plan

- [x] All 233 core tests pass
- [x] All 63 application tests pass
- [x] TypeScript types clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)