### PR TITLE
refactor(web): replace manual body check with Validator DSL in contact route

### DIFF
--- a/apps/web/src/app/api/v1/contact/route.ts
+++ b/apps/web/src/app/api/v1/contact/route.ts
@@ -2,20 +2,25 @@ import { SendContactMessage } from '@repo/application/contact';
 import { ValidationError, left } from '@repo/core/shared';
 import { getContainer } from '@repo/infra';
 import { NextRequest } from 'next/server';
+import { Validator } from '@repo/utils/validator';
 
 import { handleRequest } from '~/lib/api/handler';
 
 export async function POST(request: NextRequest) {
   return handleRequest(async () => {
     const body = await request.json().catch(() => null);
-    if (!body || typeof body !== 'object') {
+
+    const { isValid, error } = Validator.of(body)
+      .notNil('Invalid JSON body.')
+      .refine((v) => typeof v === 'object', 'Invalid JSON body.')
+      .validate();
+
+    if (!isValid && error) {
       return left(
-        new ValidationError({
-          code: 'INVALID_INPUT',
-          message: 'Invalid JSON body',
-        }),
+        new ValidationError({ code: 'INVALID_INPUT', message: error }),
       );
     }
+
     const { emailService } = getContainer();
     return new SendContactMessage(emailService).execute({
       name: body.name ?? '',

--- a/apps/web/src/app/api/v1/contact/route.ts
+++ b/apps/web/src/app/api/v1/contact/route.ts
@@ -4,6 +4,7 @@ import { getContainer } from '@repo/infra';
 import { Validator } from '@repo/utils/validator';
 import { NextRequest } from 'next/server';
 
+import { HttpErrorCodes } from '~/lib/api/error-codes';
 import { handleRequest } from '~/lib/api/handler';
 
 export async function POST(request: NextRequest) {
@@ -17,7 +18,10 @@ export async function POST(request: NextRequest) {
 
     if (!isValid && error) {
       return left(
-        new ValidationError({ code: 'INVALID_INPUT', message: error }),
+        new ValidationError({
+          code: HttpErrorCodes.INVALID_INPUT,
+          message: error,
+        }),
       );
     }
 

--- a/apps/web/src/app/api/v1/contact/route.ts
+++ b/apps/web/src/app/api/v1/contact/route.ts
@@ -1,8 +1,8 @@
 import { SendContactMessage } from '@repo/application/contact';
 import { ValidationError, left } from '@repo/core/shared';
 import { getContainer } from '@repo/infra';
-import { NextRequest } from 'next/server';
 import { Validator } from '@repo/utils/validator';
+import { NextRequest } from 'next/server';
 
 import { handleRequest } from '~/lib/api/handler';
 

--- a/apps/web/tests/app/api/v1/contact/route.test.ts
+++ b/apps/web/tests/app/api/v1/contact/route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment node
+ */
+import { type Container, getContainer } from '@repo/infra';
+import { NextRequest } from 'next/server';
+
+import { POST } from '~/app/api/v1/contact/route';
+
+vi.mock('@repo/infra', () => ({
+  getContainer: vi.fn(),
+}));
+
+const mockSend = vi.fn();
+
+beforeEach(() => {
+  vi.mocked(getContainer).mockReturnValue({
+    emailService: { send: mockSend },
+  } as unknown as Container);
+});
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/v1/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/v1/contact', () => {
+  it('should return 400 when body is null', async () => {
+    const request = new NextRequest('http://localhost/api/v1/contact', {
+      method: 'POST',
+      body: 'not-json{{{',
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('INVALID_INPUT');
+  });
+
+  it('should return 400 when body is not an object', async () => {
+    const request = new NextRequest('http://localhost/api/v1/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(42),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('INVALID_INPUT');
+  });
+
+  it('should return 400 when name is missing', async () => {
+    const response = await POST(
+      makeRequest({ name: '', email: 'a@b.com', message: 'hello' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('INVALID_NAME');
+  });
+
+  it('should return 400 when email is invalid', async () => {
+    const response = await POST(
+      makeRequest({ name: 'Alice', email: 'not-an-email', message: 'hello' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('INVALID_EMAIL');
+  });
+
+  it('should return 201 when email service succeeds', async () => {
+    const { right } = await import('@repo/core/shared');
+    mockSend.mockResolvedValue(right(undefined));
+
+    const response = await POST(
+      makeRequest({ name: 'Alice', email: 'alice@example.com', message: 'hello' }),
+    );
+
+    expect(response.status).toBe(201);
+  });
+
+  it('should return 500 when email service throws', async () => {
+    mockSend.mockRejectedValue(new Error('SMTP failure'));
+
+    const response = await POST(
+      makeRequest({ name: 'Alice', email: 'alice@example.com', message: 'hello' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces `if (!body || typeof body !== 'object')` with `Validator.of(body).notNil().refine()` — consistent with how validation is expressed everywhere else in the application layer
- Imports `Validator` via `@repo/utils/validator` sub-path to avoid pulling the full utils package
- Adds first test coverage for `POST /api/v1/contact`: null body, non-object body, missing name, invalid email, success (201), and service exception (500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)