### PR TITLE
docs: pluggable auth, authSubject, and identity REST plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ CONTACT_EMAIL_FROM="onboarding@resend.dev"
 # Email address of the initial admin user created by the seed script.
 # Defaults to "admin@portfolio.dev" if not set.
 ADMIN_EMAIL="admin@portfolio.dev"
+
+# Supabase Auth (server-side only — for IAuthenticationGateway when implemented)
+# Project Settings → API
+# SUPABASE_URL="https://[project-ref].supabase.co"
+# SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,7 @@ interface IProjectRepository {
 - Tests that verify implementation instead of behavior
 - Direct imports between bounded contexts — use only the Shared Kernel
 - Importing `@repo/application` or calling use cases from `apps/web` pages, layouts, or client components — use HTTP to `/api/v1/...` instead
+- Importing `@supabase/*` or other IdP SDKs from `apps/web` UI or `middleware.ts` — auth belongs behind `IAuthenticationGateway` in `@repo/infra` and REST routes; see [11-IDENTITY](./docs/11-IDENTITY.md)
 
 ---
 

--- a/docs/02-ARCHITECTURE.md
+++ b/docs/02-ARCHITECTURE.md
@@ -76,7 +76,8 @@ Allowed: plain TypeScript, `@repo/utils`, `uuid`.
 ### `apps/web` and `apps/api`
 
 - **REST is mandatory for presentation:** pages, layouts, and client components fetch the **HTTP API** (`/api/v1/...`). They must **not** import or call `@repo/application` use cases directly.
-- **Composition root:** only **HTTP route handlers** (e.g. `apps/web/app/api/**` or `apps/api`) wire `@repo/infra` with `@repo/application` and invoke use cases. That is the single entry point from the outside world into the application layer.
+- **No auth vendor in the UI:** `apps/web` must **not** import `@supabase/*`, `next-auth/*`, or other IdP SDKs from pages, layouts, client components, hooks, or `middleware.ts`. Authentication is **pluggable** behind `IAuthenticationGateway` (see [11-IDENTITY](./11-IDENTITY.md)); the browser uses only your REST routes (e.g. `POST /api/v1/auth/sign-in`).
+- **Composition root:** only **HTTP route handlers** (e.g. `apps/web/app/api/**` or `apps/api`) wire `@repo/infra` with `@repo/application` and invoke use cases. Handlers obtain the auth gateway from the container — never embed Supabase in a `page.tsx`.
 - Never import concrete repositories from presentation code.
 - React components must contain no business logic.
 

--- a/docs/04-APPLICATION-LAYER.md
+++ b/docs/04-APPLICATION-LAYER.md
@@ -57,6 +57,9 @@ Repository interfaces for **Portfolio** and **Identity** live in `@repo/core`. S
 | `IProfileRepository` | `@repo/core/portfolio` | defined |
 | `IUserRepository` | `@repo/core/identity` | defined |
 | `IEmailService` | `@repo/application/contact` | implemented (`ResendEmailService` in `@repo/infra`) |
+| `IAuthenticationGateway` | `@repo/application/identity` (planned) | **Planned** — sessão/sign-in sem acoplar o front ao IdP; ver [11-IDENTITY](./11-IDENTITY.md) |
+
+The **authentication gateway** abstracts reading and establishing sessions from HTTP cookies. **Supabase** (or another IdP) lives only in an adapter in **`@repo/infra`**. The browser calls **`/api/v1/auth/*`** only.
 
 `IEmailService` signature:
 
@@ -82,14 +85,17 @@ interface IEmailService {
 
 ### Identity
 
-Identity is modeled as its **own bounded context** in `packages/core` (`User`, `Role`, `IUserRepository`, `UnauthorizedError`). Application use cases enforce **authorization rules** (who may act), while **authentication** (session / tokens) is resolved at the HTTP edge (cookies, headers) and passed in as inputs such as `userId`.
+Identity is modeled as its **own bounded context** in `packages/core` (`User`, `Role`, `IUserRepository`, `UnauthorizedError`). **Authorization** use cases take `userId` after the handler resolves session → `authSubject` → `User.id` (when `authSubject` and gateway exist). **Authentication** is delegated to **`IAuthenticationGateway`** at the composition root — not to React.
 
 | Use case | Port(s) | Input | Output | Status |
 |----------|---------|-------|--------|--------|
 | `GetCurrentUser` | `IUserRepository` | `{ userId }` | `UserDTO` | implemented |
 | `EnsureAdmin` | `IUserRepository` | `{ userId }` | `void` | implemented |
+| `EnsureAppUserForAuthSession` | `IUserRepository` | `{ authSubject, email, defaultName? }` | application `userId` (`string`) | **planned** |
 
 `EnsureAdmin` returns `UnauthorizedError` when the user exists but is not `Role.ADMIN`. Route handlers map that to **401** (see [05-API-CONTRACTS](./05-API-CONTRACTS.md)).
+
+`EnsureAppUserForAuthSession` (planned): link `authSubject` to an existing `User` by email or create a `VISITOR`; used after sign-in and on `GET /api/v1/me`.
 
 ### Contact
 
@@ -160,9 +166,11 @@ packages/application/src/
   identity/
     dtos/
       UserDTO.ts
+    ports/                    ← planned: IAuthenticationGateway
     use-cases/
       GetCurrentUser.ts
       EnsureAdmin.ts
+      EnsureAppUserForAuthSession.ts   ← planned
   contact/
     dtos/
     ports/

--- a/docs/05-API-CONTRACTS.md
+++ b/docs/05-API-CONTRACTS.md
@@ -36,10 +36,11 @@ All API responses follow a consistent envelope:
 |----------------------------|-------------|
 | `ValidationError` / invalid input | 400 |
 | `NotFoundError` | 404 |
-| `UnauthorizedError` (e.g. `EnsureAdmin` when user is not admin) | 401 |
+| Missing session / no resolvable application `userId` | 401 (`AUTH_REQUIRED`) |
+| `UnauthorizedError` / failed `EnsureAdmin` | 401 (`UNAUTHORIZED`) |
 | Unexpected / infrastructure | 500 |
 
-Use **403** only when you introduce a distinct “authenticated but forbidden for this resource” rule; today `UnauthorizedError` maps to **401** for failed privilege checks.
+Use **403** for “authenticated but forbidden **for this resource**” (ex.: recurso de outro dono). Sessão ausente e falta de papel admin usam **401** com códigos distintos.
 
 ---
 
@@ -55,7 +56,10 @@ Examples:
 | `ERROR_INVALID_TEXT` | 400 | Text length constraint violated |
 | `INVALID_SLUG` | 400 | Slug format violated |
 | `NOT_FOUND` | 404 | Resource not found |
-| `UNAUTHORIZED` | 401 | Not allowed (e.g. not admin) |
+| `AUTH_REQUIRED` | 401 | Sem sessão ou impossível resolver `userId` |
+| `UNAUTHORIZED` | 401 | Autenticado mas sem permissão (ex.: não é `ADMIN`) |
+| `AUTH_INVALID_CREDENTIALS` | 401 | Sign-in rejeitado pelo IdP (planeado) |
+| `AUTH_SUBJECT_CONFLICT` | 409 | Email já ligado a outro `authSubject` (planeado) |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |
 
 ---
@@ -68,7 +72,11 @@ try {
   if (result.isLeft()) {
     const { code } = result.value;
     const status =
-      code === 'NOT_FOUND' ? 404 : code === 'UNAUTHORIZED' ? 401 : 400;
+      code === 'NOT_FOUND'
+        ? 404
+        : code === 'UNAUTHORIZED' || code === 'AUTH_REQUIRED'
+          ? 401
+          : 400;
     const message = translateError(code, locale) ?? result.value.message;
     return Response.json({ data: null, error: { code, message } }, { status });
   }
@@ -93,15 +101,32 @@ try {
 
 ---
 
+## Authentication (contract — implementation pending)
+
+- **Pluggable provider:** session and sign-in go through **`IAuthenticationGateway`** (`@repo/application`), implemented in **`@repo/infra`** (e.g. Supabase). Route handlers use the **container** — not `@supabase/*` in `page.tsx` or `middleware.ts`. See [11-IDENTITY](./11-IDENTITY.md).
+- **Mechanism:** cookie-based session after successful sign-in; cookie names are an infra detail.
+- **Resolution:** handler obtains **`authSubject`** (opaque external id) from the gateway, maps to application `User.id` via **`authSubject`** column + `IUserRepository` (when implemented), then passes `userId` to use cases.
+- **Passwords:** never stored in the application `User` table — only at the IdP.
+
+### Auth routes (planned)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/api/v1/auth/sign-in` | Body `{ email, password }` → gateway → cookies; then sync/link `User` (planned use case). |
+| `POST` | `/api/v1/auth/sign-out` | Clear session via gateway. |
+| `POST` | `/api/v1/auth/refresh` | Refresh session cookies (optional; same-origin from layout/middleware). |
+
+---
+
 ## Authorization model (overview)
 
 | Audience | Typical use |
 |----------|-------------|
 | **Anonymous** | Public read endpoints (portfolio content), `POST /contact` |
-| **Authenticated** | `GET /me` — requires a valid session; resolves `userId` for `GetCurrentUser` |
-| **Admin** | Mutations and admin-only reads — handler runs `EnsureAdmin` with the current `userId` before proceeding |
+| **Authenticated** | `GET /me` — valid session + `User` row; `GetCurrentUser` |
+| **Admin** | All routes under `/api/v1/admin/*` — after session resolution, `EnsureAdmin.execute({ userId })`; failure → **401** `UNAUTHORIZED` |
 
-Exact session mechanics (Supabase Auth, cookies, headers) live in **infra** and **middleware**; the API contract assumes the handler can obtain a stable `userId` for logged-in requests.
+Session details: [11-IDENTITY](./11-IDENTITY.md).
 
 ---
 
@@ -131,9 +156,24 @@ Query parameters such as `locale` should align with `@repo/core` `Locale` and ex
 
 | Method | Path | Use case | Auth |
 |--------|------|----------|------|
-| `GET` | `/api/v1/me` | `GetCurrentUser` | **Session required** — without a resolvable `userId`, respond with **401** |
+| `GET` | `/api/v1/me` | `GetCurrentUser` | **Authenticated** — sem sessão / sem `User` → **401** `AUTH_REQUIRED` |
 
-Admin-only routes (e.g. future `PATCH /api/v1/projects/:slug`) must call `EnsureAdmin.execute({ userId })` before applying changes; failure → **401** with `UNAUTHORIZED`.
+---
+
+### Admin-only endpoints (`/api/v1/admin/*`) — planned
+
+**Rule:** every handler under this prefix calls `EnsureAdmin` after resolving `userId`. Missing session → **401** `AUTH_REQUIRED`; not admin → **401** `UNAUTHORIZED`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/api/v1/admin/projects` | Create project (`DRAFT`) |
+| `PATCH` | `/api/v1/admin/projects/:slug` | Update project |
+| `POST` | `/api/v1/admin/projects/:slug/publish` | Publish |
+| `POST` | `/api/v1/admin/projects/:slug/archive` | Archive |
+| `PATCH` | `/api/v1/admin/profile` | Update profile |
+| `POST` / `PATCH` / `DELETE` | `/api/v1/admin/experiences` … | CRUD experiences |
+
+Public reads under `/api/v1/projects`, `/api/v1/profile`, etc. stay **public** and return only published (or policy-approved) data.
 
 ---
 

--- a/docs/10-GLOSSARY.md
+++ b/docs/10-GLOSSARY.md
@@ -97,7 +97,15 @@ A contact form submission. Contains name, email, and message body.
 
 ### User
 
-Aggregate root em `@repo/core/identity`. Identificador (`Id`), `Name`, `Email`, `Role`. Métodos `isAdmin()` / `isVisitor()` para regras de autorização no domínio. O vínculo com o fornecedor de auth (ex.: `sub` do Supabase) pode ser mapeado na infraestrutura ao resolver `userId` na borda HTTP.
+Aggregate root em `@repo/core/identity`. Identificador (`Id`), `Name`, `Email`, `Role`. Métodos `isAdmin()` / `isVisitor()`. O vínculo com o IdP será tipicamente uma coluna **`authSubject`** (UUID estável, ex. `sub` do Supabase) na persistência — **planeado**; senhas ficam só no IdP.
+
+### authSubject
+
+Identificador externo do utilizador no provedor de auth (ex. id em `auth.users`). Liga a sessão ao registo `User` da aplicação; ver [11-IDENTITY](./11-IDENTITY.md).
+
+### IAuthenticationGateway (application port)
+
+Contrato para ler sessão, sign-in, sign-out e refresh **sem** expor Supabase à application ou ao front. Implementação concreta na infra; ver [11-IDENTITY](./11-IDENTITY.md).
 
 ### Role
 

--- a/docs/11-IDENTITY.md
+++ b/docs/11-IDENTITY.md
@@ -1,17 +1,57 @@
 # 11 — Identity
 
-> Bounded context de identidade: utilizadores, papéis e autorização. Complementa [03-BOUNDED-CONTEXTS](./03-BOUNDED-CONTEXTS.md) e [05-API-CONTRACTS](./05-API-CONTRACTS.md).
+> Bounded context de identidade: utilizadores, papéis, **autenticação** (sessão) e **autorização** (admin). Complementa [03-BOUNDED-CONTEXTS](./03-BOUNDED-CONTEXTS.md) e [05-API-CONTRACTS](./05-API-CONTRACTS.md).
 
 ---
 
 ## O que é “auth” neste projeto
 
-Em DDD, **Identity** é um **bounded context** próprio: modela *quem* é o utilizador e *que* pode fazer no sistema (via `Role` e casos de uso como `EnsureAdmin`). **Não** é apenas “middleware”: a regra de negócio “só ADMIN pode…” vive no domínio e na camada de aplicação.
+Em DDD, **Identity** é um **bounded context** próprio: modela *quem* é o utilizador e *que* pode fazer no sistema (via `Role` e casos de uso como `EnsureAdmin`). **Não** é apenas “middleware”: a regra “só ADMIN pode…” vive no domínio e na camada de aplicação.
 
-- **Autenticação** (prova de identidade — sessão, JWT, Supabase Auth): mecanismo na **infra** + borda HTTP (cookies, headers).
-- **Autorização** (permissão para uma ação): **`EnsureAdmin`**, futuros policies, e leitura de utilizador com **`GetCurrentUser`** — sempre invocados a partir de **route handlers**, nunca a partir de componentes React.
+- **Autenticação** (sessão, credenciais): deve ser abstraída por um **porto na application** (`IAuthenticationGateway`), com **implementação na infra** (ex.: Supabase). O **front-end** não referencia o SDK do fornecedor.
+- **Autorização:** **`EnsureAdmin`**, **`GetCurrentUser`**, e futuros casos de uso — invocados **apenas** a partir de **route handlers**, nunca a partir de componentes React.
 
-O **front-end** consome apenas **REST**; não importa `@repo/application` para Identity.
+O **front-end** consome apenas **REST**; não importa `@repo/application` nem **`@supabase/*`**.
+
+---
+
+## Senhas e `authSubject` (modelo alvo)
+
+- **O projeto não armazena senhas** na tabela de aplicação (`User` no Prisma). Credenciais ficam no **provedor de auth** (ex.: `auth.users` no Supabase).
+- Na **tua** base guardas perfil e papéis, e uma coluna estável que liga à conta de auth — por exemplo **`authSubject`** (UUID igual ao id do utilizador no Supabase Auth / claim `sub` do JWT).
+- Fluxo mental: `auth.users` (IdP) ↔ `User` (Prisma) via `authSubject`; email e nome podem existir nos dois lados, mas a **senha** só no IdP.
+
+---
+
+## Fornecedor plugável (Clean Architecture)
+
+| Layer | O que pode saber sobre Supabase (ou outro IdP) |
+|-------|-----------------------------------------------|
+| **`apps/web` (UI, `middleware.ts`)** | **Nada.** Só `fetch` a `/api/v1/...`. |
+| **`apps/web/app/api/**` (Route Handlers)** | **Não** importar `@supabase/*`. Usar `getContainer()` e o porto `IAuthenticationGateway` em `@repo/infra`. |
+| **`@repo/application`** | Só o **contrato** do porto (`AuthCookieApi`, `IAuthenticationGateway`, DTOs de erro). Sem SDK do IdP. |
+| **`@repo/infra`** | **Única** camada com `@supabase/supabase-js` / `@supabase/ssr` enquanto esse for o adaptador. Outro fornecedor = nova classe + wiring. |
+
+**Ponte Next.js (fina):** um helper `createNextAuthCookieApi()` em `apps/web` pode mapear `cookies()` de `next/headers` para `AuthCookieApi` — é cola de framework, **não** é Supabase.
+
+---
+
+## Fluxo alvo (email + password)
+
+```text
+Browser          Route Handler              @repo/infra                    BD
+   │                    │                         │                          │
+   │── POST sign-in ───►│── container.gateway ─────►│ adaptador (ex. Supabase)  │
+   │                    │◄── Set-Cookie ───────────│                          │
+   │                    │── principal (sub, email) ───────────────────────────►│
+   │                    │── EnsureAppUserForAuthSession (planeado)              │
+   │                    │── GetCurrentUser(userId)                               │
+   │◄── UserDTO ────────│                                                      │
+```
+
+1. Login: `POST /api/v1/auth/sign-in` com JSON `{ email, password }` — o adaptador valida no IdP e define cookies de sessão.
+2. Sessão: handlers leem cookies via gateway → **`authSubject`** + email → repositório resolve ou cria `User` (ver [plans/identity-mvp.md](../plans/identity-mvp.md)).
+3. `GET /api/v1/me`: mesmo pipeline até `GetCurrentUser`.
 
 ---
 
@@ -19,48 +59,43 @@ O **front-end** consome apenas **REST**; não importa `@repo/application` para I
 
 | Layer | Conteúdo |
 |-------|----------|
-| **core** (`@repo/core/identity`) | `User`, `Role`, `IUserRepository`, `UnauthorizedError` |
+| **core** | `User`, `Role`, `IUserRepository`, `UnauthorizedError` |
 | **application** | `GetCurrentUser`, `EnsureAdmin`, `UserDTO` |
-| **infra** | Implementação de `IUserRepository` (ex.: Prisma), utilizadores em BD |
+| **infra** | `PrismaUserRepository`, tabela `User` |
+| **Planeado** | `IAuthenticationGateway`, `EnsureAppUserForAuthSession`, coluna `authSubject`, rotas `auth/*`, handlers REST |
 
-Rotas HTTP (`/api/v1/me`, etc.) estão descritas em [05-API-CONTRACTS](./05-API-CONTRACTS.md); a implementação dos Route Handlers pode acompanhar o roadmap.
+Contrato HTTP: [05-API-CONTRACTS](./05-API-CONTRACTS.md). Plano por fases: [plans/identity-mvp.md](../plans/identity-mvp.md).
 
 ---
 
 ## Papéis
 
-`Role` é um enum em `packages/core`:
-
-- `ADMIN` — acesso a operações de gestão (quando expostas pela API).
-- `VISITOR` — utilizador autenticado sem privilégios de administração.
-
-`EnsureAdmin` devolve `UnauthorizedError` (código `UNAUTHORIZED`) quando o utilizador não é `ADMIN` — mapeado a **401** na API.
+- **ADMIN** — endpoints `/api/v1/admin/*` e UI `/{locale}/admin/*` (quando existirem).
+- **VISITOR** — autenticado sem privilégios de admin; `GET /api/v1/me` permitido; admin API → **401** após `EnsureAdmin`.
 
 ---
 
-## Casos de uso
+## Casos de uso (hoje e alvo)
 
-| Caso de uso | Finalidade |
-|-------------|------------|
-| `GetCurrentUser` | Dado um `userId` válido (já extraído da sessão na borda), devolve `UserDTO`. |
-| `EnsureAdmin` | Garante que o utilizador existe e é `ADMIN`; caso contrário falha com `UnauthorizedError`. |
-
-O **nível de acesso** a cada endpoint HTTP é definido na camada de interface: rotas públicas sem sessão; rotas autenticadas exigem sessão e passam `userId` aos casos de uso; rotas admin chamam `EnsureAdmin` antes de mutações.
+| Caso de uso | Finalidade | Estado |
+|-------------|------------|--------|
+| `GetCurrentUser` | Dado `userId` de domínio, devolve `UserDTO`. | Implementado |
+| `EnsureAdmin` | Utilizador existe e é `ADMIN`; senão `UnauthorizedError`. | Implementado |
+| `EnsureAppUserForAuthSession` | Liga `authSubject` ao `User` (por subject ou email) ou cria `VISITOR`. | **Planeado** |
 
 ---
 
-## UI (planeado / em curso)
+## UI (planeado)
 
-- `/[locale]/login` — login (email + senha ou fluxo do fornecedor).
-- `/[locale]/admin/*` — área protegida; o servidor deve validar sessão e, nas operações sensíveis, alinhar com `EnsureAdmin` no handler.
-
-Detalhes de fases em [plans/identity-mvp.md](../plans/identity-mvp.md) e [ROADMAP](./ROADMAP.md).
+- `/{locale}/login` — formulário + `fetch` a **`POST /api/v1/auth/sign-in`** (sem SDK do IdP no cliente).
+- `/{locale}/admin/*` — dados via `/api/v1/me` e `/api/v1/admin/*`.
 
 ---
 
 ## Ver também
 
-- [03-BOUNDED-CONTEXTS](./03-BOUNDED-CONTEXTS.md) — mapa de contextos
-- [04-APPLICATION-LAYER](./04-APPLICATION-LAYER.md) — lista de casos de uso
-- [ROADMAP](./ROADMAP.md) — fase Identity
-- [packages/infra/README.md](../packages/infra/README.md) — schema e repositórios
+- [02-ARCHITECTURE](./02-ARCHITECTURE.md) — regras da camada interface
+- [04-APPLICATION-LAYER](./04-APPLICATION-LAYER.md) — portos e casos de uso
+- [05-API-CONTRACTS](./05-API-CONTRACTS.md) — rotas e códigos de erro
+- [ROADMAP](./ROADMAP.md)
+- [packages/infra/README.md](../packages/infra/README.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -58,7 +58,7 @@
 - **[packages/core/README.md](../packages/core/README.md)** — Core package overview, links to 02-ARCHITECTURE and 03-BOUNDED-CONTEXTS
 - **[packages/core/decisions/](../packages/core/decisions/)** — Architectural Decision Records (ADRs)
 - **[ROADMAP.md](./ROADMAP.md)** — Product roadmap and sprint planning
-- **[plans/identity-mvp.md](../plans/identity-mvp.md)** — Plano de implementação Identity (MVP)
+- **[plans/identity-mvp.md](../plans/identity-mvp.md)** — Plano: gateway de auth plugável, `authSubject`, REST `auth/*` e admin
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,15 +67,17 @@ Evolution view for the portfolio, aligned with Clean Architecture, DDD, i18n, an
 
 ## Phase 4 — Identity (sessions and admin UI)
 
-> Domain and application layers for Identity are in place. Remaining work is **HTTP session integration**, **middleware**, and **admin UI**.
+> Core + application já têm `User`, `GetCurrentUser`, `EnsureAdmin`. Falta **gateway de auth**, **`authSubject`**, **rotas REST** e UI — ver [plans/identity-mvp.md](../plans/identity-mvp.md).
 
 - [x] **Domain** (`packages/core`): `User`, `Role`, `IUserRepository`, `UnauthorizedError`
 - [x] **Infrastructure**: Prisma `User` model and repository
 - [x] **Application**: `GetCurrentUser`, `EnsureAdmin`
-- [ ] **Sessions**: middleware; resolve `userId` for authenticated routes
-- [ ] **Web**: `/[locale]/login`, `/[locale]/admin/*` layouts protected consistently with API rules
+- [ ] **`IAuthenticationGateway`** + adaptador Supabase **só em `@repo/infra`**
+- [ ] **Dados**: `User.authSubject`, `findByAuthSubject` / `linkAuthSubject`, caso de uso `EnsureAppUserForAuthSession`
+- [ ] **REST**: `POST /api/v1/auth/sign-in`, `sign-out`, `refresh`, `GET /api/v1/me` ([05-API-CONTRACTS](./05-API-CONTRACTS.md))
+- [ ] **Middleware / Web**: login e admin sem SDK do IdP no cliente
 
-Modelo de papéis: `ADMIN | VISITOR`. Referência: [11-IDENTITY](./11-IDENTITY.md), [plans/identity-mvp.md](../plans/identity-mvp.md).
+Modelo de papéis: `ADMIN | VISITOR`.
 
 ---
 

--- a/packages/infra/README.md
+++ b/packages/infra/README.md
@@ -27,9 +27,9 @@
 
 ## Supabase
 
-- **Função**: Postgres (tabelas `projects`, `posts`, `tags`, etc.), Auth (se necessário para admin/Contact) e Realtime (opcional para Blog).
-- **Cliente**: `@supabase/supabase-js` no Node e, se fizer sentido, no edge (Route Handlers Next.js).
-- **Variáveis**: `SUPABASE_URL`, `SUPABASE_ANON_KEY`; em contextos server-only, `SUPABASE_SERVICE_ROLE_KEY` — **nunca expor no client**.
+- **Função**: Postgres (portfolio, identity, etc.). **Auth** deve passar por um adaptador que implemente **`IAuthenticationGateway`** (`@repo/application`): o SDK **não** deve ser usado em `apps/web` (UI/middleware); apenas em classes deste pacote, chamadas pelos Route Handlers via container ([docs/11-IDENTITY](../../docs/11-IDENTITY.md)).
+- **Cliente**: `@supabase/supabase-js` (e, se necessário, `@supabase/ssr`) **apenas** em `packages/infra`, não no bundle do cliente.
+- **Variáveis**: `SUPABASE_URL`, `SUPABASE_ANON_KEY` para o adaptador no servidor; `SUPABASE_SERVICE_ROLE_KEY` só para operações server-only — **nunca** expor chaves sensíveis ao browser; login via `POST /api/v1/auth/sign-in` quando implementado.
 
 ---
 

--- a/plans/identity-mvp.md
+++ b/plans/identity-mvp.md
@@ -1,23 +1,54 @@
-# Identity — Plano de Implementação (MVP)
+# Identity e autenticação — plano de implementação (documentação)
 
-> Bounded context de autenticação e autorização. **Status:** planejado, não implementado.
+> Este ficheiro descreve **o que implementar**, não código já feito. Contrato e conceitos: [docs/11-IDENTITY.md](../docs/11-IDENTITY.md), [docs/05-API-CONTRACTS.md](../docs/05-API-CONTRACTS.md).
 
-## Decisões arquiteturais
+## Princípios
 
-- **Modelo de papéis**: binário `ADMIN | VISITOR`
-- **Auth**: Supabase Auth (`@supabase/supabase-js`, `@supabase/ssr`)
-- **Rotas protegidas**: `/[locale]/admin/*` → middleware + layout com `EnsureAdminUseCase`
-- **Rotas públicas**: login em `/[locale]/login`
-- **Fora do escopo MVP**: logout, magic link/OAuth, audit log, notification
+- **Sem senha na tabela `User`:** credenciais no IdP (ex. Supabase `auth.users`); na app, `authSubject` + perfil + `role`.
+- **Front sem SDK do IdP:** só `fetch` a `/api/v1/...`; `IAuthenticationGateway` + adaptador em `@repo/infra`.
+- **REST obrigatório** para a camada externa; route handlers compõem container.
 
-## Fases resumidas
+## Fase 0 — Porto `IAuthenticationGateway` (`@repo/application`)
 
-| Fase | Conteúdo |
-|------|----------|
-| 0 | Setup `packages/application` (identity), `packages/infra`, `apps/web` |
-| 1 | Core: Email, Role, User, UnauthorizedError, IUserRepository, AccessPolicy |
-| 2 | Infra: migration `users`, SupabaseUserRepository, seed admin |
-| 3 | Application: GetCurrentUserUseCase, EnsureAdminUseCase |
-| 4 | Web: getAuthenticatedUser, middleware, login, layout admin |
+- Contrato: `signInWithPassword`, `signOut`, `refreshSession`, `getPrincipalFromCookies`, com `AuthCookieApi` (sem tipos Next/Supabase no contrato).
+- **Critério:** interface estável + testes com fake.
 
-Ver documento completo em [docs/11-IDENTITY.md](../docs/11-IDENTITY.md).
+## Fase 1 — Domínio e dados: `authSubject`
+
+- Migration Prisma: coluna `authSubject` (UUID, único, nullable até ao primeiro login).
+- `IUserRepository`: `findByAuthSubject`, `linkAuthSubject`, e `save` alinhado ao agregado (se ainda não existir no contrato).
+- Validação em `User` para `authSubject` opcional (UUID).
+
+## Fase 2 — Adaptador Supabase (`@repo/infra`)
+
+- `SupabaseAuthenticationGateway implements IAuthenticationGateway`.
+- Dependências `@supabase/supabase-js`, `@supabase/ssr` **só** neste pacote.
+- Env: `SUPABASE_URL`, `SUPABASE_ANON_KEY` (servidor; ver [.env.example](../.env.example)).
+- Registar `authGateway` no `makeContainer()`.
+
+## Fase 3 — REST: `auth/*`, `GET /api/v1/me`
+
+- `POST /api/v1/auth/sign-in`, `sign-out`, `refresh`.
+- `GET /api/v1/me` → gateway → `EnsureAppUserForAuthSession` → `GetCurrentUser`.
+- Helper `createNextAuthCookieApi()` em `apps/web` (só `next/headers` → `AuthCookieApi`).
+
+## Fase 4 — `/api/v1/admin/*`
+
+- Mutations com `EnsureAdmin` + casos de uso de escrita (incremental). Ver tabela em [05-API-CONTRACTS](../docs/05-API-CONTRACTS.md).
+
+## Fase 5 — UI
+
+- `/{locale}/login` com `fetch` a sign-in.
+- `/{locale}/admin/*` via `/api/v1/me` e APIs admin.
+- Middleware: redirect sem cookie de sessão; **sem** `@supabase/*` no middleware.
+
+## Riscos
+
+- Prisma no Edge pode ser inviável — manter auth pesado em Route Handlers Node.
+- CSRF / SameSite documentar na infra.
+
+## Referências
+
+- [docs/11-IDENTITY.md](../docs/11-IDENTITY.md)
+- [docs/04-APPLICATION-LAYER.md](../docs/04-APPLICATION-LAYER.md)
+- [docs/ROADMAP.md](../docs/ROADMAP.md)


### PR DESCRIPTION
This pull request updates documentation only (no runtime code).

## Summary

- **Architecture:** No IdP SDK in `apps/web`; auth stays behind `IAuthenticationGateway` in `@repo/infra` and REST routes (02, 11, CLAUDE).
- **Identity:** Full narrative on passwords at the IdP, `authSubject` linking, planned `EnsureAppUserForAuthSession`, and layer table.
- **API contracts:** `AUTH_*` codes, planned `/api/v1/auth/*`, admin surface under `/api/v1/admin/*`.
- **Glossary, roadmap (phase 4),** `plans/identity-mvp.md`, **infra README**, **.env.example** (commented `SUPABASE_*` for future use).

Commits use `git -c commit.gpgsign=false` where signing is unavailable in CI/sandbox.

Made with [Cursor](https://cursor.com)