### PR TITLE
feat(web): StatCard component + profile stats on Home (T-24)

### DIFF
--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -5,15 +5,28 @@ import { applyDevSimulations } from '~/dev/simulate';
 import { getInternalBaseUrl } from '~/lib/api/internal';
 import { ApiResponse } from '~/lib/api/envelope';
 import HeroLandingPage from '~assets/images/hero-landing-page.png';
-import { ContactForm, HeroBanner, ProjectList, ContactInfo } from '~components';
+import {
+  ContactForm,
+  HeroBanner,
+  ProjectList,
+  ContactInfo,
+  StatCard,
+} from '~components';
 
 import { ProjectSummary } from '~components/View/ProjectList';
+
+interface ProfileStat {
+  label: string;
+  value: string;
+  icon: string;
+}
 
 interface ProfileHero {
   name: string;
   headline: string;
   bio: string;
   photo: { url: string; alt: string };
+  stats: ProfileStat[];
 }
 
 interface HomePageProps {
@@ -60,6 +73,18 @@ export default async function Home({ searchParams }: HomePageProps) {
         alt={profile?.photo.alt ?? t('hero_image_alt')}
         imageClassName="object-contain 2xl:object-cover"
       />
+      {profile?.stats && profile.stats.length > 0 && (
+        <section className="mx-4 my-6 grid grid-cols-2 gap-3 xl:mx-auto xl:my-8 xl:w-full xl:max-w-237.5 xl:grid-cols-4">
+          {profile.stats.map((stat) => (
+            <StatCard
+              key={stat.label}
+              label={stat.label}
+              value={stat.value}
+              icon={stat.icon}
+            />
+          ))}
+        </section>
+      )}
       <h4 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
         {t('projects_title')}
       </h4>

--- a/apps/web/src/components/View/StatCard/index.tsx
+++ b/apps/web/src/components/View/StatCard/index.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react';
+
+import { Icon } from '@repo/ui/Imagery';
+
+interface IStatCardProps {
+  label: string;
+  value: string;
+  icon: string;
+}
+
+export const StatCard: FC<IStatCardProps> = ({ label, value, icon }) => {
+  return (
+    <article className="flex items-center gap-x-3 border border-dark-300 px-4 py-4 rounded-xl bg-dark-300/20">
+      <Icon icon={icon} className="text-4xl text-accent shrink-0" />
+      <div className="flex flex-col">
+        <span className="text-white font-semibold text-lg leading-tight">
+          {value}
+        </span>
+        <span className="text-gray-400 text-sm">{label}</span>
+      </div>
+    </article>
+  );
+};

--- a/apps/web/src/components/View/index.ts
+++ b/apps/web/src/components/View/index.ts
@@ -9,3 +9,4 @@ export * from './ProjectCard';
 export * from './ProjectList';
 export * from './SideNavigation';
 export * from './Skill';
+export * from './StatCard';

--- a/apps/web/tests/components/View/StatCard/StatCard.test.tsx
+++ b/apps/web/tests/components/View/StatCard/StatCard.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('@repo/ui/Imagery', () => ({
+  Icon: ({ icon, className }: { icon: string; className?: string }) => (
+    <span data-testid={`icon-${icon}`} className={className} />
+  ),
+}));
+
+import { StatCard } from '~/components/View/StatCard';
+
+const defaultProps = {
+  label: 'Years of experience',
+  value: '+5',
+  icon: 'mdi:briefcase',
+};
+
+describe('StatCard', () => {
+  it('should render the value', () => {
+    render(<StatCard {...defaultProps} />);
+    expect(screen.getByText('+5')).toBeInTheDocument();
+  });
+
+  it('should render the label', () => {
+    render(<StatCard {...defaultProps} />);
+    expect(screen.getByText('Years of experience')).toBeInTheDocument();
+  });
+
+  it('should render the icon with the correct icon prop', () => {
+    render(<StatCard {...defaultProps} />);
+    expect(screen.getByTestId('icon-mdi:briefcase')).toBeInTheDocument();
+  });
+
+  it('should render as an article element', () => {
+    const { container } = render(<StatCard {...defaultProps} />);
+    expect(container.querySelector('article')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Creates `StatCard` component (`apps/web/src/components/View/StatCard/index.tsx`) with props `{ label, value, icon }`, rendering icon via Iconify (`@repo/ui/Imagery`)
- Exports `StatCard` from the View barrel (`components/View/index.ts`)
- Extends `ProfileHero` on the Home page to include `stats: ProfileStat[]`
- Renders a responsive 2-col (mobile) / 4-col (desktop) grid of `StatCard`s between the hero and the projects list when profile stats are available
- 4 new tests for `StatCard`, all passing — full suite: 99 tests, 22 files

## Test plan

- [ ] `StatCard` renders value, label, and icon with correct test IDs
- [ ] Home page shows stats grid when profile returns stats
- [ ] Home page renders without stats grid when profile is unavailable
- [ ] `pnpm test` passes (22 files, 99 tests)
- [ ] `pnpm types` passes with no errors

Refs #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)