### PR TITLE
feat(web): LanguageSelector funcional no SideNavigation

### DIFF
--- a/apps/web/src/components/View/SideNavigation/LanguageSelector.tsx
+++ b/apps/web/src/components/View/SideNavigation/LanguageSelector.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { FC, useCallback } from 'react';
+
+import {
+  Radio,
+  RadioGroup,
+  RadioGroupChildrenFn,
+  RadioGroupProps,
+} from '@repo/ui/Control';
+import { useTranslations, useLocale } from 'next-intl';
+import { useRouter } from 'next/navigation';
+
+import { usePathname } from '~i18n/routing';
+
+import { MenuItem } from '../MenuItem';
+import { LANGUAGES_OPTIONS } from './constants';
+
+export const LanguageSelector: FC = () => {
+  const t = useTranslations('SideNavigation');
+  const locale = useLocale();
+  const { replace } = useRouter();
+  const pathname = usePathname();
+
+  const onChangeLanguage = useCallback<RadioGroupProps['onChange']>(
+    (event) => {
+      const { value } = event.target;
+
+      replace(pathname !== '/' ? `/${value}${pathname}` : value);
+    },
+    [replace, pathname],
+  );
+
+  const renderLanguages = useCallback<RadioGroupChildrenFn>(
+    ({ name, value, onChange }) => {
+      return LANGUAGES_OPTIONS.map(({ label, icon, option }) => (
+        <li key={option} className="flex flex-row gap-x-3">
+          <Radio
+            id={option}
+            name={name}
+            value={value}
+            onChange={onChange}
+            option={option}
+            icon={icon}
+          >
+            {label}
+          </Radio>
+        </li>
+      ));
+    },
+    [],
+  );
+
+  return (
+    <MenuItem.Item2.Expandable
+      title={t('language')}
+      icon="material-symbols:language"
+      iconClassName="text-white"
+    >
+      <RadioGroup
+        name="language"
+        value={locale}
+        onChange={onChangeLanguage}
+        containerElementType="ul"
+        className="flex flex-col gap-y-2"
+      >
+        {renderLanguages}
+      </RadioGroup>
+    </MenuItem.Item2.Expandable>
+  );
+};

--- a/apps/web/src/components/View/SideNavigation/index.tsx
+++ b/apps/web/src/components/View/SideNavigation/index.tsx
@@ -1,60 +1,20 @@
 'use client';
 
-import { FC, useCallback } from 'react';
+import { FC } from 'react';
 
-import {
-  Radio,
-  RadioGroup,
-  RadioGroupProps,
-  RadioGroupChildrenFn,
-} from '@repo/ui/Control';
 import { Divider } from '@repo/ui/View';
 import classNames from 'classnames';
-import { useTranslations, useLocale } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
 import { useLayout } from '~hooks';
-import { usePathname } from '~i18n/routing';
 
 import { MenuItem } from '../MenuItem';
-import { LANGUAGES_OPTIONS } from './constants';
+import { LanguageSelector } from './LanguageSelector';
 import { ThemeToggle } from './ThemeToggle';
 
 export const SideNavigation: FC = () => {
   const { open } = useLayout();
   const t = useTranslations('SideNavigation');
-  const locale = useLocale();
-  const { replace } = useRouter();
-  const pathname = usePathname();
-
-  const onChangeLanguage = useCallback<RadioGroupProps['onChange']>(
-    (event) => {
-      const { value } = event.target;
-
-      replace(pathname !== '/' ? `/${value}${pathname}` : value);
-    },
-    [replace, pathname],
-  );
-
-  const renderLanguages = useCallback<RadioGroupChildrenFn>(
-    ({ name, value, onChange }) => {
-      return LANGUAGES_OPTIONS.map(({ label, icon, option }) => (
-        <li key={option} className="flex flex-row gap-x-3">
-          <Radio
-            id={option}
-            name={name}
-            value={value}
-            onChange={onChange}
-            option={option}
-            icon={icon}
-          >
-            {label}
-          </Radio>
-        </li>
-      ));
-    },
-    [],
-  );
 
   return (
     <nav
@@ -100,21 +60,7 @@ export const SideNavigation: FC = () => {
           GitHub
         </MenuItem.Item2.Link>
         <ThemeToggle />
-        <MenuItem.Item2.Expandable
-          title={t('language')}
-          icon="material-symbols:language"
-          iconClassName="text-white"
-        >
-          <RadioGroup
-            name="language"
-            value={locale}
-            onChange={onChangeLanguage}
-            containerElementType="ul"
-            className="flex flex-col gap-y-2"
-          >
-            {renderLanguages}
-          </RadioGroup>
-        </MenuItem.Item2.Expandable>
+        <LanguageSelector />
       </ul>
     </nav>
   );

--- a/apps/web/tests/components/View/SideNavigation/LanguageSelector.test.tsx
+++ b/apps/web/tests/components/View/SideNavigation/LanguageSelector.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { LanguageSelector } from '~/components/View/SideNavigation/LanguageSelector';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockReplace = vi.fn();
+let mockPathname = '/about';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+vi.mock('~i18n/routing', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en-US',
+}));
+
+vi.mock('~/components/View/MenuItem/index', () => ({
+  MenuItem: {
+    Item2: {
+      Expandable: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="language-expandable">{children}</div>
+      ),
+    },
+  },
+}));
+
+vi.mock('@repo/ui/Control', () => ({
+  RadioGroup: ({
+    children,
+    name,
+    value,
+    onChange,
+  }: {
+    children: (args: {
+      name: string;
+      value: string;
+      onChange: React.ChangeEventHandler<HTMLInputElement>;
+    }) => React.ReactNode;
+    name: string;
+    value: string;
+    onChange: React.ChangeEventHandler<HTMLInputElement>;
+    containerElementType?: string;
+    className?: string;
+  }) => <ul>{children({ name, value, onChange })}</ul>,
+  Radio: ({
+    children,
+    option,
+    onChange,
+    name,
+  }: {
+    children: React.ReactNode;
+    id: string;
+    name: string;
+    value: string;
+    onChange: React.ChangeEventHandler<HTMLInputElement>;
+    option: string;
+    icon: string;
+    iconClassName?: string;
+  }) => (
+    <label>
+      <input
+        type="radio"
+        name={name}
+        value={option}
+        onChange={onChange}
+        data-testid={`radio-${option}`}
+      />
+      {children}
+    </label>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPathname = '/about';
+});
+
+describe('LanguageSelector', () => {
+  it('should render all three language options', () => {
+    render(<LanguageSelector />);
+
+    expect(screen.getByTestId('radio-en-US')).toBeInTheDocument();
+    expect(screen.getByTestId('radio-pt-BR')).toBeInTheDocument();
+    expect(screen.getByTestId('radio-es')).toBeInTheDocument();
+  });
+
+  it('should render the expandable language container', () => {
+    render(<LanguageSelector />);
+
+    expect(screen.getByTestId('language-expandable')).toBeInTheDocument();
+  });
+
+  it('should navigate to /<locale><pathname> when a language is selected on a non-root path', () => {
+    render(<LanguageSelector />);
+
+    fireEvent.click(screen.getByTestId('radio-pt-BR'));
+
+    expect(mockReplace).toHaveBeenCalledWith('/pt-BR/about');
+  });
+
+  it('should navigate to <locale> when a language is selected on the root path', () => {
+    mockPathname = '/';
+
+    render(<LanguageSelector />);
+
+    fireEvent.click(screen.getByTestId('radio-es'));
+
+    expect(mockReplace).toHaveBeenCalledWith('es');
+  });
+
+  it('should call replace with "/en-US/<pathname>" when en-US radio is selected', () => {
+    render(<LanguageSelector />);
+
+    fireEvent.click(screen.getByTestId('radio-en-US'));
+
+    expect(mockReplace).toHaveBeenCalledWith('/en-US/about');
+  });
+});


### PR DESCRIPTION
## Summary

- Extrai a lógica do `LanguageSelector` do `SideNavigation` para um componente dedicado `LanguageSelector.tsx`
- Integra o `LanguageSelector` ao `SideNavigation` via importação direta
- Adiciona 5 testes unitários cobrindo renderização e navegação por locale (path não-root e root)

Refs #298

## Test plan

- [ ] `pnpm --filter web run test:watch -- run` — todos os 65 testes passando
- [ ] `pnpm --filter web types` — sem erros de TypeScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)