### PR TITLE
feat(web): add custom not-found page with i18n and tests (T-34)

### DIFF
--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -32,6 +32,11 @@
     "description": "We couldn't load this content. Please try again.",
     "retry": "Try again"
   },
+  "NotFound": {
+    "title": "Page not found",
+    "description": "The page you're looking for doesn't exist or has been moved.",
+    "backToHome": "Back to home"
+  },
   "Validations": {
     "required": "Required field.",
     "min": "Minimum of 3 characters."

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -32,6 +32,11 @@
     "description": "No pudimos cargar este contenido. Por favor, inténtelo de nuevo.",
     "retry": "Intentar de nuevo"
   },
+  "NotFound": {
+    "title": "Página no encontrada",
+    "description": "La página que estás buscando no existe o fue movida.",
+    "backToHome": "Volver al inicio"
+  },
   "Validations": {
     "required": "Campo obligatorio.",
     "min": "Mínimo de 3 caracteres."

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -32,6 +32,11 @@
     "description": "Não foi possível carregar este conteúdo. Tente novamente.",
     "retry": "Tentar novamente"
   },
+  "NotFound": {
+    "title": "Página não encontrada",
+    "description": "A página que você está procurando não existe ou foi movida.",
+    "backToHome": "Voltar para o início"
+  },
   "Validations": {
     "required": "Campo obrigatório.",
     "min": "Mínimo de 3 caracteres."

--- a/apps/web/src/app/[locale]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[...rest]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation';
+
+export default function CatchAllPage() {
+  notFound();
+}

--- a/apps/web/src/app/[locale]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[...rest]/page.tsx
@@ -1,9 +1,0 @@
-import { useLocale } from 'next-intl';
-
-import { redirect } from '~i18n/routing';
-
-export default function CatchAllPage() {
-  const locale = useLocale();
-
-  redirect({ href: '/', locale: locale });
-}

--- a/apps/web/src/app/[locale]/not-found.tsx
+++ b/apps/web/src/app/[locale]/not-found.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { Link } from '~i18n/routing';
+
+export default function NotFound() {
+  const t = useTranslations('NotFound');
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-y-4 text-white">
+      <h1 className="text-6xl font-bold">404</h1>
+      <h2 className="text-2xl font-semibold">{t('title')}</h2>
+      <p className="text-dark-900 text-center max-w-sm">{t('description')}</p>
+      <Link
+        href="/"
+        className="px-6 py-2 bg-white text-black rounded-lg font-medium hover:bg-gray-200 transition-colors"
+      >
+        {t('backToHome')}
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/tests/app/not-found.test.tsx
+++ b/apps/web/tests/app/not-found.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('~i18n/routing', () => ({
+  Link: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import NotFound from '~/app/[locale]/not-found';
+
+describe('NotFound', () => {
+  it('should render the 404 heading', () => {
+    render(<NotFound />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+
+  it('should render translated title and description', () => {
+    render(<NotFound />);
+    expect(screen.getByRole('heading', { name: 'title' })).toBeInTheDocument();
+    expect(screen.getByText('description')).toBeInTheDocument();
+  });
+
+  it('should render a link back to home', () => {
+    render(<NotFound />);
+    const link = screen.getByRole('link', { name: 'backToHome' });
+    expect(link).toHaveAttribute('href', '/');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `apps/web/src/app/[locale]/not-found.tsx` — Client Component using `useTranslations('NotFound')` and `Link` from `~i18n/routing`
- Adds `NotFound` i18n namespace to `en-US.json`, `pt-BR.json`, and `es.json` with `title`, `description`, and `backToHome` keys
- Adds `apps/web/tests/app/not-found.test.tsx` with 3 behavior tests (404 heading, translated content, link href)

Refs #300

## Test plan

- [x] `should render the 404 heading`
- [x] `should render translated title and description`
- [x] `should render a link back to home`

🤖 Generated with [Claude Code](https://claude.com/claude-code)