### PR TITLE
[T-48] feat(infra): add SupabaseAuthenticationGateway

### DIFF
--- a/.claude/skills/engineering-standards/SKILL.md
+++ b/.claude/skills/engineering-standards/SKILL.md
@@ -21,3 +21,16 @@ description: Apply DDD, Clean Architecture, Either pattern, validation, and test
 - [docs/08-TESTING.md](../../../docs/08-TESTING.md) — testing strategy and naming
 
 Do not duplicate long content here; use the references above for full templates and rules.
+
+## Mandatory: tests ship with the code
+
+**Every implementation task must include tests committed in the same branch and PR.**
+
+- New gateway, adapter, or infra class → integration/unit tests for all public methods (happy path + error paths)
+- New use case → unit tests with fake ports
+- New port interface → contract tests using a fake implementation
+- New entity or value object → unit tests covering valid construction and all validation error cases
+
+A PR that adds production code without tests is **not done**. Do not open the PR, do not mark the task as done, do not move on to the next task until tests exist and pass.
+
+> Rationale: `SupabaseAuthenticationGateway` was shipped in one commit without tests, requiring a second commit to add them. This rule prevents that pattern.

--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ CONTACT_EMAIL_FROM="onboarding@resend.dev"
 # Defaults to "admin@portfolio.dev" if not set.
 ADMIN_EMAIL="admin@portfolio.dev"
 
-# Supabase Auth (server-side only — for IAuthenticationGateway when implemented)
+# Supabase Auth (server-side only — used by SupabaseAuthenticationGateway in @repo/infra)
 # Project Settings → API
-# SUPABASE_URL="https://[project-ref].supabase.co"
-# SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+SUPABASE_URL="https://[project-ref].supabase.co"
+SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,7 @@ interface IProjectRepository {
 - Maximum 200 lines per file
 - Import order: external libs → internal packages → relative imports
 - Test naming: `should <expected behavior> when <context>`
+- **Tests are mandatory for every implementation** — never commit a new class, port, adapter, use case, or gateway without accompanying tests in the same branch/PR. A PR without tests for new production code is incomplete. See [docs/08-TESTING.md](./docs/08-TESTING.md) for strategy and naming.
 
 ---
 

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -4,8 +4,14 @@
   "private": true,
   "main": "src/index.ts",
   "exports": {
-    ".": { "types": "./dist/types/index.d.ts", "default": "./src/index.ts" },
-    "./prisma": { "types": "./dist/types/prisma/client.d.ts", "default": "./src/prisma/client.ts" }
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./src/index.ts"
+    },
+    "./prisma": {
+      "types": "./dist/types/prisma/client.d.ts",
+      "default": "./src/prisma/client.ts"
+    }
   },
   "scripts": {
     "lint": "eslint --fix --ext .ts ./src",
@@ -30,6 +36,8 @@
     "@repo/application": "workspace:*",
     "@repo/core": "workspace:*",
     "@repo/utils": "workspace:*",
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.103.0",
     "resend": "^6.9.4"
   },
   "devDependencies": {

--- a/packages/infra/src/container.ts
+++ b/packages/infra/src/container.ts
@@ -5,6 +5,7 @@ import { IExperienceRepository } from '@repo/core/portfolio';
 import { IProfileRepository } from '@repo/core/portfolio';
 import { IProjectRepository } from '@repo/core/portfolio';
 import { IEmailService } from '@repo/application/contact';
+import { IAuthenticationGateway } from '@repo/application/identity';
 import { validateEnv } from '@repo/utils/env';
 
 import { env } from '~/env';
@@ -13,6 +14,7 @@ import { PrismaExperienceRepository } from '~/repositories/experience/PrismaExpe
 import { PrismaProfileRepository } from '~/repositories/profile/PrismaProfileRepository';
 import { PrismaProjectRepository } from '~/repositories/project/PrismaProjectRepository';
 import { PrismaUserRepository } from '~/repositories/user/PrismaUserRepository';
+import { SupabaseAuthenticationGateway } from '~/identity/SupabaseAuthenticationGateway';
 import { ResendEmailService } from '~/services/ResendEmailService';
 
 export interface Container {
@@ -21,6 +23,7 @@ export interface Container {
   profileRepository: IProfileRepository;
   emailService: IEmailService;
   userRepository: IUserRepository;
+  authGateway: IAuthenticationGateway;
 }
 
 export function makeContainer(): Container {
@@ -37,6 +40,7 @@ export function makeContainer(): Container {
       senderEmail: env.CONTACT_EMAIL_FROM,
     }),
     userRepository: new PrismaUserRepository(prisma),
+    authGateway: new SupabaseAuthenticationGateway(env.SUPABASE_URL, env.SUPABASE_ANON_KEY),
   };
 }
 

--- a/packages/infra/src/env.ts
+++ b/packages/infra/src/env.ts
@@ -11,4 +11,10 @@ export const env = {
   get ADMIN_EMAIL() {
     return process.env['ADMIN_EMAIL'] ?? 'admin@portfolio.dev';
   },
+  get SUPABASE_URL() {
+    return process.env['SUPABASE_URL']!;
+  },
+  get SUPABASE_ANON_KEY() {
+    return process.env['SUPABASE_ANON_KEY']!;
+  },
 };

--- a/packages/infra/src/identity/SupabaseAuthenticationGateway.ts
+++ b/packages/infra/src/identity/SupabaseAuthenticationGateway.ts
@@ -1,0 +1,161 @@
+import { createClient } from '@supabase/supabase-js';
+
+import {
+  AuthCookieApi,
+  AuthPrincipal,
+  AuthSession,
+  IAuthenticationGateway,
+  SignInWithPasswordInput,
+} from '@repo/application/identity';
+import { DomainError, Either, left, right } from '@repo/core/shared';
+
+/** Cookie name used to persist the Supabase access token (JWT). */
+export const SUPABASE_ACCESS_TOKEN_COOKIE = 'sb-access-token';
+/** Cookie name used to persist the Supabase refresh token. */
+export const SUPABASE_REFRESH_TOKEN_COOKIE = 'sb-refresh-token';
+
+/**
+ * Supabase implementation of IAuthenticationGateway.
+ *
+ * All Supabase SDK imports are confined to this file and this package.
+ * The application layer sees only the IAuthenticationGateway contract.
+ */
+export class SupabaseAuthenticationGateway implements IAuthenticationGateway {
+  constructor(
+    private readonly supabaseUrl: string,
+    private readonly supabaseAnonKey: string,
+  ) {}
+
+  async signInWithPassword(
+    credentials: SignInWithPasswordInput,
+  ): Promise<Either<DomainError, AuthSession>> {
+    try {
+      const supabase = createClient(this.supabaseUrl, this.supabaseAnonKey, {
+        auth: { persistSession: false },
+      });
+
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email: credentials.email,
+        password: credentials.password,
+      });
+
+      if (error || !data.session) {
+        return left(
+          new DomainError('INVALID_CREDENTIALS', {
+            message: error?.message ?? 'Sign-in failed.',
+          }),
+        );
+      }
+
+      return right({
+        accessToken: data.session.access_token,
+        refreshToken: data.session.refresh_token,
+        expiresAt: data.session.expires_at ?? Math.floor(Date.now() / 1000) + 3600,
+      });
+    } catch (err) {
+      return left(this._unexpectedError(err));
+    }
+  }
+
+  async signOut(cookies: AuthCookieApi): Promise<Either<DomainError, void>> {
+    try {
+      const accessToken = cookies.get(SUPABASE_ACCESS_TOKEN_COOKIE);
+      const refreshToken = cookies.get(SUPABASE_REFRESH_TOKEN_COOKIE);
+
+      if (accessToken && refreshToken) {
+        const supabase = createClient(this.supabaseUrl, this.supabaseAnonKey, {
+          auth: { persistSession: false },
+        });
+        await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        });
+        await supabase.auth.signOut();
+      }
+
+      cookies.delete(SUPABASE_ACCESS_TOKEN_COOKIE);
+      cookies.delete(SUPABASE_REFRESH_TOKEN_COOKIE);
+
+      return right(undefined);
+    } catch (err) {
+      return left(this._unexpectedError(err));
+    }
+  }
+
+  async refreshSession(cookies: AuthCookieApi): Promise<Either<DomainError, AuthSession>> {
+    try {
+      const refreshToken = cookies.get(SUPABASE_REFRESH_TOKEN_COOKIE);
+
+      if (!refreshToken) {
+        return left(
+          new DomainError('NO_REFRESH_TOKEN', { message: 'No refresh token in cookies.' }),
+        );
+      }
+
+      const supabase = createClient(this.supabaseUrl, this.supabaseAnonKey, {
+        auth: { persistSession: false },
+      });
+
+      const { data, error } = await supabase.auth.refreshSession({
+        refresh_token: refreshToken,
+      });
+
+      if (error || !data.session) {
+        return left(
+          new DomainError('INVALID_REFRESH_TOKEN', {
+            message: error?.message ?? 'Session refresh failed.',
+          }),
+        );
+      }
+
+      return right({
+        accessToken: data.session.access_token,
+        refreshToken: data.session.refresh_token,
+        expiresAt: data.session.expires_at ?? Math.floor(Date.now() / 1000) + 3600,
+      });
+    } catch (err) {
+      return left(this._unexpectedError(err));
+    }
+  }
+
+  async getPrincipalFromCookies(
+    cookies: AuthCookieApi,
+  ): Promise<Either<DomainError, AuthPrincipal>> {
+    try {
+      const accessToken = cookies.get(SUPABASE_ACCESS_TOKEN_COOKIE);
+
+      if (!accessToken) {
+        return left(
+          new DomainError('NO_ACCESS_TOKEN', { message: 'No access token in cookies.' }),
+        );
+      }
+
+      const supabase = createClient(this.supabaseUrl, this.supabaseAnonKey, {
+        auth: { persistSession: false },
+      });
+
+      const { data, error } = await supabase.auth.getUser(accessToken);
+
+      if (error || !data.user) {
+        return left(
+          new DomainError('INVALID_ACCESS_TOKEN', {
+            message: error?.message ?? 'Access token is invalid or expired.',
+          }),
+        );
+      }
+
+      return right({
+        id: data.user.id,
+        email: data.user.email ?? '',
+        role: (data.user.app_metadata?.['role'] as string | undefined) ?? 'VISITOR',
+      });
+    } catch (err) {
+      return left(this._unexpectedError(err));
+    }
+  }
+
+  private _unexpectedError(err: unknown): DomainError {
+    const message = err instanceof Error ? err.message : 'Unexpected authentication error.';
+    return new DomainError('AUTH_UNEXPECTED_ERROR', { message });
+  }
+}

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -13,3 +13,8 @@ export { ResendEmailService } from '~/services/ResendEmailService';
 export type { IResendEmailServiceConfig } from '~/services/ResendEmailService';
 export { UserMapper } from '~/repositories/user/UserMapper';
 export { PrismaUserRepository } from '~/repositories/user/PrismaUserRepository';
+export {
+  SupabaseAuthenticationGateway,
+  SUPABASE_ACCESS_TOKEN_COOKIE,
+  SUPABASE_REFRESH_TOKEN_COOKIE,
+} from '~/identity/SupabaseAuthenticationGateway';

--- a/packages/infra/test/identity/SupabaseAuthenticationGateway.test.ts
+++ b/packages/infra/test/identity/SupabaseAuthenticationGateway.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DomainError } from '@repo/core/shared';
+
+import {
+  SUPABASE_ACCESS_TOKEN_COOKIE,
+  SUPABASE_REFRESH_TOKEN_COOKIE,
+  SupabaseAuthenticationGateway,
+} from '../../src/identity/SupabaseAuthenticationGateway';
+import { AuthCookieApi } from '@repo/application/identity';
+
+// ---------------------------------------------------------------------------
+// Module mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn() }));
+
+import { createClient } from '@supabase/supabase-js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeGateway() {
+  return new SupabaseAuthenticationGateway(
+    'https://test.supabase.co',
+    'test-anon-key',
+  );
+}
+
+function makeCookieApi(initial: Record<string, string> = {}): AuthCookieApi & {
+  store: Record<string, string>;
+} {
+  const store: Record<string, string> = { ...initial };
+  return {
+    store,
+    get: (name) => store[name],
+    set: (name, value) => { store[name] = value; },
+    delete: (name) => { delete store[name]; },
+  };
+}
+
+function makeAuthMock(overrides: Record<string, ReturnType<typeof vi.fn>> = {}) {
+  return {
+    signInWithPassword: vi.fn(),
+    setSession: vi.fn(),
+    signOut: vi.fn(),
+    refreshSession: vi.fn(),
+    getUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+function mockClient(authOverrides: Record<string, ReturnType<typeof vi.fn>> = {}) {
+  const auth = makeAuthMock(authOverrides);
+  vi.mocked(createClient).mockReturnValue({ auth } as ReturnType<typeof createClient>);
+  return auth;
+}
+
+const SESSION = {
+  access_token: 'access-jwt',
+  refresh_token: 'refresh-token',
+  expires_at: 9999999999,
+};
+
+// ---------------------------------------------------------------------------
+// signInWithPassword
+// ---------------------------------------------------------------------------
+
+describe('SupabaseAuthenticationGateway — signInWithPassword', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should return Right(AuthSession) on valid credentials', async () => {
+    mockClient({
+      signInWithPassword: vi.fn().mockResolvedValue({ data: { session: SESSION }, error: null }),
+    });
+
+    const result = await makeGateway().signInWithPassword({
+      email: 'admin@example.com',
+      password: 'secret',
+    });
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toMatchObject({
+      accessToken: SESSION.access_token,
+      refreshToken: SESSION.refresh_token,
+      expiresAt: SESSION.expires_at,
+    });
+  });
+
+  it('should return Left(DomainError INVALID_CREDENTIALS) when Supabase returns an error', async () => {
+    mockClient({
+      signInWithPassword: vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Invalid login credentials' },
+      }),
+    });
+
+    const result = await makeGateway().signInWithPassword({
+      email: 'admin@example.com',
+      password: 'wrong',
+    });
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_CREDENTIALS');
+    expect((result.value as DomainError).message).toContain('Invalid login credentials');
+  });
+
+  it('should return Left(DomainError INVALID_CREDENTIALS) when session is null without error', async () => {
+    mockClient({
+      signInWithPassword: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+    });
+
+    const result = await makeGateway().signInWithPassword({
+      email: 'admin@example.com',
+      password: 'secret',
+    });
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_CREDENTIALS');
+  });
+
+  it('should return Left(DomainError AUTH_UNEXPECTED_ERROR) when createClient throws', async () => {
+    vi.mocked(createClient).mockImplementation(() => { throw new Error('Network failure'); });
+
+    const result = await makeGateway().signInWithPassword({
+      email: 'admin@example.com',
+      password: 'secret',
+    });
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('AUTH_UNEXPECTED_ERROR');
+    expect((result.value as DomainError).message).toContain('Network failure');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signOut
+// ---------------------------------------------------------------------------
+
+describe('SupabaseAuthenticationGateway — signOut', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should return Right(void) and delete cookies when tokens are present', async () => {
+    mockClient({
+      setSession: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const cookies = makeCookieApi({
+      [SUPABASE_ACCESS_TOKEN_COOKIE]: 'access-jwt',
+      [SUPABASE_REFRESH_TOKEN_COOKIE]: 'refresh-token',
+    });
+
+    const result = await makeGateway().signOut(cookies);
+
+    expect(result.isRight()).toBe(true);
+    expect(cookies.store[SUPABASE_ACCESS_TOKEN_COOKIE]).toBeUndefined();
+    expect(cookies.store[SUPABASE_REFRESH_TOKEN_COOKIE]).toBeUndefined();
+  });
+
+  it('should return Right(void) even when cookies are already absent', async () => {
+    mockClient();
+
+    const result = await makeGateway().signOut(makeCookieApi());
+
+    expect(result.isRight()).toBe(true);
+  });
+
+  it('should return Left(DomainError AUTH_UNEXPECTED_ERROR) when signOut throws', async () => {
+    mockClient({
+      setSession: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      signOut: vi.fn().mockRejectedValue(new Error('Supabase unreachable')),
+    });
+    const cookies = makeCookieApi({
+      [SUPABASE_ACCESS_TOKEN_COOKIE]: 'access-jwt',
+      [SUPABASE_REFRESH_TOKEN_COOKIE]: 'refresh-token',
+    });
+
+    const result = await makeGateway().signOut(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('AUTH_UNEXPECTED_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshSession
+// ---------------------------------------------------------------------------
+
+describe('SupabaseAuthenticationGateway — refreshSession', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should return Right(AuthSession) with new tokens', async () => {
+    const newSession = { ...SESSION, access_token: 'new-access', refresh_token: 'new-refresh' };
+    mockClient({
+      refreshSession: vi.fn().mockResolvedValue({ data: { session: newSession }, error: null }),
+    });
+    const cookies = makeCookieApi({ [SUPABASE_REFRESH_TOKEN_COOKIE]: 'old-refresh' });
+
+    const result = await makeGateway().refreshSession(cookies);
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toMatchObject({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+    });
+  });
+
+  it('should return Left(DomainError NO_REFRESH_TOKEN) when cookie is absent', async () => {
+    mockClient();
+
+    const result = await makeGateway().refreshSession(makeCookieApi());
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('NO_REFRESH_TOKEN');
+  });
+
+  it('should return Left(DomainError INVALID_REFRESH_TOKEN) when Supabase returns an error', async () => {
+    mockClient({
+      refreshSession: vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Refresh token already used' },
+      }),
+    });
+    const cookies = makeCookieApi({ [SUPABASE_REFRESH_TOKEN_COOKIE]: 'stale-token' });
+
+    const result = await makeGateway().refreshSession(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_REFRESH_TOKEN');
+    expect((result.value as DomainError).message).toContain('Refresh token already used');
+  });
+
+  it('should return Left(DomainError AUTH_UNEXPECTED_ERROR) when refreshSession throws', async () => {
+    mockClient({
+      refreshSession: vi.fn().mockRejectedValue(new Error('Network timeout')),
+    });
+    const cookies = makeCookieApi({ [SUPABASE_REFRESH_TOKEN_COOKIE]: 'some-token' });
+
+    const result = await makeGateway().refreshSession(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('AUTH_UNEXPECTED_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPrincipalFromCookies
+// ---------------------------------------------------------------------------
+
+describe('SupabaseAuthenticationGateway — getPrincipalFromCookies', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should return Right(AuthPrincipal) with user data', async () => {
+    mockClient({
+      getUser: vi.fn().mockResolvedValue({
+        data: {
+          user: {
+            id: 'user-uuid',
+            email: 'admin@example.com',
+            app_metadata: { role: 'ADMIN' },
+          },
+        },
+        error: null,
+      }),
+    });
+    const cookies = makeCookieApi({ [SUPABASE_ACCESS_TOKEN_COOKIE]: 'access-jwt' });
+
+    const result = await makeGateway().getPrincipalFromCookies(cookies);
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toEqual({
+      id: 'user-uuid',
+      email: 'admin@example.com',
+      role: 'ADMIN',
+    });
+  });
+
+  it('should default role to VISITOR when app_metadata has no role', async () => {
+    mockClient({
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: 'user-uuid', email: 'visitor@example.com', app_metadata: {} } },
+        error: null,
+      }),
+    });
+    const cookies = makeCookieApi({ [SUPABASE_ACCESS_TOKEN_COOKIE]: 'access-jwt' });
+
+    const result = await makeGateway().getPrincipalFromCookies(cookies);
+
+    expect(result.isRight()).toBe(true);
+    expect((result.value as { role: string }).role).toBe('VISITOR');
+  });
+
+  it('should return Left(DomainError NO_ACCESS_TOKEN) when cookie is absent', async () => {
+    mockClient();
+
+    const result = await makeGateway().getPrincipalFromCookies(makeCookieApi());
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('NO_ACCESS_TOKEN');
+  });
+
+  it('should return Left(DomainError INVALID_ACCESS_TOKEN) when Supabase returns an error', async () => {
+    mockClient({
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: null },
+        error: { message: 'JWT expired' },
+      }),
+    });
+    const cookies = makeCookieApi({ [SUPABASE_ACCESS_TOKEN_COOKIE]: 'expired-jwt' });
+
+    const result = await makeGateway().getPrincipalFromCookies(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_ACCESS_TOKEN');
+    expect((result.value as DomainError).message).toContain('JWT expired');
+  });
+
+  it('should return Left(DomainError AUTH_UNEXPECTED_ERROR) when getUser throws', async () => {
+    mockClient({
+      getUser: vi.fn().mockRejectedValue(new Error('Connection refused')),
+    });
+    const cookies = makeCookieApi({ [SUPABASE_ACCESS_TOKEN_COOKIE]: 'access-jwt' });
+
+    const result = await makeGateway().getPrincipalFromCookies(cookies);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('AUTH_UNEXPECTED_ERROR');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,12 @@ importers:
       '@repo/utils':
         specifier: workspace:*
         version: link:../utils
+      '@supabase/ssr':
+        specifier: ^0.10.2
+        version: 0.10.2(@supabase/supabase-js@2.103.0)
+      '@supabase/supabase-js':
+        specifier: ^2.103.0
+        version: 2.103.0
       resend:
         specifier: ^6.9.4
         version: 6.9.4
@@ -4457,6 +4463,75 @@ packages:
       storybook: 8.4.5(prettier@3.2.5)
     dev: true
 
+  /@supabase/auth-js@2.103.0:
+    resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/functions-js@2.103.0:
+    resolution: {integrity: sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/phoenix@0.4.0:
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+    dev: false
+
+  /@supabase/postgrest-js@2.103.0:
+    resolution: {integrity: sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/realtime-js@2.103.0:
+    resolution: {integrity: sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@supabase/ssr@0.10.2(@supabase/supabase-js@2.103.0):
+    resolution: {integrity: sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.102.1
+    dependencies:
+      '@supabase/supabase-js': 2.103.0
+      cookie: 1.1.1
+    dev: false
+
+  /@supabase/storage-js@2.103.0:
+    resolution: {integrity: sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/supabase-js@2.103.0:
+    resolution: {integrity: sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@supabase/auth-js': 2.103.0
+      '@supabase/functions-js': 2.103.0
+      '@supabase/postgrest-js': 2.103.0
+      '@supabase/realtime-js': 2.103.0
+      '@supabase/storage-js': 2.103.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /@swc/counter@0.1.3:
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -4725,7 +4800,6 @@ packages:
     resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
 
   /@types/node@22.9.3:
     resolution: {integrity: sha512-F3u1fs/fce3FFk+DAxbxc78DF8x0cY09RRL8GnXLmkJ1jvx3TtPdWoTT5/NiYfI5ASqXBmfqJi9dZ3gxMx4lzw==}
@@ -4787,6 +4861,12 @@ packages:
   /@types/validator@13.12.1:
     resolution: {integrity: sha512-w0URwf7BQb0rD/EuiG12KP0bailHKHP5YVviJG9zw3ykAokL0TuxU2TUqMB7EwZ59bDHYdeTIvjI5m0S7qHfOA==}
     dev: true
+
+  /@types/ws@8.18.1:
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+    dependencies:
+      '@types/node': 20.14.2
+    dev: false
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -5197,7 +5277,7 @@ packages:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.14.2)
+      vitest: 3.2.4(@types/node@20.14.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6557,6 +6637,11 @@ packages:
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  /cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+    dev: false
 
   /core-js-compat@3.39.0:
     resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
@@ -8930,6 +9015,11 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
     dev: true
+
+  /iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+    dev: false
 
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -13071,7 +13161,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/core': 0.1.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /synckit@0.9.0:
@@ -13079,7 +13169,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/core': 0.1.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /tailwindcss@3.4.13(ts-node@10.9.2):
@@ -13472,10 +13562,6 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
-    dev: true
-
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -13712,7 +13798,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
 
   /undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -14417,6 +14502,19 @@ packages:
       utf-8-validate:
         optional: true
     dev: true
+
+  /ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}


### PR DESCRIPTION
## Summary

- Implement `SupabaseAuthenticationGateway implements IAuthenticationGateway` in `@repo/infra`
- All `@supabase/supabase-js` e `@supabase/ssr` imports confined to `@repo/infra` — nada vaza para `@repo/application` ou `apps/web`
- Operações: `signInWithPassword`, `signOut`, `refreshSession`, `getPrincipalFromCookies`
- Todos os erros Supabase mapeados para `DomainError` — nenhum tipo do SDK chega à UI
- Adiciona `SUPABASE_URL` e `SUPABASE_ANON_KEY` em `env.ts` e `.env.example`
- Registra `authGateway` em `makeContainer()` / interface `Container`
- Exporta constantes `SUPABASE_ACCESS_TOKEN_COOKIE` e `SUPABASE_REFRESH_TOKEN_COOKIE`

Closes #444

## Test plan

- [x] `pnpm types` em `packages/infra` — sem erros
- [x] Todos os checks do lefthook pre-commit passam
- [ ] Teste de integração contra projeto Supabase real (requer env vars — manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)