### PR TITLE
feat(core): introduce IRepository<T> generic base interface in Shared Kernel

### DIFF
--- a/packages/core/src/portfolio/entities/experience/repositories/IExperienceRepository.ts
+++ b/packages/core/src/portfolio/entities/experience/repositories/IExperienceRepository.ts
@@ -1,9 +1,4 @@
-import { Id } from '../../../../shared';
+import { IRepository } from '../../../../shared/base/IRepository';
 import { Experience } from '../model/Experience';
 
-export interface IExperienceRepository {
-  findAll(): Promise<Experience[]>;
-  findById(id: Id): Promise<Experience | null>;
-  save(experience: Experience): Promise<void>;
-  delete(id: Id): Promise<void>;
-}
+export interface IExperienceRepository extends IRepository<Experience> {}

--- a/packages/core/src/portfolio/entities/project/repositories/IProjectRepository.ts
+++ b/packages/core/src/portfolio/entities/project/repositories/IProjectRepository.ts
@@ -1,13 +1,11 @@
-import { Id, Slug } from '../../../../shared';
+import { Slug } from '../../../../shared';
+import { Id } from '../../../../shared';
+import { IRepository } from '../../../../shared/base/IRepository';
 import { Project } from '../model/Project';
 
-export interface IProjectRepository {
-  findAll(): Promise<Project[]>;
+export interface IProjectRepository extends IRepository<Project> {
   findPublished(): Promise<Project[]>;
   findFeatured(): Promise<Project[]>;
-  findById(id: Id): Promise<Project | null>;
   findBySlug(slug: Slug): Promise<Project | null>;
   findRelated(id: Id, limit?: number): Promise<Project[]>;
-  save(project: Project): Promise<void>;
-  delete(id: Id): Promise<void>;
 }

--- a/packages/core/src/portfolio/entities/project/repositories/IProjectRepository.ts
+++ b/packages/core/src/portfolio/entities/project/repositories/IProjectRepository.ts
@@ -1,5 +1,4 @@
-import { Slug } from '../../../../shared';
-import { Id } from '../../../../shared';
+import { Slug, Id } from '../../../../shared';
 import { IRepository } from '../../../../shared/base/IRepository';
 import { Project } from '../model/Project';
 

--- a/packages/core/src/portfolio/entities/skill/repositories/ISkillRepository.ts
+++ b/packages/core/src/portfolio/entities/skill/repositories/ISkillRepository.ts
@@ -1,9 +1,4 @@
-import { Id } from '../../../../shared';
+import { IRepository } from '../../../../shared/base/IRepository';
 import { Skill } from '../model/Skill';
 
-export interface ISkillRepository {
-  findAll(): Promise<Skill[]>;
-  findById(id: Id): Promise<Skill | null>;
-  save(skill: Skill): Promise<void>;
-  delete(id: Id): Promise<void>;
-}
+export interface ISkillRepository extends IRepository<Skill> {}

--- a/packages/core/src/shared/base/IRepository.ts
+++ b/packages/core/src/shared/base/IRepository.ts
@@ -1,0 +1,13 @@
+import { Id } from '../vo/Id';
+
+/**
+ * Generic base repository interface for entity persistence operations.
+ *
+ * @template T - The domain entity type managed by this repository
+ */
+export interface IRepository<T> {
+  findAll(): Promise<T[]>;
+  findById(id: Id): Promise<T | null>;
+  save(entity: T): Promise<void>;
+  delete(id: Id): Promise<void>;
+}

--- a/packages/core/src/shared/base/index.ts
+++ b/packages/core/src/shared/base/index.ts
@@ -1,3 +1,4 @@
 export * from './AggregateRoot';
 export * from './Entity';
+export * from './IRepository';
 export * from './ValueObject';


### PR DESCRIPTION
Closes #402

## Summary

- Cria `IRepository<T>` em `packages/core/src/shared/base/IRepository.ts` com os métodos `findAll`, `findById`, `save` e `delete`
- `IExperienceRepository` e `ISkillRepository` passam a estender `IRepository<T>` — eliminando duplicação
- `IProjectRepository` estende `IRepository<Project>` e mantém os métodos domain-specific: `findPublished`, `findFeatured`, `findBySlug`, `findRelated`
- `IProfileRepository` permanece independente (padrão singleton: sem `findAll`, `findById` ou `delete`)
- Exportado via `packages/core/src/shared/base/index.ts`

## Test plan

- [x] 233 testes core passando sem alterações
- [x] Types clean em todos os pacotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)