### PR TITLE
refactor(web): extract handleRequest helper to remove route handler boilerplate

### DIFF
--- a/apps/web/src/app/api/v1/contact/route.ts
+++ b/apps/web/src/app/api/v1/contact/route.ts
@@ -1,49 +1,26 @@
 import { SendContactMessage } from '@repo/application/contact';
+import { ValidationError, left } from '@repo/core/shared';
 import { getContainer } from '@repo/infra';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
-import { errorResponse, successResponse } from '~/lib/api/envelope';
-import { HttpErrorCodes } from '~/lib/api/error-codes';
-import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { handleRequest } from '~/lib/api/handler';
 
 export async function POST(request: NextRequest) {
-  try {
+  return handleRequest(async () => {
     const body = await request.json().catch(() => null);
     if (!body || typeof body !== 'object') {
-      return NextResponse.json(
-        errorResponse(HttpErrorCodes.INVALID_INPUT, 'Invalid JSON body', 400),
-        {
-          status: 400,
-        },
+      return left(
+        new ValidationError({
+          code: 'INVALID_INPUT',
+          message: 'Invalid JSON body',
+        }),
       );
     }
-
     const { emailService } = getContainer();
-    const useCase = new SendContactMessage(emailService);
-    const result = await useCase.execute({
+    return new SendContactMessage(emailService).execute({
       name: body.name ?? '',
       email: body.email ?? '',
       message: body.message ?? '',
     });
-
-    if (result.isLeft()) {
-      const { status, code, message } = mapDomainErrorToHttp(result.value);
-      return NextResponse.json(errorResponse(code, message, status), {
-        status,
-      });
-    }
-
-    return NextResponse.json(successResponse(null), { status: 201 });
-  } catch {
-    return NextResponse.json(
-      errorResponse(
-        HttpErrorCodes.INTERNAL_ERROR,
-        'Internal server error',
-        500,
-      ),
-      {
-        status: 500,
-      },
-    );
-  }
+  }, 201);
 }

--- a/apps/web/src/app/api/v1/experiences/route.ts
+++ b/apps/web/src/app/api/v1/experiences/route.ts
@@ -1,35 +1,14 @@
 import { GetExperiences } from '@repo/application/portfolio';
 import { getContainer } from '@repo/infra';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
-import { errorResponse, successResponse } from '~/lib/api/envelope';
-import { HttpErrorCodes } from '~/lib/api/error-codes';
-import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { handleRequest } from '~/lib/api/handler';
 import { resolveLocale } from '~/lib/api/locale';
 
 export async function GET(request: NextRequest) {
-  try {
+  return handleRequest(() => {
     const locale = resolveLocale(request);
     const { experienceRepository } = getContainer();
-    const useCase = new GetExperiences(experienceRepository);
-    const result = await useCase.execute({ locale });
-    if (result.isLeft()) {
-      const { status, code, message } = mapDomainErrorToHttp(result.value);
-      return NextResponse.json(errorResponse(code, message, status), {
-        status,
-      });
-    }
-    return NextResponse.json(successResponse(result.value));
-  } catch {
-    return NextResponse.json(
-      errorResponse(
-        HttpErrorCodes.INTERNAL_ERROR,
-        'Internal server error',
-        500,
-      ),
-      {
-        status: 500,
-      },
-    );
-  }
+    return new GetExperiences(experienceRepository).execute({ locale });
+  });
 }

--- a/apps/web/src/app/api/v1/profile/route.ts
+++ b/apps/web/src/app/api/v1/profile/route.ts
@@ -1,35 +1,14 @@
 import { GetProfile } from '@repo/application/portfolio';
 import { getContainer } from '@repo/infra';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
-import { errorResponse, successResponse } from '~/lib/api/envelope';
-import { HttpErrorCodes } from '~/lib/api/error-codes';
-import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { handleRequest } from '~/lib/api/handler';
 import { resolveLocale } from '~/lib/api/locale';
 
 export async function GET(request: NextRequest) {
-  try {
+  return handleRequest(() => {
     const locale = resolveLocale(request);
     const { profileRepository } = getContainer();
-    const useCase = new GetProfile(profileRepository);
-    const result = await useCase.execute({ locale });
-    if (result.isLeft()) {
-      const { status, code, message } = mapDomainErrorToHttp(result.value);
-      return NextResponse.json(errorResponse(code, message, status), {
-        status,
-      });
-    }
-    return NextResponse.json(successResponse(result.value));
-  } catch {
-    return NextResponse.json(
-      errorResponse(
-        HttpErrorCodes.INTERNAL_ERROR,
-        'Internal server error',
-        500,
-      ),
-      {
-        status: 500,
-      },
-    );
-  }
+    return new GetProfile(profileRepository).execute({ locale });
+  });
 }

--- a/apps/web/src/app/api/v1/projects/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[slug]/route.ts
@@ -1,10 +1,8 @@
 import { GetProjectBySlug } from '@repo/application/portfolio';
 import { getContainer } from '@repo/infra';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
-import { errorResponse, successResponse } from '~/lib/api/envelope';
-import { HttpErrorCodes } from '~/lib/api/error-codes';
-import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { handleRequest } from '~/lib/api/handler';
 import { resolveLocale } from '~/lib/api/locale';
 
 interface RouteParams {
@@ -12,28 +10,12 @@ interface RouteParams {
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
-  try {
+  return handleRequest(() => {
     const locale = resolveLocale(request);
     const { projectRepository } = getContainer();
-    const useCase = new GetProjectBySlug(projectRepository);
-    const result = await useCase.execute({ slug: params.slug, locale });
-    if (result.isLeft()) {
-      const { status, code, message } = mapDomainErrorToHttp(result.value);
-      return NextResponse.json(errorResponse(code, message, status), {
-        status,
-      });
-    }
-    return NextResponse.json(successResponse(result.value));
-  } catch {
-    return NextResponse.json(
-      errorResponse(
-        HttpErrorCodes.INTERNAL_ERROR,
-        'Internal server error',
-        500,
-      ),
-      {
-        status: 500,
-      },
-    );
-  }
+    return new GetProjectBySlug(projectRepository).execute({
+      slug: params.slug,
+      locale,
+    });
+  });
 }

--- a/apps/web/src/app/api/v1/projects/featured/route.ts
+++ b/apps/web/src/app/api/v1/projects/featured/route.ts
@@ -1,35 +1,14 @@
 import { GetFeaturedProjects } from '@repo/application/portfolio';
 import { getContainer } from '@repo/infra';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
-import { errorResponse, successResponse } from '~/lib/api/envelope';
-import { HttpErrorCodes } from '~/lib/api/error-codes';
-import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { handleRequest } from '~/lib/api/handler';
 import { resolveLocale } from '~/lib/api/locale';
 
 export async function GET(request: NextRequest) {
-  try {
+  return handleRequest(() => {
     const locale = resolveLocale(request);
     const { projectRepository } = getContainer();
-    const useCase = new GetFeaturedProjects(projectRepository);
-    const result = await useCase.execute({ locale });
-    if (result.isLeft()) {
-      const { status, code, message } = mapDomainErrorToHttp(result.value);
-      return NextResponse.json(errorResponse(code, message, status), {
-        status,
-      });
-    }
-    return NextResponse.json(successResponse(result.value));
-  } catch {
-    return NextResponse.json(
-      errorResponse(
-        HttpErrorCodes.INTERNAL_ERROR,
-        'Internal server error',
-        500,
-      ),
-      {
-        status: 500,
-      },
-    );
-  }
+    return new GetFeaturedProjects(projectRepository).execute({ locale });
+  });
 }

--- a/apps/web/src/app/api/v1/projects/route.ts
+++ b/apps/web/src/app/api/v1/projects/route.ts
@@ -1,35 +1,14 @@
 import { GetPublishedProjects } from '@repo/application/portfolio';
 import { getContainer } from '@repo/infra';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
-import { errorResponse, successResponse } from '~/lib/api/envelope';
-import { HttpErrorCodes } from '~/lib/api/error-codes';
-import { mapDomainErrorToHttp } from '~/lib/api/error-mapper';
+import { handleRequest } from '~/lib/api/handler';
 import { resolveLocale } from '~/lib/api/locale';
 
 export async function GET(request: NextRequest) {
-  try {
+  return handleRequest(() => {
     const locale = resolveLocale(request);
     const { projectRepository } = getContainer();
-    const useCase = new GetPublishedProjects(projectRepository);
-    const result = await useCase.execute({ locale });
-    if (result.isLeft()) {
-      const { status, code, message } = mapDomainErrorToHttp(result.value);
-      return NextResponse.json(errorResponse(code, message, status), {
-        status,
-      });
-    }
-    return NextResponse.json(successResponse(result.value));
-  } catch {
-    return NextResponse.json(
-      errorResponse(
-        HttpErrorCodes.INTERNAL_ERROR,
-        'Internal server error',
-        500,
-      ),
-      {
-        status: 500,
-      },
-    );
-  }
+    return new GetPublishedProjects(projectRepository).execute({ locale });
+  });
 }

--- a/apps/web/src/lib/api/handler.ts
+++ b/apps/web/src/lib/api/handler.ts
@@ -1,0 +1,28 @@
+import { DomainError, Either } from '@repo/core/shared';
+import { NextResponse } from 'next/server';
+
+import { errorResponse, successResponse } from './envelope';
+import { mapDomainErrorToHttp } from './error-mapper';
+
+export async function handleRequest<T>(
+  factory: () => Promise<Either<DomainError, T>>,
+  successStatus = 200,
+): Promise<NextResponse> {
+  try {
+    const result = await factory();
+    if (result.isLeft()) {
+      const { status, code, message } = mapDomainErrorToHttp(result.value);
+      return NextResponse.json(errorResponse(code, message, status), {
+        status,
+      });
+    }
+    return NextResponse.json(successResponse(result.value), {
+      status: successStatus,
+    });
+  } catch {
+    return NextResponse.json(
+      errorResponse('INTERNAL_ERROR', 'Internal server error', 500),
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/tests/lib/api/handler.test.ts
+++ b/apps/web/tests/lib/api/handler.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment node
+ */
+import { DomainError, NotFoundError, ValidationError, left, right } from '@repo/core/shared';
+
+import { handleRequest } from '~/lib/api/handler';
+
+describe('handleRequest', () => {
+  it('should return 200 with successResponse when factory resolves right', async () => {
+    const response = await handleRequest(() =>
+      Promise.resolve(right<DomainError, { id: string }>({ id: '1' })),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual({ id: '1' });
+    expect(body.error).toBeNull();
+  });
+
+  it('should use custom successStatus when provided', async () => {
+    const response = await handleRequest(
+      () => Promise.resolve(right<DomainError, null>(null)),
+      201,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data).toBeNull();
+    expect(body.error).toBeNull();
+  });
+
+  it('should return 404 when factory resolves left(NotFoundError)', async () => {
+    const response = await handleRequest(() =>
+      Promise.resolve(left(new NotFoundError({ slug: 'missing' }))),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.data).toBeNull();
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('should return 400 with original code when factory resolves left(ValidationError)', async () => {
+    const response = await handleRequest(() =>
+      Promise.resolve(left(new ValidationError({ code: 'INVALID_SLUG', message: 'Bad slug' }))),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('INVALID_SLUG');
+    expect(body.error.message).toBe('Bad slug');
+  });
+
+  it('should return 500 with INTERNAL_ERROR when factory throws', async () => {
+    const response = await handleRequest(() => {
+      throw new Error('Unexpected DB failure');
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.data).toBeNull();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('should return 500 when factory returns left with unknown DomainError', async () => {
+    const response = await handleRequest(() =>
+      Promise.resolve(left(new DomainError('FETCH_FAILED', { message: 'timeout' }))),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `apps/web/src/lib/api/handler.ts` with a generic `handleRequest<T>` function that owns try/catch, Either unwrapping, `mapDomainErrorToHttp`, and the 500 fallback
- All 6 route handlers are reduced to a single `return handleRequest(() => ...)` call — each now expresses only what's specific to it (which use case, which args)
- `contact/route.ts` replaces its early `NextResponse.json` return with `left(new ValidationError(...))` so invalid JSON body flows through the same error mapper as all other failures
- Adds 6 tests for `handleRequest` covering success, custom status, 404, 400, thrown exception, and unknown DomainError

## Test plan

- [ ] 22 web tests pass
- [ ] All route handlers still return correct status codes and envelope shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)