### PR TITLE
docs: sync architecture with REST boundary and Identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Always prioritize clean, testable, extensible code.
 apps/
   web/          → Public portfolio (Next.js 14+ App Router)
   blog/         → Blog (future, post-MVP)
-  api/          → Backend (Next.js API Routes, future)
+  api/          → Optional dedicated HTTP app if routes outgrow apps/web/app/api
 
 packages/
   core/         → Domain + Shared Kernel (entities, VOs, repository interfaces)
@@ -44,6 +44,7 @@ All project documentation lives in `docs/` with a numbered structure.
 | Testing strategy | [08-TESTING](./docs/08-TESTING.md) |
 | Code templates (Either, VO, Entity) | [09-PATTERNS](./docs/09-PATTERNS.md) |
 | Domain and architectural terms | [10-GLOSSARY](./docs/10-GLOSSARY.md) |
+| Identity (auth, REST boundary) | [11-IDENTITY](./docs/11-IDENTITY.md) |
 
 ---
 
@@ -56,7 +57,7 @@ core ← application ← infra ← web / api
 - **`packages/core`**: zero framework dependencies (no React, Next.js, Prisma, Axios)
 - **`packages/application`**: depends only on `core`; defines port interfaces
 - **`packages/infra`**: implements ports; knows `core` and `application`
-- **`apps/web` / `apps/api`**: presentation; calls application layer only
+- **`apps/web` / `apps/api`**: **HTTP route handlers** compose infra + application (use cases). **Pages and React code consume only the REST API** — they do not import `@repo/application`. See [02-ARCHITECTURE](./docs/02-ARCHITECTURE.md) and [05-API-CONTRACTS](./docs/05-API-CONTRACTS.md).
 
 See [02-ARCHITECTURE](./docs/02-ARCHITECTURE.md) for full layer rules and ESLint enforcement.
 
@@ -212,13 +213,14 @@ interface IProjectRepository {
 
 - Business logic in React components, controllers, or repositories
 - Importing Prisma / ORM inside `core` or `application`
-- `useEffect` for data fetching — use TanStack Query or Server Components
+- `useEffect` for data fetching — use TanStack Query (client) or `fetch` to `/api/v1/...` (Server Components); never call use cases from components
 - `throw` for domain business-rule errors — use Either pattern
 - Public setters on entities — use business-semantic methods
 - `any` in types — use explicit types or `unknown`
 - `<img>` or `<a>` for internal Next.js navigation
 - Tests that verify implementation instead of behavior
 - Direct imports between bounded contexts — use only the Shared Kernel
+- Importing `@repo/application` or calling use cases from `apps/web` pages, layouts, or client components — use HTTP to `/api/v1/...` instead
 
 ---
 

--- a/docs/00-INTRODUCTION.md
+++ b/docs/00-INTRODUCTION.md
@@ -26,7 +26,7 @@ It is also a **technical reference** for applying Clean Architecture, Domain-Dri
 |---------|------------|
 | Frontend | Next.js 14+ (App Router), React, Tailwind CSS |
 | Domain layer | TypeScript, DDD, Either pattern, Value Objects |
-| Data fetching | TanStack Query (client), Server Components (server) |
+| Data fetching | **HTTP only** — TanStack Query (client) and server-side `fetch` to the REST API; pages and components do **not** import `@repo/application` use cases (see [02-ARCHITECTURE](./02-ARCHITECTURE.md)) |
 | Forms | React Hook Form + Zod |
 | i18n | next-intl |
 | Database | Supabase (Postgres + Auth + Realtime) |
@@ -43,7 +43,7 @@ It is also a **technical reference** for applying Clean Architecture, Domain-Dri
 apps/
   web/          → Public portfolio (Next.js App Router)
   blog/         → Blog (future, post-MVP)
-  api/          → Backend API routes (future)
+  api/          → Optional dedicated API app if the HTTP surface outgrows `apps/web/app/api`
 
 packages/
   core/         → Domain + Shared Kernel (entities, VOs, repositories)

--- a/docs/02-ARCHITECTURE.md
+++ b/docs/02-ARCHITECTURE.md
@@ -44,7 +44,7 @@ core ← application ← infra ← web / api
 | **Domain** | `@repo/core` | Entities, Value Objects, invariants, repository interfaces. Zero framework dependencies. |
 | **Application** | `@repo/application` | Use cases, ports (interfaces), DTOs/view models. Orchestrates the domain. |
 | **Infrastructure** | `@repo/infra` | Repository implementations (Prisma + Supabase), external service adapters. |
-| **Interface** | `apps/web`, `apps/api` | HTTP routes, React components, Server Actions. Calls Application layer. |
+| **Interface** | `apps/web`, `apps/api` | HTTP route handlers (REST) compose use cases; React renders data obtained via **HTTP** from the app. |
 
 ---
 
@@ -75,9 +75,10 @@ Allowed: plain TypeScript, `@repo/utils`, `uuid`.
 
 ### `apps/web` and `apps/api`
 
-- Consume use cases through Server Components or API Routes
-- Never import concrete repositories directly
-- React components must contain no business logic
+- **REST is mandatory for presentation:** pages, layouts, and client components fetch the **HTTP API** (`/api/v1/...`). They must **not** import or call `@repo/application` use cases directly.
+- **Composition root:** only **HTTP route handlers** (e.g. `apps/web/app/api/**` or `apps/api`) wire `@repo/infra` with `@repo/application` and invoke use cases. That is the single entry point from the outside world into the application layer.
+- Never import concrete repositories from presentation code.
+- React components must contain no business logic.
 
 ---
 
@@ -100,9 +101,9 @@ Allowed: plain TypeScript, `@repo/utils`, `uuid`.
 
 ## Current State vs Target Architecture
 
-- **Current state**: `packages/application` and `packages/infra` are still being introduced; some orchestration and reads still happen in `apps/web` using static data.
-- **Target**: the full `core ← application ← infra ← web` pipeline is in place.
-- **Rule**: for new code, always follow the target. For existing code, migrate incrementally.
+- **`packages/core`**, **`packages/application`**, and **`packages/infra`** are in place (Portfolio + Identity domain, Prisma repositories, use cases, DTOs).
+- **REST boundary**: new presentation code must go through the documented API ([05-API-CONTRACTS](./05-API-CONTRACTS.md)); route handlers are added or extended as needed. Legacy static data in `apps/web` should be migrated behind the same HTTP surface.
+- **Rule**: do not bypass the API from the front-end — even on the server, use `fetch` to the app’s own API (or a shared route-handler module called only from `app/api`, not from `page.tsx`).
 
 ---
 

--- a/docs/03-BOUNDED-CONTEXTS.md
+++ b/docs/03-BOUNDED-CONTEXTS.md
@@ -10,8 +10,8 @@
 |---------|----------------|------------|--------|
 | **Portfolio** | Projects, experience, skills, profile, values | Project, Experience, Skill, ProfessionalValue, Language, SocialNetwork | Active |
 | **Blog** | Posts, tags, publication | BlogPost, Tag | Stub (future) |
-| **Contact** | Contact form capture and delivery | DTOs / Message entity | Stub |
-| **Identity** | Autenticação, autorização, papéis | User, Role, AccessPolicy | Planejado |
+| **Contact** | Contact form capture and delivery | `SendContactMessage`, `IEmailService` | Application + infra (API route pending) |
+| **Identity** | Autenticação, autorização, papéis | User, Role, `IUserRepository`, use cases na application | Em uso (domínio + casos de uso; API HTTP em evolução) |
 | **Shared Kernel** | Cross-context primitives | Id, Text, DateTime, Name, Url, enums, Either, errors | Active |
 
 ```text
@@ -27,8 +27,8 @@
 ┌────────────────┐  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐
 │   Portfolio    │  │      Blog      │  │    Contact     │  │    Identity    │
 │  Project       │  │   BlogPost     │  │  (DTOs/forms)  │  │  User, Role    │
-│  Experience    │  │   Tag          │  │                │  │  AccessPolicy  │
-│  Skill, etc.   │  │                │  │                │  │  (planejado)   │
+│  Experience    │  │   Tag          │  │                │  │  IUserRepo     │
+│  Skill, etc.   │  │                │  │                │  │  EnsureAdmin   │
 └────────────────┘  └────────────────┘  └────────────────┘  └────────────────┘
 ```
 
@@ -80,7 +80,7 @@ import { Slug, Either, ValidationError }  from '@repo/core/shared';
 - `Id`, `Text`, `DateTime`, `Name`, `Url`
 - `EmploymentType`, `LocationType`, `SkillType`, `Fluency`
 - `Slug`, `Image`, `DateRange`, `LocalizedText`, `Email` (planejado)
-- `Either<L, R>`, `ValidationError`, `DomainError`, `NotFoundError`, `UnauthorizedError` (planejado)
+- `Either<L, R>`, `ValidationError`, `DomainError`, `NotFoundError`, `UnauthorizedError` (identity)
 - `ERROR_MESSAGE` (domain error codes with `pt-BR` / `en-US` translations)
 
 **What does not belong here:** rules specific to one context (e.g., "a post can only be published with at least one tag" belongs to Blog).
@@ -120,7 +120,8 @@ src/
       */repositories/           → IExperienceRepository.ts, IProfileRepository.ts, etc.
 
   blog/                         → Stub (future)
-  contact/                      → Stub
+  identity/                     → User, Role, IUserRepository
+  contact/                      → Stub at core; application use case + infra email
 ```
 
 ---
@@ -134,18 +135,21 @@ src/
 
 ---
 
-## Identity Context (Planejado)
+## Identity Context
 
-**Responsabilidade:** autenticação, autorização, papéis (ADMIN | VISITOR). Supabase Auth.
+**Responsabilidade:** utilizador de back-office, papéis (`Role.ADMIN` | `Role.VISITOR`), e regras de autorização expressas nos casos de uso (`EnsureAdmin`, `GetCurrentUser`). Autenticação com fornecedor (ex.: Supabase Auth) fica na **infra** e no **middleware**; o domínio recebe identificadores já validados na borda HTTP.
 
-**Modelos previstos:**
+**Modelos em `packages/core`:**
 
 | Class | Role | Descrição |
 |-------|------|-----------|
-| `User` | Entity | auth_id, email, role |
-| `Role` | Value Object | ADMIN \| VISITOR |
-| `AccessPolicy` | Policy | canAccessAdmin, canPublish, etc. |
-| `IUserRepository` | Interface | findByAuthId, findByEmail, save |
+| `User` | Aggregate root | `Name`, `Email`, `Role` |
+| `Role` | Enum | `ADMIN` \| `VISITOR` |
+| `IUserRepository` | Interface | `findById`, `findByEmail` |
+
+**Application (`packages/application/identity`):** `GetCurrentUser`, `EnsureAdmin`.
+
+**API:** ver [05-API-CONTRACTS](./05-API-CONTRACTS.md) (`GET /api/v1/me`, rotas admin futuras). **Regra:** o front-end não chama estes casos de uso diretamente — apenas HTTP.
 
 Ver [11-IDENTITY](./11-IDENTITY.md) e [plans/identity-mvp.md](../plans/identity-mvp.md).
 

--- a/docs/04-APPLICATION-LAYER.md
+++ b/docs/04-APPLICATION-LAYER.md
@@ -8,14 +8,14 @@
 
 The application layer:
 - **Orchestrates** the domain: use cases call repository ports and return data ready for the interface layer
-- **Keeps Core pure**: Application depends on Core and defines port interfaces; Infrastructure implements them
-- **Isolates delivery**: Web / API never access concrete repositories directly
+- **Keeps Core pure**: Application depends on Core and uses port interfaces; Infrastructure implements them
+- **Is not called by the front-end directly**: `apps/web` consumes **REST** only; route handlers invoke use cases (see [02-ARCHITECTURE](./02-ARCHITECTURE.md), [05-API-CONTRACTS](./05-API-CONTRACTS.md))
 
 ---
 
 ## Abstract `UseCase` Base Class
 
-All use cases extend the abstract base class defined in `packages/application/src/shared/UseCase.ts`:
+Most use cases extend the abstract base class in `packages/application/src/shared/UseCase.ts`:
 
 ```typescript
 export abstract class UseCase<TInput, TOutput, TError = DomainError> {
@@ -42,18 +42,21 @@ export class GetFeaturedProjects extends UseCase<GetFeaturedProjectsInput, Proje
 }
 ```
 
+`SendContactMessage` follows the same orchestration style but does not extend `UseCase` (historical shape); it still returns `Either`.
+
 ---
 
 ## Ports
 
-Repository interfaces live in `@repo/core` (not in `@repo/application`). Service ports that are not related to the domain are defined in `@repo/application`:
+Repository interfaces for **Portfolio** and **Identity** live in `@repo/core`. Service ports not tied to a single aggregate are defined in `@repo/application`:
 
 | Port | Package | Status |
 |------|---------|--------|
 | `IProjectRepository` | `@repo/core/portfolio` | defined |
 | `IExperienceRepository` | `@repo/core/portfolio` | defined |
 | `IProfileRepository` | `@repo/core/portfolio` | defined |
-| `IEmailService` | `@repo/application/contact` | ✅ implemented |
+| `IUserRepository` | `@repo/core/identity` | defined |
+| `IEmailService` | `@repo/application/contact` | implemented (`ResendEmailService` in `@repo/infra`) |
 
 `IEmailService` signature:
 
@@ -67,14 +70,32 @@ interface IEmailService {
 
 ## Use Cases
 
+### Portfolio
+
 | Use case | Port(s) | Input | Output | Status |
 |----------|---------|-------|--------|--------|
-| `GetFeaturedProjects` | `IProjectRepository` | `{ locale }` | `ProjectSummaryDTO[]` | ✅ implemented |
-| `GetPublishedProjects` | `IProjectRepository` | `{ locale }` | `ProjectSummaryDTO[]` | pending |
-| `GetProjectBySlug` | `IProjectRepository` | `{ locale, slug }` | `ProjectDetailDTO` | pending |
-| `GetExperiences` | `IExperienceRepository` | `{ locale }` | `ExperienceDTO[]` | pending |
-| `GetProfile` | `IProfileRepository` | `{ locale }` | `ProfileDTO` | pending |
-| `SendContactMessage` | `IEmailService` | `IContactMessageDTO` | `void` | pending |
+| `GetFeaturedProjects` | `IProjectRepository` | `{ locale }` | `ProjectSummaryDTO[]` | implemented |
+| `GetPublishedProjects` | `IProjectRepository` | `{ locale }` | `ProjectSummaryDTO[]` | implemented |
+| `GetProjectBySlug` | `IProjectRepository` | `{ locale, slug }` | `ProjectDetailDTO` | implemented |
+| `GetExperiences` | `IExperienceRepository` | `{ locale }` | `ExperienceDTO[]` | implemented |
+| `GetProfile` | `IProfileRepository` | `{ locale }` | `ProfileDTO` | implemented |
+
+### Identity
+
+Identity is modeled as its **own bounded context** in `packages/core` (`User`, `Role`, `IUserRepository`, `UnauthorizedError`). Application use cases enforce **authorization rules** (who may act), while **authentication** (session / tokens) is resolved at the HTTP edge (cookies, headers) and passed in as inputs such as `userId`.
+
+| Use case | Port(s) | Input | Output | Status |
+|----------|---------|-------|--------|--------|
+| `GetCurrentUser` | `IUserRepository` | `{ userId }` | `UserDTO` | implemented |
+| `EnsureAdmin` | `IUserRepository` | `{ userId }` | `void` | implemented |
+
+`EnsureAdmin` returns `UnauthorizedError` when the user exists but is not `Role.ADMIN`. Route handlers map that to **401** (see [05-API-CONTRACTS](./05-API-CONTRACTS.md)).
+
+### Contact
+
+| Use case | Port(s) | Input | Output | Status |
+|----------|---------|-------|--------|--------|
+| `SendContactMessage` | `IEmailService` | `SendContactMessageInput` | `void` | implemented |
 
 Use cases **never** know Supabase, HTTP, or Prisma. Domain errors are propagated as `Either` and mapped at the edge.
 
@@ -82,21 +103,21 @@ Use cases **never** know Supabase, HTTP, or Prisma. Domain errors are propagated
 
 ## DTOs
 
-DTOs are plain serializable types — no domain logic, no Either. They are the output contract of use cases, with all localized fields already resolved to a single string.
+DTOs are plain serializable types — no domain logic, no Either. They are the output (or input) contract of use cases, with localized fields resolved to a single string where applicable.
 
-| DTO | File | Description |
-|-----|------|-------------|
-| `ProjectSummaryDTO` | `portfolio/dtos/ProjectSummaryDTO.ts` | Card / listing view |
-| `ProjectDetailDTO` | `portfolio/dtos/ProjectDetailDTO.ts` | Detail page; extends `ProjectSummaryDTO` |
-| `ExperienceDTO` | `portfolio/dtos/ExperienceDTO.ts` | Work experience entry |
-| `ExperienceSkillDTO` | `portfolio/dtos/ExperienceSkillDTO.ts` | Skill inside an experience |
-| `ProfileDTO` | `portfolio/dtos/ProfileDTO.ts` | Full profile |
-| `ProfileStatDTO` | `portfolio/dtos/ProfileStatDTO.ts` | Single stat inside a profile |
-| `SocialNetworkDTO` | `portfolio/dtos/SocialNetworkDTO.ts` | Social link |
-| `IContactMessageDTO` | `contact/dtos/ContactMessageDTO.ts` | Input DTO for contact form |
+| DTO | Module | Description |
+|-----|--------|-------------|
+| `ProjectSummaryDTO` | portfolio | Card / listing view |
+| `ProjectDetailDTO` | portfolio | Detail page; extends `ProjectSummaryDTO` |
+| `ExperienceDTO` | portfolio | Work experience entry (`skills: string[]`) |
+| `ProfileDTO` | portfolio | Full profile |
+| `ProfileStatDTO` | portfolio | Stat inside a profile |
+| `SocialNetworkDTO` | portfolio | Social link |
+| `UserDTO` | identity | `id`, `name`, `email`, `role` |
+| `IContactMessageDTO` | contact | Input shape for email send |
 
 ```typescript
-// ProjectSummaryDTO — output of GetFeaturedProjects
+// ProjectSummaryDTO — output of list/featured use cases
 type ProjectSummaryDTO = {
   id: string;
   slug: string;
@@ -127,44 +148,56 @@ type ProjectDetailDTO = ProjectSummaryDTO & {
 ```text
 packages/application/src/
   shared/
-    UseCase.ts              ✅ abstract base class
+    UseCase.ts
   portfolio/
     dtos/
-      ProjectSummaryDTO.ts  ✅
-      ProjectDetailDTO.ts   ✅
-      ExperienceDTO.ts      ✅
-      ExperienceSkillDTO.ts ✅
-      ProfileDTO.ts         ✅
-      ProfileStatDTO.ts     ✅
-      SocialNetworkDTO.ts   ✅
     use-cases/
-      GetFeaturedProjects.ts ✅
+      GetFeaturedProjects.ts
+      GetPublishedProjects.ts
+      GetProjectBySlug.ts
+      GetExperiences.ts
+      GetProfile.ts
+  identity/
+    dtos/
+      UserDTO.ts
+    use-cases/
+      GetCurrentUser.ts
+      EnsureAdmin.ts
   contact/
     dtos/
-      ContactMessageDTO.ts  ✅
     ports/
-      IEmailService.ts      ✅
+      IEmailService.ts
+    use-cases/
+      SendContactMessage.ts
   index.ts
 ```
 
-**Dependencies**: only `@repo/core` (and `@repo/utils` for shared types if needed). Must **not** depend on `@repo/infra`, `apps/web`, or `apps/api`.
+**Dependencies**: `@repo/core` only (plus `@repo/utils` where needed for validation helpers in contact). Must **not** depend on `@repo/infra`, `apps/web`, or `apps/api`.
 
 ---
 
-## Read Flow Example
+## Read / write flow (HTTP boundary)
 
-**List projects:**
+**List published projects (correct pattern):**
 
-1. `apps/web` (Server Component or Route Handler) calls `GetPublishedProjects.execute({ locale })`.
-2. `GetPublishedProjects` calls `IProjectRepository.findPublished()`.
-3. `@repo/infra` reads Supabase rows and maps them to `Project[]`.
-4. Use case maps `Project[]` → `ProjectDTO[]` and returns.
-5. `apps/web` renders the result or maps domain errors to HTTP status + localized message.
+1. Browser or Server Component calls `GET /api/v1/projects?locale=...` (or the client uses TanStack Query with that URL).
+2. **Route handler** resolves locale, builds `GetPublishedProjects` with `IProjectRepository` from infra, calls `execute()`.
+3. Use case calls `IProjectRepository.findPublished()`, maps to `ProjectSummaryDTO[]`, returns `Either`.
+4. Handler maps `Either` to the [envelope](./05-API-CONTRACTS.md) and HTTP status.
+
+**Admin-only action (example):**
+
+1. Handler reads **authenticated user id** from the session (middleware / Supabase / cookie — infrastructure detail at the edge).
+2. Handler calls `EnsureAdmin.execute({ userId })`; on `right`, proceeds to call other use cases or mutations; on `UnauthorizedError`, responds with **401**.
+
+Pages and React components **do not** import `GetPublishedProjects` or `EnsureAdmin` directly.
 
 ---
 
 ## See Also
 
-- **[02-ARCHITECTURE](./02-ARCHITECTURE.md)** — Layer dependency rule
-- **[05-API-CONTRACTS](./05-API-CONTRACTS.md)** — HTTP envelope and error mapping
+- **[02-ARCHITECTURE](./02-ARCHITECTURE.md)** — Layer dependency rule and REST boundary
+- **[03-BOUNDED-CONTEXTS](./03-BOUNDED-CONTEXTS.md)** — Identity vs Portfolio
+- **[05-API-CONTRACTS](./05-API-CONTRACTS.md)** — HTTP envelope and endpoints
+- **[11-IDENTITY](./11-IDENTITY.md)** — Identity context and routes
 - **[10-GLOSSARY](./10-GLOSSARY.md)** — Use Case, Port, DTO definitions

--- a/docs/05-API-CONTRACTS.md
+++ b/docs/05-API-CONTRACTS.md
@@ -1,6 +1,16 @@
 # 05 — API Contracts
 
-> Response envelope, error handling, HTTP status mapping, and planned endpoints.
+> Response envelope, error handling, HTTP status mapping, authorization, and the REST surface (`/api/v1`).
+
+---
+
+## REST as the only presentation boundary
+
+- **`apps/web` must not** import `@repo/application` or call use cases from pages, layouts, or client components.
+- **Route handlers** (Next.js Route Handlers under `apps/web/app/api/...`, or a future `apps/api` app) are the **composition root**: they wire `@repo/infra`, invoke use cases, and return JSON.
+- This keeps a single HTTP contract for browsers, SSR, and external clients.
+
+See [02-ARCHITECTURE](./02-ARCHITECTURE.md) and [04-APPLICATION-LAYER](./04-APPLICATION-LAYER.md).
 
 ---
 
@@ -22,17 +32,20 @@ All API responses follow a consistent envelope:
 
 ## HTTP Error Mapping
 
-| Domain error | HTTP status |
-|--------------|-------------|
-| `ValidationError` / `DomainError` | 400 |
+| Domain / application error | HTTP status |
+|----------------------------|-------------|
+| `ValidationError` / invalid input | 400 |
 | `NotFoundError` | 404 |
+| `UnauthorizedError` (e.g. `EnsureAdmin` when user is not admin) | 401 |
 | Unexpected / infrastructure | 500 |
+
+Use **403** only when you introduce a distinct “authenticated but forbidden for this resource” rule; today `UnauthorizedError` maps to **401** for failed privilege checks.
 
 ---
 
 ## Error Codes
 
-The domain uses **stable error codes** (e.g., `INVALID_SLUG`, `INVALID_DATE_RANGE`). The edge maps them to HTTP status and resolves a localized message.
+The domain uses **stable error codes** (e.g. `INVALID_SLUG`, `UNAUTHORIZED`). The edge maps them to HTTP status and resolves a localized message.
 
 Examples:
 
@@ -42,6 +55,7 @@ Examples:
 | `ERROR_INVALID_TEXT` | 400 | Text length constraint violated |
 | `INVALID_SLUG` | 400 | Slug format violated |
 | `NOT_FOUND` | 404 | Resource not found |
+| `UNAUTHORIZED` | 401 | Not allowed (e.g. not admin) |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |
 
 ---
@@ -53,7 +67,8 @@ try {
   const result = await getProjectBySlug(slug);
   if (result.isLeft()) {
     const { code } = result.value;
-    const status = code === 'NOT_FOUND' ? 404 : 400;
+    const status =
+      code === 'NOT_FOUND' ? 404 : code === 'UNAUTHORIZED' ? 401 : 400;
     const message = translateError(code, locale) ?? result.value.message;
     return Response.json({ data: null, error: { code, message } }, { status });
   }
@@ -78,29 +93,57 @@ try {
 
 ---
 
-## Planned Endpoints
+## Authorization model (overview)
 
-### Projects
+| Audience | Typical use |
+|----------|-------------|
+| **Anonymous** | Public read endpoints (portfolio content), `POST /contact` |
+| **Authenticated** | `GET /me` — requires a valid session; resolves `userId` for `GetCurrentUser` |
+| **Admin** | Mutations and admin-only reads — handler runs `EnsureAdmin` with the current `userId` before proceeding |
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/projects` | List published projects |
-| `GET` | `/api/v1/projects/:slug` | Get project by slug |
-| `GET` | `/api/v1/projects/featured` | List featured projects |
+Exact session mechanics (Supabase Auth, cookies, headers) live in **infra** and **middleware**; the API contract assumes the handler can obtain a stable `userId` for logged-in requests.
 
-### Blog _(post-MVP)_
+---
+
+## REST surface (`/api/v1`)
+
+Paths below are the **contract**. Handlers may be implemented incrementally; behavior must match use cases in [04-APPLICATION-LAYER](./04-APPLICATION-LAYER.md).
+
+### Portfolio (read, public)
+
+| Method | Path | Use case | Auth |
+|--------|------|----------|------|
+| `GET` | `/api/v1/projects` | `GetPublishedProjects` | Public |
+| `GET` | `/api/v1/projects/featured` | `GetFeaturedProjects` | Public |
+| `GET` | `/api/v1/projects/:slug` | `GetProjectBySlug` | Public |
+| `GET` | `/api/v1/experiences` | `GetExperiences` | Public |
+| `GET` | `/api/v1/profile` | `GetProfile` | Public |
+
+Query parameters such as `locale` should align with `@repo/core` `Locale` and existing i18n conventions.
+
+### Contact
+
+| Method | Path | Use case | Auth |
+|--------|------|----------|------|
+| `POST` | `/api/v1/contact` | `SendContactMessage` | Public (consider rate limit / CAPTCHA at the edge) |
+
+### Identity
+
+| Method | Path | Use case | Auth |
+|--------|------|----------|------|
+| `GET` | `/api/v1/me` | `GetCurrentUser` | **Session required** — without a resolvable `userId`, respond with **401** |
+
+Admin-only routes (e.g. future `PATCH /api/v1/projects/:slug`) must call `EnsureAdmin.execute({ userId })` before applying changes; failure → **401** with `UNAUTHORIZED`.
+
+---
+
+## Blog _(post-MVP)_
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/v1/posts` | List posts (`?tag=`, `?limit=`, `?offset=`) |
 | `GET` | `/api/v1/posts/:slug` | Get post by slug |
 | `GET` | `/api/v1/tags` | List tags |
-
-### Contact
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/api/v1/contact` | Submit contact form |
 
 ---
 
@@ -118,3 +161,4 @@ try {
 - **[04-APPLICATION-LAYER](./04-APPLICATION-LAYER.md)** — Use cases and ports
 - **[06-VALIDATION](./06-VALIDATION.md)** — Edge validation with Zod
 - **[07-I18N](./07-I18N.md)** — Locale resolution and error message translation
+- **[11-IDENTITY](./11-IDENTITY.md)** — Identity bounded context and UI routes

--- a/docs/09-PATTERNS.md
+++ b/docs/09-PATTERNS.md
@@ -203,12 +203,14 @@ Apply only when solving a real problem. Comment with `// Pattern: <Name>`.
 ## `apps/web` Patterns
 
 ```typescript
-// ✅ Server Component consuming a use case
+// ✅ Server Component — data via REST (use cases run inside Route Handlers only)
 export default async function ProjectsPage() {
-  const useCase = container.resolve(GetPublishedProjectsUseCase);
-  const result = await useCase.execute({ locale: 'pt-BR' });
-  if (result.isLeft()) notFound();
-  return <ProjectList projects={result.value} />;
+  const res = await fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/v1/projects?locale=pt-BR`, {
+    cache: 'no-store',
+  });
+  const body = await res.json();
+  if (!res.ok || body.error) notFound();
+  return <ProjectList projects={body.data} />;
 }
 ```
 

--- a/docs/10-GLOSSARY.md
+++ b/docs/10-GLOSSARY.md
@@ -93,23 +93,23 @@ A contact form submission. Contains name, email, and message body.
 
 ---
 
-## Domain Terms — Identity Context (Planejado)
+## Domain Terms — Identity Context
 
 ### User
 
-Identidade autenticada no sistema. Possui `auth_id` (Supabase Auth), `email` e `role`. Usada para autorização de ações admin.
+Aggregate root em `@repo/core/identity`. Identificador (`Id`), `Name`, `Email`, `Role`. Métodos `isAdmin()` / `isVisitor()` para regras de autorização no domínio. O vínculo com o fornecedor de auth (ex.: `sub` do Supabase) pode ser mapeado na infraestrutura ao resolver `userId` na borda HTTP.
 
 ### Role
 
-Papel do usuário. Valores: `ADMIN` (acesso total) ou `VISITOR` (apenas leitura pública).
+Enum (`ADMIN` | `VISITOR`). `ADMIN` desbloqueia operações de gestão quando a API e os casos de uso (`EnsureAdmin`) o exigem.
 
-### AccessPolicy
+### EnsureAdmin (application use case)
 
-Policy que determina se um User pode executar ações protegidas (publicar, gerenciar projetos, acessar área admin). Todos os métodos delegam para `role === 'ADMIN'`.
+Caso de uso que verifica se o utilizador existe e é `ADMIN`; caso contrário devolve `UnauthorizedError`. Substitui um objeto `AccessPolicy` separado enquanto as regras forem binárias.
 
 ### UnauthorizedError
 
-Erro de domínio para falhas de autenticação ou autorização (usuário não logado ou sem permissão).
+Erro de domínio (`code` `UNAUTHORIZED`) para falhas de autorização (ex.: utilizador autenticado sem privilégio de admin). Na API, mapeia tipicamente a HTTP **401** (ver [05-API-CONTRACTS](./05-API-CONTRACTS.md)).
 
 ---
 

--- a/docs/11-IDENTITY.md
+++ b/docs/11-IDENTITY.md
@@ -1,36 +1,66 @@
-# 11 — Identity (Planejado)
+# 11 — Identity
 
-> Bounded context de autenticação e autorização. Plano detalhado para implementação futura.
+> Bounded context de identidade: utilizadores, papéis e autorização. Complementa [03-BOUNDED-CONTEXTS](./03-BOUNDED-CONTEXTS.md) e [05-API-CONTRACTS](./05-API-CONTRACTS.md).
 
-## Contexto
+---
 
-Responsável por autenticação e autorização. Modelo binário: `ADMIN | VISITOR`. Supabase Auth como mecanismo; domínio em `packages/core`. Dependency rule: `core ← application ← infra ← web`.
+## O que é “auth” neste projeto
 
-## Context Map
+Em DDD, **Identity** é um **bounded context** próprio: modela *quem* é o utilizador e *que* pode fazer no sistema (via `Role` e casos de uso como `EnsureAdmin`). **Não** é apenas “middleware”: a regra de negócio “só ADMIN pode…” vive no domínio e na camada de aplicação.
 
-| Context | Status | Modelos principais |
-|---------|--------|--------------------|
-| Identity | Planejado | User, Role, AccessPolicy, IUserRepository |
+- **Autenticação** (prova de identidade — sessão, JWT, Supabase Auth): mecanismo na **infra** + borda HTTP (cookies, headers).
+- **Autorização** (permissão para uma ação): **`EnsureAdmin`**, futuros policies, e leitura de utilizador com **`GetCurrentUser`** — sempre invocados a partir de **route handlers**, nunca a partir de componentes React.
 
-## Modelos previstos
+O **front-end** consome apenas **REST**; não importa `@repo/application` para Identity.
 
-- **User** — entidade: `auth_id`, `email`, `role`
-- **Role** — VO: `ADMIN | VISITOR`
-- **Email** — VO no Shared Kernel
-- **AccessPolicy** — policy: `canPublish`, `canManageProjects`, `canAccessAdmin`, etc.
-- **IUserRepository** — interface em core
+---
 
-## Rotas previstas
+## Estado atual (código)
 
-- `/[locale]/login` — página de login (email + senha)
-- `/[locale]/admin/*` — área protegida; middleware + layout com `EnsureAdminUseCase`
+| Layer | Conteúdo |
+|-------|----------|
+| **core** (`@repo/core/identity`) | `User`, `Role`, `IUserRepository`, `UnauthorizedError` |
+| **application** | `GetCurrentUser`, `EnsureAdmin`, `UserDTO` |
+| **infra** | Implementação de `IUserRepository` (ex.: Prisma), utilizadores em BD |
 
-## Plano de implementação
+Rotas HTTP (`/api/v1/me`, etc.) estão descritas em [05-API-CONTRACTS](./05-API-CONTRACTS.md); a implementação dos Route Handlers pode acompanhar o roadmap.
 
-O plano detalhado por fases está em [plans/identity-mvp.md](../plans/identity-mvp.md).
+---
+
+## Papéis
+
+`Role` é um enum em `packages/core`:
+
+- `ADMIN` — acesso a operações de gestão (quando expostas pela API).
+- `VISITOR` — utilizador autenticado sem privilégios de administração.
+
+`EnsureAdmin` devolve `UnauthorizedError` (código `UNAUTHORIZED`) quando o utilizador não é `ADMIN` — mapeado a **401** na API.
+
+---
+
+## Casos de uso
+
+| Caso de uso | Finalidade |
+|-------------|------------|
+| `GetCurrentUser` | Dado um `userId` válido (já extraído da sessão na borda), devolve `UserDTO`. |
+| `EnsureAdmin` | Garante que o utilizador existe e é `ADMIN`; caso contrário falha com `UnauthorizedError`. |
+
+O **nível de acesso** a cada endpoint HTTP é definido na camada de interface: rotas públicas sem sessão; rotas autenticadas exigem sessão e passam `userId` aos casos de uso; rotas admin chamam `EnsureAdmin` antes de mutações.
+
+---
+
+## UI (planeado / em curso)
+
+- `/[locale]/login` — login (email + senha ou fluxo do fornecedor).
+- `/[locale]/admin/*` — área protegida; o servidor deve validar sessão e, nas operações sensíveis, alinhar com `EnsureAdmin` no handler.
+
+Detalhes de fases em [plans/identity-mvp.md](../plans/identity-mvp.md) e [ROADMAP](./ROADMAP.md).
+
+---
 
 ## Ver também
 
 - [03-BOUNDED-CONTEXTS](./03-BOUNDED-CONTEXTS.md) — mapa de contextos
+- [04-APPLICATION-LAYER](./04-APPLICATION-LAYER.md) — lista de casos de uso
 - [ROADMAP](./ROADMAP.md) — fase Identity
-- [packages/infra/README.md](../packages/infra/README.md) — schema `users`
+- [packages/infra/README.md](../packages/infra/README.md) — schema e repositórios

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,7 +20,7 @@
 | Writing or reviewing tests? | [08-TESTING](./08-TESTING.md) |
 | Looking for code templates (Either, VO, Entity)? | [09-PATTERNS](./09-PATTERNS.md) |
 | Looking for a domain term? | [10-GLOSSARY](./10-GLOSSARY.md) |
-| Identity (auth, admin)? | [11-IDENTITY](./11-IDENTITY.md) |
+| Identity (auth, admin, REST)? | [11-IDENTITY](./11-IDENTITY.md) |
 
 ---
 
@@ -48,7 +48,7 @@
 
 ### Planned Features
 
-- **[11-IDENTITY](./11-IDENTITY.md)** — Identity bounded context (auth, roles, admin area) — planejado
+- **[11-IDENTITY](./11-IDENTITY.md)** — Identity bounded context (auth, roles, admin, API contract)
 
 ---
 
@@ -66,5 +66,5 @@
 
 1. **Single Source of Truth** — each concept appears in exactly one authoritative location
 2. **Numbered for reading order** — read 00 → 10 or jump directly to the topic
-3. **Current state vs target** — where they differ, the target is the direction for new code
+3. **Current state vs target** — where they differ, the docs call out migration (e.g. static data → REST)
 4. **CLAUDE.md is the operational guide** — this index is the knowledge base

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,10 +7,10 @@ Evolution view for the portfolio, aligned with Clean Architecture, DDD, i18n, an
 ## Index
 
 - [MVP (Current and In Progress)](#mvp-current-and-in-progress)
-- [Phase 1 — API and Infra](#phase-1--api-and-infra)
+- [Phase 1 — REST API and Web Consumption](#phase-1--rest-api-and-web-consumption)
 - [Phase 2 — Blog and Supabase](#phase-2--blog-and-supabase)
-- [Phase 3 — Application and Contact Backend](#phase-3--application-and-contact-backend)
-- [Phase 4 — Identity (Auth)](#phase-4--identity-auth)
+- [Phase 3 — Contact Delivery at the Edge](#phase-3--contact-delivery-at-the-edge)
+- [Phase 4 — Identity (sessions and admin UI)](#phase-4--identity-sessions-and-admin-ui)
 - [Continuous Improvements](#continuous-improvements)
 
 ---
@@ -21,27 +21,23 @@ Evolution view for the portfolio, aligned with Clean Architecture, DDD, i18n, an
 - [x] Next.js 14 (App Router) in `apps/web`
 - [x] i18n (`next-intl`): `pt-BR`, `en-US`, `es`
 - [x] Pages: Home, Projects, About
-- [x] Domain in `@repo/core`: `Project`, `Experience`, `Skill`, `ProfessionalValue`, `Language`, `SocialNetwork`
+- [x] Domain in `@repo/core`: Portfolio + Identity (`User`, `Role`, …)
+- [x] `packages/application`: Portfolio use cases, Identity (`GetCurrentUser`, `EnsureAdmin`), `SendContactMessage`
+- [x] `packages/infra`: Prisma repositories, email adapter (`ResendEmailService`)
 - [x] Shared UI components in `@repo/ui`; Storybook in `apps/storybooks`
-- [x] Contact form (Formik + Yup); still without backend delivery
-- [x] Static data (projects in the page layer)
+- [ ] **REST Route Handlers** implementing [05-API-CONTRACTS](./05-API-CONTRACTS.md) (`/api/v1/...`)
+- [ ] **Web**: replace static data with `fetch` / TanStack Query to the REST API only (no direct `@repo/application` imports from pages)
 - [ ] Environment variables documented and optionally populated for links / contact data
 
 ---
 
-## Phase 1 — API and Infra
+## Phase 1 — REST API and Web Consumption
 
-- [ ] **`packages/infra`**
-  - Supabase client (`@supabase/supabase-js`)
-  - Env: `SUPABASE_URL`, `SUPABASE_ANON_KEY` (and `SUPABASE_SERVICE_ROLE_KEY` if needed, server only)
-- [ ] **Supabase schema (Portfolio)**
-  - Tables such as `projects`, `project_skills`, `skills`, `experiences`, etc., according to [../packages/infra/README.md](../packages/infra/README.md)
-- [ ] **Mappers and repositories**
-  - `ProjectMapper`, `ProjectRepositorySupabase` (and, if needed, equivalents for `Skill` and `Experience`)
-- [ ] **REST API (Projects)**
-  - `GET /api/projects`, `GET /api/projects/:id` (Route Handlers in `apps/web` or a future `apps/api`)
-  - Envelope and errors according to [API.md](API.md) and [ERROR_HANDLING.md](ERROR_HANDLING.md)
-- [ ] **Web**: replace static data with fetches to `/api/projects`
+- [ ] **Route handlers** in `apps/web/app/api/v1/...` (or extract `apps/api` if the surface grows)
+- [ ] **Envelope and errors** per [05-API-CONTRACTS](./05-API-CONTRACTS.md) and [06-VALIDATION](./06-VALIDATION.md)
+- [ ] **Portfolio**: `GET` projects (published, featured, by slug), experiences, profile
+- [ ] **Identity**: `GET /api/v1/me` (session required); admin routes call `EnsureAdmin` before mutations
+- [ ] **Web**: all data reads/writes through HTTP; align with authorization table in [05-API-CONTRACTS](./05-API-CONTRACTS.md)
 
 ---
 
@@ -54,54 +50,41 @@ Evolution view for the portfolio, aligned with Clean Architecture, DDD, i18n, an
 - [ ] **Infra**
   - `PostMapper`, `TagMapper`, `PostRepositorySupabase`, `TagRepositorySupabase`
 - [ ] **API**
-  - `GET /api/posts`, `GET /api/posts/:slug`, `GET /api/tags`
+  - `GET /api/v1/posts`, `GET /api/v1/posts/:slug`, `GET /api/v1/tags` (see [05-API-CONTRACTS](./05-API-CONTRACTS.md))
 - [ ] **Web**
   - Pages for post listing and post-by-slug
-  - localized content strategy for Blog (for example, `LocalizedText` or locale-specific columns; see [I18N.md](I18N.md))
+  - Localized content strategy for Blog (for example, `LocalizedText` or locale-specific columns; see [07-I18N](./07-I18N.md))
 
 ---
 
-## Phase 3 — Application and Contact Backend
+## Phase 3 — Contact Delivery at the Edge
 
-- [x] **`packages/application`** — base structure
-  - [x] Abstract `UseCase` base class
-  - [x] Output DTOs: `ProjectSummaryDTO`, `ProjectDetailDTO`, `ExperienceDTO`, `ProfileDTO`, and others
-  - [x] `IEmailService` port
-  - [x] `ContactMessageDTO`
-  - [x] `GetFeaturedProjects` use case
-  - [ ] Remaining use cases: `GetPublishedProjects`, `GetProjectBySlug`, `GetExperiences`, `GetProfile`, `SendContactMessage`
-- [ ] **Infra**
-  - Concrete implementations of the ports; `ContactSender` (Supabase `contacts`, Resend, or another provider)
-- [ ] **API**
-  - `POST /api/contact`; validation with Zod; rate limit and / or CAPTCHA (to be decided)
-- [ ] **Web**
-  - Contact form submits to `/api/contact`; error handling uses stable codes and i18n
+- [x] `SendContactMessage` use case and `IEmailService` implementation
+- [ ] **`POST /api/v1/contact`** with Zod validation, rate limit and / or CAPTCHA (to be decided)
+- [ ] **Web**: contact form submits to `POST /api/v1/contact`; errors use stable codes and i18n
 
 ---
 
-## Phase 4 — Identity (Auth)
+## Phase 4 — Identity (sessions and admin UI)
 
-> **Status:** planejado. Plano detalhado em [11-IDENTITY](./11-IDENTITY.md) e [plans/identity-mvp.md](../plans/identity-mvp.md).
+> Domain and application layers for Identity are in place. Remaining work is **HTTP session integration**, **middleware**, and **admin UI**.
 
-- [ ] **Domain** (`packages/core`)
-  - User, Role, Email, AccessPolicy, IUserRepository, UnauthorizedError
-- [ ] **Infrastructure** (`packages/infra`)
-  - Migration tabela `users`; SupabaseUserRepository; seed admin
-- [ ] **Application** (`packages/application`)
-  - GetCurrentUserUseCase, EnsureAdminUseCase
-- [ ] **Web** (`apps/web`)
-  - Middleware auth; página login; layout admin; getAuthenticatedUser
+- [x] **Domain** (`packages/core`): `User`, `Role`, `IUserRepository`, `UnauthorizedError`
+- [x] **Infrastructure**: Prisma `User` model and repository
+- [x] **Application**: `GetCurrentUser`, `EnsureAdmin`
+- [ ] **Sessions**: middleware; resolve `userId` for authenticated routes
+- [ ] **Web**: `/[locale]/login`, `/[locale]/admin/*` layouts protected consistently with API rules
 
-Modelo de papéis: `ADMIN | VISITOR`. Rotas protegidas: `/[locale]/admin/*`. Login: `/[locale]/login`.
+Modelo de papéis: `ADMIN | VISITOR`. Referência: [11-IDENTITY](./11-IDENTITY.md), [plans/identity-mvp.md](../plans/identity-mvp.md).
 
 ---
 
 ## Continuous Improvements
 
-- **Validation**: Zod in the API and row decoding; gradual migration from Yup to Zod in forms; see [VALIDATION.md](VALIDATION.md)
+- **Validation**: Zod in the API and row decoding; gradual migration from Yup to Zod in forms; see [06-VALIDATION](./06-VALIDATION.md)
 - **Errors**: complete `ERROR_MESSAGE` with `es`; standardize codes and HTTP mapping across endpoints
 - **Domain content i18n**: define and implement `LocalizedText` or translation columns / tables for Projects and Blog
-- **Tests**: coverage for use cases, repositories (with local Supabase or mocks), and Route Handlers
+- **Tests**: coverage for use cases, repositories (with local DB or mocks), and Route Handlers
 - **Quality**: CI for lint, format, types, and tests; PR previews where applicable
 - **`apps/api`**: if the API grows significantly, extract Route Handlers into a dedicated app in the monorepo
 - **Documentation**: keep READMEs and `docs/` in sync with decisions and code


### PR DESCRIPTION
This pull request updates project documentation to match the current codebase and the agreed architecture rules.

## Changes

- **REST as the mandatory presentation boundary:** `apps/web` must consume data via HTTP (`/api/v1/...`); only route handlers compose `@repo/infra` and `@repo/application` use cases. Reflected in `02-ARCHITECTURE`, `00-INTRODUCTION`, `05-API-CONTRACTS`, `04-APPLICATION-LAYER`, `CLAUDE.md`, and the Server Component example in `09-PATTERNS`.
- **Application layer:** Use-case and port tables aligned with `packages/application` (Portfolio, Identity `GetCurrentUser` / `EnsureAdmin`, Contact `SendContactMessage`); structure and read/write flow examples updated.
- **API contracts:** Portfolio read surface, contact, identity (`GET /api/v1/me`), authorization overview, and `UnauthorizedError` → 401 mapping.
- **Bounded contexts & Identity:** `03-BOUNDED-CONTEXTS` and `11-IDENTITY` describe Identity as an active bounded context with application use cases; glossary updated.
- **Roadmap & INDEX:** Phases and links corrected (`05-API-CONTRACTS`, `06-VALIDATION`, `07-I18N`).

No runtime code changes.

Made with [Cursor](https://cursor.com)