### PR TITLE
fix(infra): map Prisma P2025 to InfrastructureError in PrismaUserRepository.linkAuthSubject

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ interface IProjectRepository {
 2. **Verify work not done** — check: (a) `gh issue view <n>` — if closed, stop; (b) merged PRs; (c) git log; (d) existing branches
 3. **Set Task Master to In Progress**: `task-master set-status --id=<id> --status=in-progress`
 4. **Move GitHub issue to "In Progress"** in all linked Project boards
-5. **Create branch from issue**: `gh issue develop <issue-number> --checkout`
+5. **Create branch from issue**: `gh issue develop <issue-number> --checkout` — **immediately rebase onto develop**: `git rebase origin/develop` (`gh issue develop` uses the repo default branch, not `develop`)
 6. **Implement** — code, tests, commits
 7. **Open PR against `develop`**: `gh pr create --base develop`
 8. **Set Task Master to Done**: `task-master set-status --id=<id> --status=done`

--- a/packages/infra/src/repositories/user/PrismaUserRepository.ts
+++ b/packages/infra/src/repositories/user/PrismaUserRepository.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { IUserRepository, User } from '@repo/core/identity';
 import { Email, Id } from '@repo/core/shared';
 
+import { InfrastructureError } from '~/errors/InfrastructureError';
 import { UserMapper } from '~/repositories/user/UserMapper';
 
 export class PrismaUserRepository implements IUserRepository {
@@ -28,6 +29,13 @@ export class PrismaUserRepository implements IUserRepository {
   }
 
   async linkAuthSubject(userId: Id, authSubject: Id): Promise<void> {
+    const existing = await this.db.user.findUnique({
+      where: { id: userId.value },
+      select: { id: true },
+    });
+    if (!existing) {
+      throw new InfrastructureError(`User not found: ${userId.value}`);
+    }
     await this.db.user.update({
       where: { id: userId.value },
       data: { authSubject: authSubject.value },

--- a/packages/infra/test/factories/prisma-user.factory.ts
+++ b/packages/infra/test/factories/prisma-user.factory.ts
@@ -1,0 +1,18 @@
+import { Role, User as PrismaUser } from '@prisma/client';
+
+export type PrismaUserData = Omit<PrismaUser, never>;
+
+export function buildPrismaUser(overrides?: Partial<PrismaUserData>): PrismaUserData {
+  const id = overrides?.id ?? crypto.randomUUID();
+
+  return {
+    id,
+    name: 'Test User',
+    email: `test-${id}@example.com`,
+    role: Role.VISITOR,
+    authSubject: null,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}

--- a/packages/infra/test/repositories/user/PrismaUserRepository.test.ts
+++ b/packages/infra/test/repositories/user/PrismaUserRepository.test.ts
@@ -1,0 +1,181 @@
+import { PrismaClient } from '@prisma/client';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { Id } from '@repo/core/shared';
+
+import { InfrastructureError } from '../../../src/errors/InfrastructureError';
+import { PrismaUserRepository } from '../../../src/repositories/user/PrismaUserRepository';
+import { UserMapper } from '../../../src/repositories/user/UserMapper';
+import { buildPrismaUser } from '../../factories/prisma-user.factory';
+
+// Use DIRECT_URL to bypass PgBouncer — prepared statements don't work with the pooler
+const db = new PrismaClient({
+  datasourceUrl: process.env.DIRECT_URL,
+});
+const repo = new PrismaUserRepository(db);
+
+const TEST_EMAIL_PREFIX = 'infra-test-';
+
+async function seedUser(overrides?: Partial<ReturnType<typeof buildPrismaUser>>) {
+  const raw = buildPrismaUser({
+    email: `${TEST_EMAIL_PREFIX}${crypto.randomUUID()}@example.com`,
+    ...overrides,
+  });
+
+  await db.user.create({
+    data: {
+      id: raw.id,
+      name: raw.name,
+      email: raw.email,
+      role: raw.role,
+      authSubject: raw.authSubject ?? undefined,
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+    },
+  });
+
+  return raw;
+}
+
+beforeAll(async () => {
+  await db.$connect();
+});
+
+afterAll(async () => {
+  await db.user.deleteMany({ where: { email: { startsWith: TEST_EMAIL_PREFIX } } });
+  await db.$disconnect();
+});
+
+afterEach(async () => {
+  await db.user.deleteMany({ where: { email: { startsWith: TEST_EMAIL_PREFIX } } });
+});
+
+describe('PrismaUserRepository', () => {
+  describe('findById', () => {
+    it('should return the user when found', async () => {
+      const seeded = await seedUser();
+
+      const idResult = Id.create(seeded.id);
+      if (idResult.isLeft()) throw idResult.value;
+
+      const user = await repo.findById(idResult.value);
+
+      expect(user).not.toBeNull();
+      expect(user!.id.value).toBe(seeded.id);
+    });
+
+    it('should return null when not found', async () => {
+      const idResult = Id.create(crypto.randomUUID());
+      if (idResult.isLeft()) throw idResult.value;
+
+      const user = await repo.findById(idResult.value);
+
+      expect(user).toBeNull();
+    });
+  });
+
+  describe('findByEmail', () => {
+    it('should return the user when found', async () => {
+      const seeded = await seedUser();
+
+      const { Email } = await import('@repo/core/shared');
+      const emailResult = Email.create(seeded.email);
+      if (emailResult.isLeft()) throw emailResult.value;
+
+      const user = await repo.findByEmail(emailResult.value);
+
+      expect(user).not.toBeNull();
+      expect(user!.email.value).toBe(seeded.email);
+    });
+
+    it('should return null when email does not exist', async () => {
+      const { Email } = await import('@repo/core/shared');
+      const emailResult = Email.create(`${TEST_EMAIL_PREFIX}nonexistent@example.com`);
+      if (emailResult.isLeft()) throw emailResult.value;
+
+      const user = await repo.findByEmail(emailResult.value);
+
+      expect(user).toBeNull();
+    });
+  });
+
+  describe('findByAuthSubject', () => {
+    it('should return the user when authSubject matches', async () => {
+      const authSubject = crypto.randomUUID();
+      const seeded = await seedUser({ authSubject });
+
+      const idResult = Id.create(authSubject);
+      if (idResult.isLeft()) throw idResult.value;
+
+      const user = await repo.findByAuthSubject(idResult.value);
+
+      expect(user).not.toBeNull();
+      expect(user!.id.value).toBe(seeded.id);
+    });
+
+    it('should return null when authSubject does not exist', async () => {
+      const idResult = Id.create(crypto.randomUUID());
+      if (idResult.isLeft()) throw idResult.value;
+
+      const user = await repo.findByAuthSubject(idResult.value);
+
+      expect(user).toBeNull();
+    });
+  });
+
+  describe('linkAuthSubject', () => {
+    it('should link authSubject to an existing user', async () => {
+      const seeded = await seedUser({ authSubject: null });
+      const newAuthSubject = crypto.randomUUID();
+
+      const userIdResult = Id.create(seeded.id);
+      const authSubjectResult = Id.create(newAuthSubject);
+      if (userIdResult.isLeft()) throw userIdResult.value;
+      if (authSubjectResult.isLeft()) throw authSubjectResult.value;
+
+      await repo.linkAuthSubject(userIdResult.value, authSubjectResult.value);
+
+      const updated = await db.user.findUnique({ where: { id: seeded.id } });
+      expect(updated!.authSubject).toBe(newAuthSubject);
+    });
+
+    it('should throw InfrastructureError when user does not exist', async () => {
+      const userIdResult = Id.create(crypto.randomUUID());
+      const authSubjectResult = Id.create(crypto.randomUUID());
+      if (userIdResult.isLeft()) throw userIdResult.value;
+      if (authSubjectResult.isLeft()) throw authSubjectResult.value;
+
+      await expect(
+        repo.linkAuthSubject(userIdResult.value, authSubjectResult.value),
+      ).rejects.toThrow(InfrastructureError);
+    });
+  });
+
+  describe('save', () => {
+    it('should persist a new user and retrieve it', async () => {
+      const raw = buildPrismaUser({
+        email: `${TEST_EMAIL_PREFIX}${crypto.randomUUID()}@example.com`,
+      });
+      const user = UserMapper.toDomain(raw);
+
+      await repo.save(user);
+
+      const found = await db.user.findUnique({ where: { id: raw.id } });
+      expect(found).not.toBeNull();
+      expect(found!.email).toBe(raw.email);
+    });
+
+    it('should update an existing user on upsert', async () => {
+      const seeded = await seedUser({ authSubject: null });
+      const newAuthSubject = crypto.randomUUID();
+
+      const updatedRaw = buildPrismaUser({ ...seeded, authSubject: newAuthSubject });
+      const updatedUser = UserMapper.toDomain(updatedRaw);
+
+      await repo.save(updatedUser);
+
+      const found = await db.user.findUnique({ where: { id: seeded.id } });
+      expect(found!.authSubject).toBe(newAuthSubject);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add pre-check pattern to `linkAuthSubject`: `findUnique` before `update`, throw `InfrastructureError` if user not found
- Consistent with `PrismaProjectRepository.delete` and `PrismaExperienceRepository.delete`
- Add `prisma-user.factory.ts` for building test user records
- Add integration tests for `PrismaUserRepository` covering all methods (`findById`, `findByEmail`, `findByAuthSubject`, `linkAuthSubject`, `save`)

## Test plan

- [x] `linkAuthSubject` with existing user → updates `authSubject` field
- [x] `linkAuthSubject` with non-existent user → throws `InfrastructureError`
- [x] `findById` returns user when found / null when not found
- [x] `findByEmail` returns user when found / null when not found
- [x] `findByAuthSubject` returns user when matched / null otherwise
- [x] `save` inserts new user and upserts on re-save

Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)