### PR TITLE
fix(infra): run prisma generate via postinstall instead of build

### DIFF
--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -18,7 +18,7 @@
     "lint:check": "eslint --ext .ts ./src",
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
-    "build": "prisma generate",
+    "postinstall": "prisma generate",
     "build:types": "tsc --build tsconfig.build.json",
     "types": "tsc --build tsconfig.build.json",
     "db:generate": "dotenv -e ../../.env -- prisma generate",


### PR DESCRIPTION
## Summary

- Moves `prisma generate` from `build` script to `postinstall` in `packages/infra`
- **Root cause**: Turbo remote cache was serving a stale `@repo/infra:build` result on Vercel. Because `node_modules/.prisma/client` is not in turbo's tracked `outputs` (`dist/**`), the Prisma client was never restored from cache — and never regenerated either, since turbo skipped the task as a cache hit
- **Fix**: `postinstall` runs during `pnpm install` on every Vercel deployment, before turbo processes any tasks, so Prisma is always generated regardless of cache state

## Test plan

- [ ] Trigger new preview deployment on develop — build should succeed with no `ExperienceGetPayload` error
- [ ] Confirm `@repo/infra:build` cache hit no longer breaks the Prisma types

Refs #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)