### PR TITLE
refactor(web): replace instanceof chain with registry in error-mapper

### DIFF
--- a/apps/web/src/app/api/v1/contact/route.ts
+++ b/apps/web/src/app/api/v1/contact/route.ts
@@ -3,6 +3,7 @@ import { getContainer } from '@repo/infra';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { HttpErrorCodes } from '~/lib/api/error-codes';
 import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
 
 export async function POST(request: NextRequest) {
@@ -10,7 +11,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json().catch(() => null);
     if (!body || typeof body !== 'object') {
       return NextResponse.json(
-        errorResponse('INVALID_INPUT', 'Invalid JSON body', 400),
+        errorResponse(HttpErrorCodes.INVALID_INPUT, 'Invalid JSON body', 400),
         {
           status: 400,
         },
@@ -35,7 +36,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(successResponse(null), { status: 201 });
   } catch {
     return NextResponse.json(
-      errorResponse('INTERNAL_ERROR', 'Internal server error', 500),
+      errorResponse(
+        HttpErrorCodes.INTERNAL_ERROR,
+        'Internal server error',
+        500,
+      ),
       {
         status: 500,
       },

--- a/apps/web/src/app/api/v1/experiences/route.ts
+++ b/apps/web/src/app/api/v1/experiences/route.ts
@@ -3,6 +3,7 @@ import { getContainer } from '@repo/infra';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { HttpErrorCodes } from '~/lib/api/error-codes';
 import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
 import { resolveLocale } from '~/lib/api/locale';
 
@@ -21,7 +22,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(successResponse(result.value));
   } catch {
     return NextResponse.json(
-      errorResponse('INTERNAL_ERROR', 'Internal server error', 500),
+      errorResponse(
+        HttpErrorCodes.INTERNAL_ERROR,
+        'Internal server error',
+        500,
+      ),
       {
         status: 500,
       },

--- a/apps/web/src/app/api/v1/profile/route.ts
+++ b/apps/web/src/app/api/v1/profile/route.ts
@@ -3,6 +3,7 @@ import { getContainer } from '@repo/infra';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { HttpErrorCodes } from '~/lib/api/error-codes';
 import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
 import { resolveLocale } from '~/lib/api/locale';
 
@@ -21,7 +22,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(successResponse(result.value));
   } catch {
     return NextResponse.json(
-      errorResponse('INTERNAL_ERROR', 'Internal server error', 500),
+      errorResponse(
+        HttpErrorCodes.INTERNAL_ERROR,
+        'Internal server error',
+        500,
+      ),
       {
         status: 500,
       },

--- a/apps/web/src/app/api/v1/projects/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[slug]/route.ts
@@ -3,6 +3,7 @@ import { getContainer } from '@repo/infra';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { HttpErrorCodes } from '~/lib/api/error-codes';
 import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
 import { resolveLocale } from '~/lib/api/locale';
 
@@ -25,7 +26,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(successResponse(result.value));
   } catch {
     return NextResponse.json(
-      errorResponse('INTERNAL_ERROR', 'Internal server error', 500),
+      errorResponse(
+        HttpErrorCodes.INTERNAL_ERROR,
+        'Internal server error',
+        500,
+      ),
       {
         status: 500,
       },

--- a/apps/web/src/app/api/v1/projects/featured/route.ts
+++ b/apps/web/src/app/api/v1/projects/featured/route.ts
@@ -3,6 +3,7 @@ import { getContainer } from '@repo/infra';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { HttpErrorCodes } from '~/lib/api/error-codes';
 import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
 import { resolveLocale } from '~/lib/api/locale';
 
@@ -21,7 +22,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(successResponse(result.value));
   } catch {
     return NextResponse.json(
-      errorResponse('INTERNAL_ERROR', 'Internal server error', 500),
+      errorResponse(
+        HttpErrorCodes.INTERNAL_ERROR,
+        'Internal server error',
+        500,
+      ),
       {
         status: 500,
       },

--- a/apps/web/src/app/api/v1/projects/route.ts
+++ b/apps/web/src/app/api/v1/projects/route.ts
@@ -3,6 +3,7 @@ import { getContainer } from '@repo/infra';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { errorResponse, successResponse } from '~/lib/api/envelope';
+import { HttpErrorCodes } from '~/lib/api/error-codes';
 import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
 import { resolveLocale } from '~/lib/api/locale';
 
@@ -21,7 +22,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(successResponse(result.value));
   } catch {
     return NextResponse.json(
-      errorResponse('INTERNAL_ERROR', 'Internal server error', 500),
+      errorResponse(
+        HttpErrorCodes.INTERNAL_ERROR,
+        'Internal server error',
+        500,
+      ),
       {
         status: 500,
       },

--- a/apps/web/src/lib/api/error-codes.ts
+++ b/apps/web/src/lib/api/error-codes.ts
@@ -1,0 +1,4 @@
+export const HttpErrorCodes = {
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+  INVALID_INPUT: 'INVALID_INPUT',
+} as const;

--- a/apps/web/src/lib/api/error-mapper.ts
+++ b/apps/web/src/lib/api/error-mapper.ts
@@ -1,25 +1,33 @@
 import { UnauthorizedError } from '@repo/core/identity';
 import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
 
+import { HttpErrorCodes } from './error-codes';
+
 export interface HttpError {
   status: number;
   code: string;
   message: string;
 }
 
+type DomainErrorConstructor = new (...args: never[]) => DomainError;
+
+const HTTP_STATUS_REGISTRY: ReadonlyArray<
+  readonly [DomainErrorConstructor, number]
+> = [
+  [NotFoundError, 404],
+  [ValidationError, 400],
+  [UnauthorizedError, 401],
+];
+
 export function mapDomainErrorToHttp(error: DomainError): HttpError {
-  if (error instanceof NotFoundError) {
-    return { status: 404, code: error.code, message: error.message };
-  }
-  if (error instanceof ValidationError) {
-    return { status: 400, code: error.code, message: error.message };
-  }
-  if (error instanceof UnauthorizedError) {
-    return { status: 401, code: error.code, message: error.message };
+  for (const [ErrorClass, status] of HTTP_STATUS_REGISTRY) {
+    if (error instanceof ErrorClass) {
+      return { status, code: error.code, message: error.message };
+    }
   }
   return {
     status: 500,
-    code: 'INTERNAL_ERROR',
+    code: HttpErrorCodes.INTERNAL_ERROR,
     message: 'Internal server error',
   };
 }

--- a/packages/core/src/identity/errors/UnauthorizedError.ts
+++ b/packages/core/src/identity/errors/UnauthorizedError.ts
@@ -1,12 +1,14 @@
 import { DomainError } from '../../shared/errors/DomainError';
 
 export class UnauthorizedError extends DomainError {
+  static readonly CODE = 'UNAUTHORIZED';
+
   constructor(options?: {
     message?: string;
     details?: Record<string, unknown>;
   }) {
     const message = options?.message ?? 'Unauthorized access';
-    super('UNAUTHORIZED', { message, details: options?.details });
+    super(UnauthorizedError.CODE, { message, details: options?.details });
     this.name = 'UnauthorizedError';
     Object.setPrototypeOf(this, UnauthorizedError.prototype);
   }

--- a/packages/core/src/shared/errors/NotFoundError.ts
+++ b/packages/core/src/shared/errors/NotFoundError.ts
@@ -1,12 +1,10 @@
 import { DomainError } from './DomainError';
 
-/**
- * Entity/resource not found error.
- * Default code: NOT_FOUND.
- */
 export class NotFoundError extends DomainError {
+  static readonly CODE = 'NOT_FOUND';
+
   constructor(details?: Record<string, unknown>) {
-    super('NOT_FOUND', {
+    super(NotFoundError.CODE, {
       message: 'Resource not found',
       details,
     });

--- a/packages/core/src/shared/errors/ValidationError.ts
+++ b/packages/core/src/shared/errors/ValidationError.ts
@@ -1,16 +1,14 @@
 import { DomainError } from './DomainError';
 
-/**
- * Validation error.
- * Default code: VALIDATION_ERROR.
- */
 export class ValidationError extends DomainError {
+  static readonly CODE = 'VALIDATION_ERROR';
+
   constructor(options?: {
     code?: string;
     message?: string;
     details?: Record<string, unknown>;
   }) {
-    const code = options?.code ?? 'VALIDATION_ERROR';
+    const code = options?.code ?? ValidationError.CODE;
     const message = options?.message ?? 'Validation failed';
     super(code, { message, details: options?.details });
     this.name = 'ValidationError';

--- a/packages/core/test/shared/errors/errors.test.ts
+++ b/packages/core/test/shared/errors/errors.test.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedError } from '~/identity';
 import { DomainError, NotFoundError, ValidationError } from '~/index';
 
 describe('DomainError', () => {
@@ -31,10 +32,14 @@ describe('DomainError', () => {
 });
 
 describe('NotFoundError', () => {
+  it('exposes CODE = NOT_FOUND as a static constant', () => {
+    expect(NotFoundError.CODE).toBe('NOT_FOUND');
+  });
+
   it('defaults to NOT_FOUND code', () => {
     const error = new NotFoundError();
 
-    expect(error.code).toBe('NOT_FOUND');
+    expect(error.code).toBe(NotFoundError.CODE);
     expect(error.name).toBe('NotFoundError');
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toBeInstanceOf(NotFoundError);
@@ -49,10 +54,14 @@ describe('NotFoundError', () => {
 });
 
 describe('ValidationError', () => {
+  it('exposes CODE = VALIDATION_ERROR as a static constant', () => {
+    expect(ValidationError.CODE).toBe('VALIDATION_ERROR');
+  });
+
   it('defaults to VALIDATION_ERROR when no args', () => {
     const error = new ValidationError();
 
-    expect(error.code).toBe('VALIDATION_ERROR');
+    expect(error.code).toBe(ValidationError.CODE);
     expect(error.name).toBe('ValidationError');
     expect(error).toBeInstanceOf(DomainError);
     expect(error).toBeInstanceOf(ValidationError);
@@ -83,5 +92,35 @@ describe('ValidationError', () => {
 
     expect(error.code).toBe('VALIDATION_ERROR');
     expect(error.details).toEqual(details);
+  });
+});
+
+describe('UnauthorizedError', () => {
+  it('exposes CODE = UNAUTHORIZED as a static constant', () => {
+    expect(UnauthorizedError.CODE).toBe('UNAUTHORIZED');
+  });
+
+  it('defaults to UNAUTHORIZED code and correct name', () => {
+    const error = new UnauthorizedError();
+
+    expect(error.code).toBe(UnauthorizedError.CODE);
+    expect(error.message).toBe('Unauthorized access');
+    expect(error.name).toBe('UnauthorizedError');
+    expect(error).toBeInstanceOf(DomainError);
+    expect(error).toBeInstanceOf(UnauthorizedError);
+  });
+
+  it('accepts custom message', () => {
+    const error = new UnauthorizedError({ message: 'Token expired' });
+
+    expect(error.code).toBe('UNAUTHORIZED');
+    expect(error.message).toBe('Token expired');
+  });
+
+  it('accepts optional details', () => {
+    const error = new UnauthorizedError({ details: { reason: 'token_expired' } });
+
+    expect(error.code).toBe('UNAUTHORIZED');
+    expect(error.details).toEqual({ reason: 'token_expired' });
   });
 });


### PR DESCRIPTION
## Summary

- Replaces the `if/instanceof` chain in `mapDomainErrorToHttp` with a declarative `HTTP_STATUS_REGISTRY` array — adding support for a new error type is now a one-line change
- Adds `static readonly CODE` to `NotFoundError`, `ValidationError`, and `UnauthorizedError` — the default code is now a referenceable constant on the class itself, not a buried string literal
- Adds `HttpErrorCodes` object in `apps/web/src/lib/api/error-codes.ts` to centralise `INTERNAL_ERROR` and `INVALID_INPUT` codes used at the REST boundary
- Updates all 6 route handlers to reference `HttpErrorCodes.INTERNAL_ERROR` instead of repeating the string literal
- Extends `packages/core/test/shared/errors/errors.test.ts` with `static CODE` assertions and `UnauthorizedError` coverage

## Test plan

- [ ] All 224 core tests pass
- [ ] All 16 web tests pass
- [ ] No new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)