### PR TITLE
chore(taskmaster): mark task 19 (T-48) as done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -3725,7 +3725,7 @@
         "dependencies": [
           "15"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -3778,7 +3778,7 @@
             "parentId": "undefined"
           }
         ],
-        "updatedAt": "2026-04-02T03:21:49.111Z"
+        "updatedAt": "2026-04-11T06:07:03.719Z"
       },
       {
         "id": "20",
@@ -3808,14 +3808,14 @@
         ],
         "priority": "medium",
         "subtasks": [],
-        "updatedAt": "2026-04-11T05:30:48.212Z"
+        "updatedAt": "2026-04-11T06:08:50.747Z"
       }
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-04-11T05:30:48.212Z",
+      "lastModified": "2026-04-11T06:08:50.748Z",
       "taskCount": 20,
-      "completedCount": 18,
+      "completedCount": 19,
       "tags": [
         "sprint-2"
       ]


### PR DESCRIPTION
## Summary

- Marks task 19 (T-48) as done in `.taskmaster/tasks/tasks.json`
- Related PR: #462 (already merged to develop)

Refs #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)