### PR TITLE
feat(web): REST envelope, error mapper, and portfolio/contact route handlers

### DIFF
--- a/apps/web/jest-resolver.cjs
+++ b/apps/web/jest-resolver.cjs
@@ -1,0 +1,52 @@
+/**
+ * Custom Jest resolver for the monorepo.
+ *
+ * Handles `~/` path aliases used inside workspace packages (packages/core,
+ * packages/application, packages/infra) and apps/web itself. Each package
+ * uses `~/*` mapped to its own `src/` directory, which Jest cannot resolve
+ * with a single global moduleNameMapper rule.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const PACKAGES_ROOT = path.resolve(REPO_ROOT, 'packages');
+const WEB_SRC = path.join(__dirname, 'src');
+
+/**
+ * Returns the `src` directory for the package that owns `filePath`.
+ * Falls back to apps/web/src for files not inside a packages/* directory.
+ */
+function packageSrcDir(basedir) {
+  const match = basedir.match(/\/packages\/([^/]+)\//);
+  if (match) return path.join(PACKAGES_ROOT, match[1], 'src');
+  return WEB_SRC;
+}
+
+function tryResolve(resolver, candidate, options) {
+  try {
+    return resolver(candidate, options);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = function resolver(moduleName, options) {
+  if (moduleName.startsWith('~/')) {
+    const srcDir = packageSrcDir(options.basedir || '');
+    const relative = moduleName.slice(2); // strip ~/
+    const base = path.join(srcDir, relative);
+
+    const result =
+      tryResolve(options.defaultResolver, base, options) ||
+      tryResolve(options.defaultResolver, base + '.ts', options) ||
+      tryResolve(options.defaultResolver, base + '.tsx', options) ||
+      tryResolve(options.defaultResolver, path.join(base, 'index.ts'), options) ||
+      tryResolve(options.defaultResolver, path.join(base, 'index.tsx'), options);
+
+    if (result) return result;
+  }
+
+  return options.defaultResolver(moduleName, options);
+};

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -6,9 +6,29 @@ const jestConfig: JestConfigWithTsJest = {
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+        tsconfig: {
+          moduleResolution: 'node',
+          module: 'commonjs',
+        },
+      },
+    ],
   },
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
+  resolver: './jest-resolver.cjs',
+  moduleNameMapper: {
+    // Exact aliases for apps/web (no slash — do NOT conflict with packages' ~/*)
+    '^~components$': '<rootDir>/src/components/index.ts',
+    '^~contexts$': '<rootDir>/src/contexts/index.ts',
+    '^~hocs$': '<rootDir>/src/hocs/index.ts',
+    '^~hooks$': '<rootDir>/src/hooks/index.ts',
+    '^~utils$': '<rootDir>/src/utils/index.ts',
+    '^~types$': '<rootDir>/src/types.ts',
+    // ~/... is handled by jest-resolver.cjs (context-aware per package)
+  },
 };
 
 export default jestConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,9 @@
     "types": "tsc -p ./tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@repo/application": "workspace:*",
     "@repo/core": "workspace:*",
+    "@repo/infra": "workspace:*",
     "@repo/ui": "workspace:*",
     "@repo/utils": "workspace:*",
     "classnames": "^2.5.1",

--- a/apps/web/src/app/api/v1/contact/route.ts
+++ b/apps/web/src/app/api/v1/contact/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer } from '@repo/infra';
+import { SendContactMessage } from '@repo/application/contact';
+
+import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json(errorResponse('INVALID_INPUT', 'Invalid JSON body', 400), {
+        status: 400,
+      });
+    }
+
+    const { emailService } = getContainer();
+    const useCase = new SendContactMessage(emailService);
+    const result = await useCase.execute({
+      name: body.name ?? '',
+      email: body.email ?? '',
+      message: body.message ?? '',
+    });
+
+    if (result.isLeft()) {
+      const { status, code, message } = mapDomainErrorToHttp(result.value);
+      return NextResponse.json(errorResponse(code, message, status), { status });
+    }
+
+    return NextResponse.json(successResponse(null), { status: 201 });
+  } catch {
+    return NextResponse.json(errorResponse('INTERNAL_ERROR', 'Internal server error', 500), {
+      status: 500,
+    });
+  }
+}

--- a/apps/web/src/app/api/v1/experiences/route.ts
+++ b/apps/web/src/app/api/v1/experiences/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer } from '@repo/infra';
+import { GetExperiences } from '@repo/application/portfolio';
+
+import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { resolveLocale } from '~/lib/api/locale';
+
+export async function GET(request: NextRequest) {
+  try {
+    const locale = resolveLocale(request);
+    const { experienceRepository } = getContainer();
+    const useCase = new GetExperiences(experienceRepository);
+    const result = await useCase.execute({ locale });
+    if (result.isLeft()) {
+      const { status, code, message } = mapDomainErrorToHttp(result.value);
+      return NextResponse.json(errorResponse(code, message, status), { status });
+    }
+    return NextResponse.json(successResponse(result.value));
+  } catch {
+    return NextResponse.json(errorResponse('INTERNAL_ERROR', 'Internal server error', 500), {
+      status: 500,
+    });
+  }
+}

--- a/apps/web/src/app/api/v1/profile/route.ts
+++ b/apps/web/src/app/api/v1/profile/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer } from '@repo/infra';
+import { GetProfile } from '@repo/application/portfolio';
+
+import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { resolveLocale } from '~/lib/api/locale';
+
+export async function GET(request: NextRequest) {
+  try {
+    const locale = resolveLocale(request);
+    const { profileRepository } = getContainer();
+    const useCase = new GetProfile(profileRepository);
+    const result = await useCase.execute({ locale });
+    if (result.isLeft()) {
+      const { status, code, message } = mapDomainErrorToHttp(result.value);
+      return NextResponse.json(errorResponse(code, message, status), { status });
+    }
+    return NextResponse.json(successResponse(result.value));
+  } catch {
+    return NextResponse.json(errorResponse('INTERNAL_ERROR', 'Internal server error', 500), {
+      status: 500,
+    });
+  }
+}

--- a/apps/web/src/app/api/v1/projects/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[slug]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer } from '@repo/infra';
+import { GetProjectBySlug } from '@repo/application/portfolio';
+
+import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { resolveLocale } from '~/lib/api/locale';
+
+interface RouteParams {
+  params: { slug: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const locale = resolveLocale(request);
+    const { projectRepository } = getContainer();
+    const useCase = new GetProjectBySlug(projectRepository);
+    const result = await useCase.execute({ slug: params.slug, locale });
+    if (result.isLeft()) {
+      const { status, code, message } = mapDomainErrorToHttp(result.value);
+      return NextResponse.json(errorResponse(code, message, status), { status });
+    }
+    return NextResponse.json(successResponse(result.value));
+  } catch {
+    return NextResponse.json(errorResponse('INTERNAL_ERROR', 'Internal server error', 500), {
+      status: 500,
+    });
+  }
+}

--- a/apps/web/src/app/api/v1/projects/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/projects/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { getContainer } from '@repo/infra';
+
+import { GET } from '../route';
+import { GET as GETBySlug } from '../[slug]/route';
+
+jest.mock('@repo/infra', () => ({
+  getContainer: jest.fn(),
+}));
+
+const mockFindPublished = jest.fn();
+const mockFindBySlug = jest.fn();
+const mockFindRelated = jest.fn();
+
+beforeEach(() => {
+  (getContainer as jest.Mock).mockReturnValue({
+    projectRepository: {
+      findPublished: mockFindPublished,
+      findBySlug: mockFindBySlug,
+      findRelated: mockFindRelated,
+    },
+  });
+  mockFindRelated.mockResolvedValue([]);
+});
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+describe('GET /api/v1/projects', () => {
+  it('should return 200 with empty data array when no projects exist', async () => {
+    mockFindPublished.mockResolvedValue([]);
+
+    const response = await GET(makeRequest('http://localhost/api/v1/projects'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual([]);
+    expect(body.error).toBeNull();
+  });
+
+  it('should return 500 when repository throws', async () => {
+    mockFindPublished.mockRejectedValue(new Error('DB connection failed'));
+
+    const response = await GET(makeRequest('http://localhost/api/v1/projects'));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.data).toBeNull();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+});
+
+describe('GET /api/v1/projects/[slug]', () => {
+  it('should return 400 when slug is invalid', async () => {
+    const request = makeRequest('http://localhost/api/v1/projects/ab');
+    const response = await GETBySlug(request, { params: { slug: 'ab' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.data).toBeNull();
+    expect(body.error.code).toBeDefined();
+  });
+
+  it('should return 404 when project does not exist', async () => {
+    mockFindBySlug.mockResolvedValue(null);
+
+    const request = makeRequest('http://localhost/api/v1/projects/my-project');
+    const response = await GETBySlug(request, { params: { slug: 'my-project' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.data).toBeNull();
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});

--- a/apps/web/src/app/api/v1/projects/featured/route.ts
+++ b/apps/web/src/app/api/v1/projects/featured/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer } from '@repo/infra';
+import { GetFeaturedProjects } from '@repo/application/portfolio';
+
+import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { resolveLocale } from '~/lib/api/locale';
+
+export async function GET(request: NextRequest) {
+  try {
+    const locale = resolveLocale(request);
+    const { projectRepository } = getContainer();
+    const useCase = new GetFeaturedProjects(projectRepository);
+    const result = await useCase.execute({ locale });
+    if (result.isLeft()) {
+      const { status, code, message } = mapDomainErrorToHttp(result.value);
+      return NextResponse.json(errorResponse(code, message, status), { status });
+    }
+    return NextResponse.json(successResponse(result.value));
+  } catch {
+    return NextResponse.json(errorResponse('INTERNAL_ERROR', 'Internal server error', 500), {
+      status: 500,
+    });
+  }
+}

--- a/apps/web/src/app/api/v1/projects/route.ts
+++ b/apps/web/src/app/api/v1/projects/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer } from '@repo/infra';
+import { GetPublishedProjects } from '@repo/application/portfolio';
+
+import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { resolveLocale } from '~/lib/api/locale';
+
+export async function GET(request: NextRequest) {
+  try {
+    const locale = resolveLocale(request);
+    const { projectRepository } = getContainer();
+    const useCase = new GetPublishedProjects(projectRepository);
+    const result = await useCase.execute({ locale });
+    if (result.isLeft()) {
+      const { status, code, message } = mapDomainErrorToHttp(result.value);
+      return NextResponse.json(errorResponse(code, message, status), { status });
+    }
+    return NextResponse.json(successResponse(result.value));
+  } catch {
+    return NextResponse.json(errorResponse('INTERNAL_ERROR', 'Internal server error', 500), {
+      status: 500,
+    });
+  }
+}

--- a/apps/web/src/lib/api/__tests__/envelope.test.ts
+++ b/apps/web/src/lib/api/__tests__/envelope.test.ts
@@ -1,0 +1,44 @@
+import { errorResponse, successResponse } from '../envelope';
+
+describe('successResponse', () => {
+  it('should return data with null error when no meta is provided', () => {
+    const result = successResponse({ id: '1', name: 'Test' });
+    expect(result.data).toEqual({ id: '1', name: 'Test' });
+    expect(result.error).toBeNull();
+    expect(result.meta).toBeUndefined();
+  });
+
+  it('should include meta when provided', () => {
+    const result = successResponse([1, 2, 3], { total: 3 });
+    expect(result.data).toEqual([1, 2, 3]);
+    expect(result.error).toBeNull();
+    expect(result.meta).toEqual({ total: 3 });
+  });
+
+  it('should accept null data', () => {
+    const result = successResponse(null);
+    expect(result.data).toBeNull();
+    expect(result.error).toBeNull();
+  });
+});
+
+describe('errorResponse', () => {
+  it('should return null data with error code and message', () => {
+    const result = errorResponse('NOT_FOUND', 'Resource not found', 404);
+    expect(result.data).toBeNull();
+    expect(result.error).toEqual({ code: 'NOT_FOUND', message: 'Resource not found' });
+    expect(result.meta).toEqual({ status: 404 });
+  });
+
+  it('should return correct status in meta for validation errors', () => {
+    const result = errorResponse('INVALID_SLUG', 'Slug is invalid', 400);
+    expect(result.data).toBeNull();
+    expect(result.error.code).toBe('INVALID_SLUG');
+    expect(result.meta.status).toBe(400);
+  });
+
+  it('should return correct status in meta for internal errors', () => {
+    const result = errorResponse('INTERNAL_ERROR', 'Internal server error', 500);
+    expect(result.meta.status).toBe(500);
+  });
+});

--- a/apps/web/src/lib/api/__tests__/error-mapper.test.ts
+++ b/apps/web/src/lib/api/__tests__/error-mapper.test.ts
@@ -1,0 +1,35 @@
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+import { UnauthorizedError } from '@repo/core/identity';
+
+import { mapDomainErrorToHttp } from '../error-mapper';
+
+describe('mapDomainErrorToHttp', () => {
+  it('should map NotFoundError to 404', () => {
+    const error = new NotFoundError({ slug: 'my-project' });
+    const result = mapDomainErrorToHttp(error);
+    expect(result.status).toBe(404);
+    expect(result.code).toBe('NOT_FOUND');
+  });
+
+  it('should map ValidationError to 400 with original code', () => {
+    const error = new ValidationError({ code: 'INVALID_SLUG', message: 'Slug is invalid' });
+    const result = mapDomainErrorToHttp(error);
+    expect(result.status).toBe(400);
+    expect(result.code).toBe('INVALID_SLUG');
+    expect(result.message).toBe('Slug is invalid');
+  });
+
+  it('should map UnauthorizedError to 401', () => {
+    const error = new UnauthorizedError();
+    const result = mapDomainErrorToHttp(error);
+    expect(result.status).toBe(401);
+    expect(result.code).toBe('UNAUTHORIZED');
+  });
+
+  it('should map generic DomainError to 500 with INTERNAL_ERROR code', () => {
+    const error = new DomainError('FETCH_FAILED', { message: 'DB connection failed' });
+    const result = mapDomainErrorToHttp(error);
+    expect(result.status).toBe(500);
+    expect(result.code).toBe('INTERNAL_ERROR');
+  });
+});

--- a/apps/web/src/lib/api/envelope.ts
+++ b/apps/web/src/lib/api/envelope.ts
@@ -1,0 +1,21 @@
+export interface SuccessResponse<T> {
+  data: T;
+  error: null;
+  meta?: { total?: number };
+}
+
+export interface ErrorResponse {
+  data: null;
+  error: { code: string; message: string };
+  meta: { status: number };
+}
+
+export type ApiResponse<T> = SuccessResponse<T> | ErrorResponse;
+
+export function successResponse<T>(data: T, meta?: { total?: number }): SuccessResponse<T> {
+  return { data, error: null, ...(meta ? { meta } : {}) };
+}
+
+export function errorResponse(code: string, message: string, status: number): ErrorResponse {
+  return { data: null, error: { code, message }, meta: { status } };
+}

--- a/apps/web/src/lib/api/error-mapper.ts
+++ b/apps/web/src/lib/api/error-mapper.ts
@@ -1,0 +1,21 @@
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+import { UnauthorizedError } from '@repo/core/identity';
+
+export interface HttpError {
+  status: number;
+  code: string;
+  message: string;
+}
+
+export function mapDomainErrorToHttp(error: DomainError): HttpError {
+  if (error instanceof NotFoundError) {
+    return { status: 404, code: error.code, message: error.message };
+  }
+  if (error instanceof ValidationError) {
+    return { status: 400, code: error.code, message: error.message };
+  }
+  if (error instanceof UnauthorizedError) {
+    return { status: 401, code: error.code, message: error.message };
+  }
+  return { status: 500, code: 'INTERNAL_ERROR', message: 'Internal server error' };
+}

--- a/apps/web/src/lib/api/locale.ts
+++ b/apps/web/src/lib/api/locale.ts
@@ -1,0 +1,17 @@
+import { DEFAULT_LOCALE, Locale, isLocale } from '@repo/core/shared';
+
+export function resolveLocale(request: Request): Locale {
+  const url = new URL(request.url);
+  const queryLocale = url.searchParams.get('locale');
+  if (queryLocale && isLocale(queryLocale)) return queryLocale;
+
+  const acceptLanguage = request.headers.get('Accept-Language') ?? '';
+  const candidates = acceptLanguage
+    .split(',')
+    .map((s) => (s.split(';')[0] ?? '').trim());
+  for (const candidate of candidates) {
+    if (isLocale(candidate)) return candidate;
+  }
+
+  return DEFAULT_LOCALE;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -24,7 +24,9 @@
   "references": [
     { "path": "../../packages/utils/tsconfig.build.json" },
     { "path": "../../packages/core/tsconfig.build.json" },
-    { "path": "../../packages/ui/tsconfig.build.json" }
+    { "path": "../../packages/ui/tsconfig.build.json" },
+    { "path": "../../packages/application/tsconfig.build.json" },
+    { "path": "../../packages/infra/tsconfig.build.json" }
   ],
   "include": [
     "next-env.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,9 +122,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@repo/application':
+        specifier: workspace:*
+        version: link:../../packages/application
       '@repo/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@repo/infra':
+        specifier: workspace:*
+        version: link:../../packages/infra
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -5277,7 +5283,7 @@ packages:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.14.2)(tsx@4.21.0)
+      vitest: 3.2.4(@types/node@20.14.2)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
## Summary

- Add `ApiResponse<T>` discriminated union type with `successResponse`/`errorResponse` factory helpers (`src/lib/api/envelope.ts`)
- Add `mapDomainErrorToHttp` mapper: `ValidationError→400`, `NotFoundError→404`, `UnauthorizedError→401`, default→500 (`src/lib/api/error-mapper.ts`)
- Add `resolveLocale` helper — negotiates locale from `?locale=` query param, `Accept-Language` header, or defaults to `en-US`
- Implement all public portfolio route handlers:
  - `GET /api/v1/projects` → `GetPublishedProjects`
  - `GET /api/v1/projects/featured` → `GetFeaturedProjects`
  - `GET /api/v1/projects/[slug]` → `GetProjectBySlug`
  - `GET /api/v1/profile` → `GetProfile`
  - `GET /api/v1/experiences` → `GetExperiences`
  - `POST /api/v1/contact` → `SendContactMessage`
- Add `@repo/application` and `@repo/infra` as workspace dependencies in `apps/web`
- Add `jest-resolver.cjs` — context-aware `~/` path alias resolver for workspace packages in Jest

## Test plan

- [x] `envelope.test.ts` — `successResponse` and `errorResponse` shape assertions
- [x] `error-mapper.test.ts` — 404/400/401/500 mapping for each error subclass
- [x] `route.test.ts` — 200 success (empty list), 500 domain error, 400 invalid slug, 404 not found
- [x] All 16 tests pass (`pnpm --filter web test`)
- [x] TypeScript passes (`pnpm --filter web types`)

Refs #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)