### PR TITLE
[T-47] feat(application): add IAuthenticationGateway port and AuthCookieApi

### DIFF
--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "exports": {
     ".": { "types": "./dist/types/index.d.ts", "default": "./src/index.ts" },
+    "./identity": { "types": "./dist/types/identity/index.d.ts", "default": "./src/identity/index.ts" },
     "./portfolio": { "types": "./dist/types/portfolio/index.d.ts", "default": "./src/portfolio/index.ts" },
     "./contact": { "types": "./dist/types/contact/index.d.ts", "default": "./src/contact/index.ts" }
   },

--- a/packages/application/src/identity/dtos/AuthPrincipal.ts
+++ b/packages/application/src/identity/dtos/AuthPrincipal.ts
@@ -1,0 +1,6 @@
+export type AuthPrincipal = {
+  /** Stable IdP subject identifier (e.g. Supabase `sub`). */
+  id: string;
+  email: string;
+  role: string;
+};

--- a/packages/application/src/identity/dtos/AuthSession.ts
+++ b/packages/application/src/identity/dtos/AuthSession.ts
@@ -1,0 +1,8 @@
+export type AuthSession = {
+  /** Short-lived JWT access token. */
+  accessToken: string;
+  /** Opaque refresh token used to obtain a new session. */
+  refreshToken: string;
+  /** Session expiry as a Unix timestamp (seconds). */
+  expiresAt: number;
+};

--- a/packages/application/src/identity/dtos/index.ts
+++ b/packages/application/src/identity/dtos/index.ts
@@ -1,1 +1,3 @@
+export * from '~/identity/dtos/AuthPrincipal';
+export * from '~/identity/dtos/AuthSession';
 export * from '~/identity/dtos/UserDTO';

--- a/packages/application/src/identity/index.ts
+++ b/packages/application/src/identity/index.ts
@@ -1,2 +1,3 @@
 export * from '~/identity/dtos';
+export * from '~/identity/ports';
 export * from '~/identity/use-cases';

--- a/packages/application/src/identity/ports/AuthCookieApi.ts
+++ b/packages/application/src/identity/ports/AuthCookieApi.ts
@@ -1,0 +1,21 @@
+export type CookieSetOptions = {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: 'lax' | 'strict' | 'none';
+  /** Max-age in seconds. */
+  maxAge?: number;
+  path?: string;
+};
+
+/**
+ * Framework-agnostic cookie accessor.
+ *
+ * The application layer depends on this interface; the infrastructure layer
+ * (e.g. Next.js route handlers) provides the concrete implementation.
+ * This keeps `@repo/application` free of any `next/headers` import.
+ */
+export interface AuthCookieApi {
+  get(name: string): string | undefined;
+  set(name: string, value: string, options?: CookieSetOptions): void;
+  delete(name: string): void;
+}

--- a/packages/application/src/identity/ports/IAuthenticationGateway.ts
+++ b/packages/application/src/identity/ports/IAuthenticationGateway.ts
@@ -1,0 +1,48 @@
+import { DomainError, Either } from '@repo/core/shared';
+
+import { AuthPrincipal } from '~/identity/dtos/AuthPrincipal';
+import { AuthSession } from '~/identity/dtos/AuthSession';
+import { AuthCookieApi } from '~/identity/ports/AuthCookieApi';
+
+export type SignInWithPasswordInput = {
+  email: string;
+  password: string;
+};
+
+/**
+ * Port for authentication operations.
+ *
+ * Implemented by the infrastructure layer (e.g. SupabaseAuthenticationGateway).
+ * Must never import `@supabase/*` or `next/headers` here.
+ */
+export interface IAuthenticationGateway {
+  /**
+   * Authenticate with email and password.
+   * Returns an `AuthSession` on success; the caller is responsible for
+   * persisting the tokens in cookies via `AuthCookieApi`.
+   */
+  signInWithPassword(
+    credentials: SignInWithPasswordInput,
+  ): Promise<Either<DomainError, AuthSession>>;
+
+  /**
+   * Invalidate the current session.
+   * Reads the access token from cookies to identify the session at the IdP.
+   */
+  signOut(cookies: AuthCookieApi): Promise<Either<DomainError, void>>;
+
+  /**
+   * Obtain a fresh session using the refresh token stored in cookies.
+   * Returns a new `AuthSession`; the caller updates the cookies.
+   */
+  refreshSession(cookies: AuthCookieApi): Promise<Either<DomainError, AuthSession>>;
+
+  /**
+   * Decode and validate the access token stored in cookies.
+   * Returns the authenticated principal without a network round-trip when
+   * using locally-verifiable JWTs.
+   */
+  getPrincipalFromCookies(
+    cookies: AuthCookieApi,
+  ): Promise<Either<DomainError, AuthPrincipal>>;
+}

--- a/packages/application/src/identity/ports/index.ts
+++ b/packages/application/src/identity/ports/index.ts
@@ -1,0 +1,2 @@
+export * from '~/identity/ports/AuthCookieApi';
+export * from '~/identity/ports/IAuthenticationGateway';

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,4 +1,4 @@
 export * from '~/shared';
 export * from '~/contact';
-export * from '~/portfolio';
 export * from '~/identity';
+export * from '~/portfolio';

--- a/packages/application/test/identity/FakeAuthenticationGateway.ts
+++ b/packages/application/test/identity/FakeAuthenticationGateway.ts
@@ -1,0 +1,112 @@
+import { DomainError, Either, left, right } from '@repo/core/shared';
+
+import { AuthCookieApi } from '~/identity/ports/AuthCookieApi';
+import { IAuthenticationGateway, SignInWithPasswordInput } from '~/identity/ports/IAuthenticationGateway';
+import { AuthPrincipal } from '~/identity/dtos/AuthPrincipal';
+import { AuthSession } from '~/identity/dtos/AuthSession';
+
+const ACCESS_TOKEN_COOKIE = 'sb-access-token';
+const REFRESH_TOKEN_COOKIE = 'sb-refresh-token';
+
+type StoredUser = { password: string; principal: AuthPrincipal };
+
+/**
+ * In-memory test double for IAuthenticationGateway.
+ *
+ * Seed credentials via the constructor; optionally inject errors to simulate
+ * IdP failures. Tokens are plain strings of the form `<type>:<email>:<nonce>`.
+ */
+export class FakeAuthenticationGateway implements IAuthenticationGateway {
+  private readonly users: Map<string, StoredUser>;
+  /** If set, every call returns this error. */
+  private forcedError: DomainError | null = null;
+
+  constructor(users: Record<string, { password: string; principal: AuthPrincipal }> = {}) {
+    this.users = new Map(Object.entries(users));
+  }
+
+  /** Force all subsequent calls to return a Left with this error. */
+  simulateError(error: DomainError): void {
+    this.forcedError = error;
+  }
+
+  /** Remove the forced error so calls behave normally again. */
+  clearError(): void {
+    this.forcedError = null;
+  }
+
+  async signInWithPassword(
+    credentials: SignInWithPasswordInput,
+  ): Promise<Either<DomainError, AuthSession>> {
+    if (this.forcedError) return left(this.forcedError);
+
+    const stored = this.users.get(credentials.email);
+    if (!stored || stored.password !== credentials.password) {
+      return left(new DomainError('INVALID_CREDENTIALS', { message: 'Invalid email or password.' }));
+    }
+
+    return right(this._makeSession(credentials.email));
+  }
+
+  async signOut(cookies: AuthCookieApi): Promise<Either<DomainError, void>> {
+    if (this.forcedError) return left(this.forcedError);
+
+    cookies.delete(ACCESS_TOKEN_COOKIE);
+    cookies.delete(REFRESH_TOKEN_COOKIE);
+    return right(undefined);
+  }
+
+  async refreshSession(cookies: AuthCookieApi): Promise<Either<DomainError, AuthSession>> {
+    if (this.forcedError) return left(this.forcedError);
+
+    const refreshToken = cookies.get(REFRESH_TOKEN_COOKIE);
+    if (!refreshToken) {
+      return left(new DomainError('NO_REFRESH_TOKEN', { message: 'No refresh token in cookies.' }));
+    }
+
+    const email = this._emailFromToken(refreshToken);
+    if (!email || !this.users.has(email)) {
+      return left(new DomainError('INVALID_REFRESH_TOKEN', { message: 'Refresh token is invalid or expired.' }));
+    }
+
+    return right(this._makeSession(email));
+  }
+
+  async getPrincipalFromCookies(
+    cookies: AuthCookieApi,
+  ): Promise<Either<DomainError, AuthPrincipal>> {
+    if (this.forcedError) return left(this.forcedError);
+
+    const accessToken = cookies.get(ACCESS_TOKEN_COOKIE);
+    if (!accessToken) {
+      return left(new DomainError('NO_ACCESS_TOKEN', { message: 'No access token in cookies.' }));
+    }
+
+    const email = this._emailFromToken(accessToken);
+    const stored = email ? this.users.get(email) : undefined;
+    if (!stored) {
+      return left(new DomainError('INVALID_ACCESS_TOKEN', { message: 'Access token is invalid or expired.' }));
+    }
+
+    return right(stored.principal);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private _makeSession(email: string): AuthSession {
+    const nonce = Math.random().toString(36).slice(2);
+    return {
+      accessToken: `access:${email}:${nonce}`,
+      refreshToken: `refresh:${email}:${nonce}`,
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+  }
+
+  private _emailFromToken(token: string): string | null {
+    // Token format: "<type>:<email>:<nonce>"
+    const parts = token.split(':');
+    return parts.length === 3 ? (parts[1] ?? null) : null;
+  }
+}

--- a/packages/application/test/identity/IAuthenticationGateway.test.ts
+++ b/packages/application/test/identity/IAuthenticationGateway.test.ts
@@ -1,0 +1,270 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+
+import { DomainError } from '@repo/core/shared';
+
+import { AuthCookieApi } from '~/identity/ports/AuthCookieApi';
+import { AuthPrincipal } from '~/identity/dtos/AuthPrincipal';
+import { FakeAuthenticationGateway } from './FakeAuthenticationGateway';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** In-memory cookie jar for tests. */
+function makeCookieApi(initial: Record<string, string> = {}): AuthCookieApi & {
+  store: Record<string, string>;
+} {
+  const store: Record<string, string> = { ...initial };
+  return {
+    store,
+    get(name) { return store[name]; },
+    set(name, value) { store[name] = value; },
+    delete(name) { delete store[name]; },
+  };
+}
+
+const ADMIN_PRINCIPAL: AuthPrincipal = { id: 'user-1', email: 'admin@example.com', role: 'ADMIN' };
+const VISITOR_PRINCIPAL: AuthPrincipal = { id: 'user-2', email: 'visitor@example.com', role: 'VISITOR' };
+
+const SEED_USERS = {
+  'admin@example.com': { password: 'secret-admin', principal: ADMIN_PRINCIPAL },
+  'visitor@example.com': { password: 'secret-visitor', principal: VISITOR_PRINCIPAL },
+};
+
+// ---------------------------------------------------------------------------
+// signInWithPassword
+// ---------------------------------------------------------------------------
+
+describe('IAuthenticationGateway — signInWithPassword', () => {
+  let gateway: FakeAuthenticationGateway;
+
+  beforeEach(() => {
+    gateway = new FakeAuthenticationGateway(SEED_USERS);
+  });
+
+  it('should return Right(AuthSession) when credentials are valid', async () => {
+    const result = await gateway.signInWithPassword({
+      email: 'admin@example.com',
+      password: 'secret-admin',
+    });
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toMatchObject({
+      accessToken: expect.stringContaining('access:'),
+      refreshToken: expect.stringContaining('refresh:'),
+      expiresAt: expect.any(Number),
+    });
+  });
+
+  it('should return Left(DomainError) when email does not exist', async () => {
+    const result = await gateway.signInWithPassword({
+      email: 'unknown@example.com',
+      password: 'any',
+    });
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBeInstanceOf(DomainError);
+    expect((result.value as DomainError).code).toBe('INVALID_CREDENTIALS');
+  });
+
+  it('should return Left(DomainError) when password is wrong', async () => {
+    const result = await gateway.signInWithPassword({
+      email: 'admin@example.com',
+      password: 'wrong-password',
+    });
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_CREDENTIALS');
+  });
+
+  it('should return Left(DomainError) when a forced error is set', async () => {
+    const error = new DomainError('IDP_UNAVAILABLE', { message: 'Service is down.' });
+    gateway.simulateError(error);
+
+    const result = await gateway.signInWithPassword({
+      email: 'admin@example.com',
+      password: 'secret-admin',
+    });
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBe(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signOut
+// ---------------------------------------------------------------------------
+
+describe('IAuthenticationGateway — signOut', () => {
+  let gateway: FakeAuthenticationGateway;
+
+  beforeEach(() => {
+    gateway = new FakeAuthenticationGateway(SEED_USERS);
+  });
+
+  it('should return Right(void) and remove tokens from cookies', async () => {
+    const cookies = makeCookieApi({
+      'sb-access-token': 'access:admin@example.com:abc',
+      'sb-refresh-token': 'refresh:admin@example.com:abc',
+    });
+
+    const result = await gateway.signOut(cookies);
+
+    expect(result.isRight()).toBe(true);
+    expect(cookies.store['sb-access-token']).toBeUndefined();
+    expect(cookies.store['sb-refresh-token']).toBeUndefined();
+  });
+
+  it('should return Right(void) even when cookies are already empty', async () => {
+    const cookies = makeCookieApi();
+
+    const result = await gateway.signOut(cookies);
+
+    expect(result.isRight()).toBe(true);
+  });
+
+  it('should return Left(DomainError) when a forced error is set', async () => {
+    const error = new DomainError('IDP_UNAVAILABLE', { message: 'Service is down.' });
+    gateway.simulateError(error);
+
+    const result = await gateway.signOut(makeCookieApi());
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBe(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshSession
+// ---------------------------------------------------------------------------
+
+describe('IAuthenticationGateway — refreshSession', () => {
+  let gateway: FakeAuthenticationGateway;
+
+  beforeEach(() => {
+    gateway = new FakeAuthenticationGateway(SEED_USERS);
+  });
+
+  it('should return Right(AuthSession) with a new session when refresh token is valid', async () => {
+    const cookies = makeCookieApi({
+      'sb-refresh-token': 'refresh:admin@example.com:abc',
+    });
+
+    const result = await gateway.refreshSession(cookies);
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toMatchObject({
+      accessToken: expect.stringContaining('access:admin@example.com:'),
+      refreshToken: expect.stringContaining('refresh:admin@example.com:'),
+      expiresAt: expect.any(Number),
+    });
+  });
+
+  it('should return Left(DomainError) when no refresh token cookie is present', async () => {
+    const cookies = makeCookieApi();
+
+    const result = await gateway.refreshSession(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('NO_REFRESH_TOKEN');
+  });
+
+  it('should return Left(DomainError) when refresh token is malformed', async () => {
+    const cookies = makeCookieApi({ 'sb-refresh-token': 'malformed-token' });
+
+    const result = await gateway.refreshSession(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_REFRESH_TOKEN');
+  });
+
+  it('should return Left(DomainError) when refresh token references unknown user', async () => {
+    const cookies = makeCookieApi({ 'sb-refresh-token': 'refresh:ghost@example.com:abc' });
+
+    const result = await gateway.refreshSession(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_REFRESH_TOKEN');
+  });
+
+  it('should return Left(DomainError) when a forced error is set', async () => {
+    const error = new DomainError('IDP_UNAVAILABLE', { message: 'Service is down.' });
+    gateway.simulateError(error);
+
+    const result = await gateway.refreshSession(makeCookieApi());
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBe(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPrincipalFromCookies
+// ---------------------------------------------------------------------------
+
+describe('IAuthenticationGateway — getPrincipalFromCookies', () => {
+  let gateway: FakeAuthenticationGateway;
+
+  beforeEach(() => {
+    gateway = new FakeAuthenticationGateway(SEED_USERS);
+  });
+
+  it('should return Right(AuthPrincipal) when a valid access token is in cookies', async () => {
+    const cookies = makeCookieApi({
+      'sb-access-token': 'access:admin@example.com:xyz',
+    });
+
+    const result = await gateway.getPrincipalFromCookies(cookies);
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toEqual(ADMIN_PRINCIPAL);
+  });
+
+  it('should return the correct principal for each user', async () => {
+    const cookies = makeCookieApi({
+      'sb-access-token': 'access:visitor@example.com:xyz',
+    });
+
+    const result = await gateway.getPrincipalFromCookies(cookies);
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toEqual(VISITOR_PRINCIPAL);
+  });
+
+  it('should return Left(DomainError) when no access token cookie is present', async () => {
+    const cookies = makeCookieApi();
+
+    const result = await gateway.getPrincipalFromCookies(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('NO_ACCESS_TOKEN');
+  });
+
+  it('should return Left(DomainError) when access token is malformed', async () => {
+    const cookies = makeCookieApi({ 'sb-access-token': 'malformed-token' });
+
+    const result = await gateway.getPrincipalFromCookies(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_ACCESS_TOKEN');
+  });
+
+  it('should return Left(DomainError) when access token references unknown user', async () => {
+    const cookies = makeCookieApi({ 'sb-access-token': 'access:ghost@example.com:xyz' });
+
+    const result = await gateway.getPrincipalFromCookies(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_ACCESS_TOKEN');
+  });
+
+  it('should return Left(DomainError) when a forced error is set', async () => {
+    const error = new DomainError('IDP_UNAVAILABLE', { message: 'Service is down.' });
+    gateway.simulateError(error);
+
+    const result = await gateway.getPrincipalFromCookies(makeCookieApi());
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

- Define `IAuthenticationGateway` port with `signInWithPassword`, `signOut`, `refreshSession`, and `getPrincipalFromCookies`
- Define `AuthCookieApi` — framework-agnostic cookie accessor; no `next/headers` or `@supabase/*` in `@repo/application`
- Add `AuthSession` and `AuthPrincipal` DTOs
- Implement `FakeAuthenticationGateway` (in-memory test double with `simulateError` helper)
- 18 contract tests covering happy paths and all error branches
- Fix `@repo/ui/package.json`: add missing `"types"` conditions to exports so TypeScript Bundler resolution finds the `.d.ts` files

Closes #442

## Test plan

- [x] `pnpm test` in `packages/application` — 81 tests pass
- [x] `pnpm types` in `packages/application` — no errors
- [x] `pnpm types:web` — no errors (was broken before the `@repo/ui` exports fix)
- [x] All lefthook pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)