### PR TITLE
refactor(infra): preparar infraestrutura para imports absolutos

### DIFF
--- a/packages/utils/jest.config.ts
+++ b/packages/utils/jest.config.ts
@@ -8,6 +8,9 @@ const jestConfig: JestConfigWithTsJest = {
     '!<rootDir>/src/types/**/*.ts',
   ],
   maxWorkers: 2,
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/src/$1',
+  },
   projects: [
     {
       displayName: 'node',

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "baseUrl": "src",
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "paths": {
+      "~/*": ["*"]
+    }
   },
   "include": ["src/**/*.ts", "jest.config.ts", "test/**/*.ts"],
   "exclude": ["node_modules", "dist", "build"]

--- a/scripts/migrate-to-absolute-imports.js
+++ b/scripts/migrate-to-absolute-imports.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Migrates intra-package relative imports to absolute ~/... imports.
+ *
+ * PREREQUISITE — TypeScript project references:
+ *   This script produces correct results only when each package compiles
+ *   to its own d.ts declarations (composite: true + declarationDir). In the
+ *   current setup all packages expose raw TypeScript source via `exports`
+ *   in package.json. TypeScript resolves path aliases (~/...) using the
+ *   COMPILING project's tsconfig, not the imported package's tsconfig.
+ *   This means ~/foo in package A fails when read by package B.
+ *
+ *   Until project references are configured, run this script ONLY on
+ *   packages that are not transitively imported by any other TypeScript
+ *   project in the monorepo.
+ *
+ * Usage:
+ *   node scripts/migrate-to-absolute-imports.js
+ *
+ * Requirements per package:
+ *   - tsconfig.json: baseUrl:"src", paths:{ "~/*": ["*"] }
+ *   - vitest.config.ts: resolve.alias:{ "~": path.resolve(__dirname, "./src") }
+ *   - (Jest) jest.config.ts: moduleNameMapper:{ "^~/(.*)$": "<rootDir>/src/$1" }
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// [label, srcDir] pairs — order: fewest deps first
+const PACKAGES = [
+  ['utils', path.join(ROOT, 'packages/utils/src')],
+  ['core', path.join(ROOT, 'packages/core/src')],
+  ['application', path.join(ROOT, 'packages/application/src')],
+  ['infra', path.join(ROOT, 'packages/infra/src')],
+];
+
+// Matches: from './foo', from '../foo/bar', from "../../baz"
+const RELATIVE_IMPORT_RE = /\bfrom\s+(['"])(\.\.?\/[^'"]+)\1/g;
+
+function getAllTsFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...getAllTsFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.ts')) files.push(full);
+  }
+  return files;
+}
+
+function migrateFile(file, srcDir) {
+  const original = fs.readFileSync(file, 'utf8');
+  const fileDir = path.dirname(file);
+
+  const updated = original.replace(
+    RELATIVE_IMPORT_RE,
+    (match, quote, specifier) => {
+      const absolute = path.resolve(fileDir, specifier);
+      const fromSrc = path.relative(srcDir, absolute).split(path.sep).join('/');
+      return `from ${quote}~/${fromSrc}${quote}`;
+    },
+  );
+
+  if (updated === original) return false;
+  fs.writeFileSync(file, updated);
+  return true;
+}
+
+let totalFiles = 0;
+
+for (const [label, srcDir] of PACKAGES) {
+  if (!fs.existsSync(srcDir)) {
+    console.log(`[${label}] src dir not found, skipping`);
+    continue;
+  }
+
+  const files = getAllTsFiles(srcDir);
+  let changed = 0;
+
+  for (const file of files) {
+    if (migrateFile(file, srcDir)) {
+      console.log(`  ${path.relative(ROOT, file)}`);
+      changed++;
+    }
+  }
+
+  console.log(`[${label}] ${changed}/${files.length} files updated`);
+  totalFiles += changed;
+}
+
+console.log(`\nDone. ${totalFiles} files updated total.`);


### PR DESCRIPTION
## Contexto

A migração de imports relativos para absolutos (`~/`) não pode ser executada enquanto todos os packages expõem arquivos TypeScript fonte diretamente via `exports` no `package.json` (sem compilação para `.d.ts`).

Quando o TypeScript compila um package e segue um import cross-package para o arquivo fonte de outro package, os aliases `~/` são resolvidos usando o tsconfig do package **compilador** — não do package importado. Isso faz `~/foo` em `application/src/` falhar quando lido por `infra`, por exemplo.

**Pré-requisito para desbloquear:** configurar TypeScript project references (`composite: true` + `declarationDir`) em cada package, fazendo com que a resolução cross-package use arquivos `.d.ts` gerados (onde aliases não existem).

## O que foi feito

- `packages/utils/tsconfig.json` — adicionado alias `~/*` → `*` (alinha `utils` com `core`, `application` e `infra`, que já tinham o alias)
- `packages/utils/jest.config.ts` — adicionado `moduleNameMapper: { "^~/(.*)$": "<rootDir>/src/$1" }` (necessário para Jest reconhecer o alias nos testes)
- `scripts/migrate-to-absolute-imports.js` — script de migração documentado com a pré-condição e pronto para execução futura

## Arquivos

- `packages/utils/tsconfig.json`
- `packages/utils/jest.config.ts`
- `scripts/migrate-to-absolute-imports.js` (novo)

## Critério de aceite

- [x] Testes de `@repo/utils` passam com a nova configuração (81 testes)
- [x] TypeScript sem erros em todos os packages
- [x] Script documentado e pronto para uso após configuração de project references

🤖 Generated with [Claude Code](https://claude.com/claude-code)