### PR TITLE
refactor(utils): remover Validator.combine

### DIFF
--- a/docs/06-VALIDATION.md
+++ b/docs/06-VALIDATION.md
@@ -79,7 +79,6 @@ static create(raw?: string): Either<ValidationError, Slug> {
 | `.nil(error)` | Value is `null` or `undefined` |
 | `.notNil(error)` | Value is not `null` or `undefined` |
 | `.refine(predicate, error)` | Arbitrary predicate function |
-| `Validator.combine(...validators)` | Runs multiple validators; returns first error |
 
 ---
 

--- a/packages/utils/src/validator/Validator.ts
+++ b/packages/utils/src/validator/Validator.ts
@@ -21,23 +21,6 @@ export class Validator<TValue> {
     return new Validator<TValue>(value);
   }
 
-  static combine<TValue>(...validators: Validator<TValue>[]) {
-    let isValid = true;
-    let error: string | null = null;
-
-    for (const validation of validators) {
-      const { isValid: validationValid, error: validationError } =
-        validation.validate();
-
-      isValid = validationValid;
-      error = validationError;
-
-      if (!isValid && error) break;
-    }
-
-    return { isValid, error };
-  }
-
   private append(validation: Validation, error: string) {
     this._validations.push([validation, error]);
 

--- a/packages/utils/test/node/Validator.test.ts
+++ b/packages/utils/test/node/Validator.test.ts
@@ -18,29 +18,6 @@ describe('Validator', () => {
     });
   });
 
-  describe('combine', () => {
-    it('should combine validate', () => {
-      const validator = Validator.combine(
-        Validator.of('value').notNil('NOT_NIL_ERROR'),
-        Validator.of('value').string('STRING_ERROR'),
-        Validator.of('value').alpha('ALPHA_ERROR'),
-        Validator.of('value').length(1, 5, 'LENGTH_ERROR'),
-      );
-
-      expect(validator.error).toBeNull();
-      expect(validator.isValid).toBe(true);
-    });
-
-    it('should not combine validate', () => {
-      const validator = Validator.combine(
-        Validator.of('value').length(1, 3, 'LENGTH_ERROR'),
-      );
-
-      expect(validator.error).toBe('LENGTH_ERROR');
-      expect(validator.isValid).toBe(false);
-    });
-  });
-
   describe('length', () => {
     it('should validate', () => {
       const validator = Validator.of('value')


### PR DESCRIPTION
## Summary

Remove `Validator.combine()` — método estático que nunca foi usado em código de produção (apenas em 2 testes).

**Motivação**: `combine` induz um design errado — sugere que se deve usar `Validator` para agregar validações de múltiplos campos de um objecto. O padrão correcto no projeto já é `collect()` do Either module: cada campo é um VO com `static create()`, e os resultados são agregados em `collect([...])` nas entidades. Manter `combine` era uma API incompleta e enganosa.

## Alterações

- `packages/utils/src/validator/Validator.ts` — remove `static combine<TValue>()`
- `packages/utils/test/node/Validator.test.ts` — remove `describe('combine', ...)`  
- `docs/06-VALIDATION.md` — remove linha da tabela de referência

## Test plan

- [x] `pnpm --filter utils test` — 81 testes passam, 100% coverage em `Validator.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)