### PR TITLE
chore(env): clarify .env.example scope — root for Prisma CLI, web for Next.js

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,36 +1,19 @@
-# Environment variables reference
+# Root environment variables
 #
 # Do NOT add real credentials here — this file is committed to git.
 #
-# Three gitignored env files, each with a different scope:
+# Used by: Prisma CLI (migrations, studio, seed) — run from packages/infra/.
+# Copy to .env.local at the repo root and fill in your Supabase dev credentials.
 #
-#   .env                                  ← production (never use for local work)
-#   .env.local                            ← local dev (Next.js, pnpm dev)
-#   packages/infra/.env.test.local        ← integration tests (Vitest)
-#
-# To set up local development, copy this file to .env.local and fill in your
-# Supabase dev project credentials. Then copy it again (or create separately)
-# to packages/infra/.env.test.local for test runs.
-#
-# See docs/01-GETTING-STARTED.md → "Environment Variables" for details.
+# Next.js variables live in apps/web/.env.example (separate scope).
 
 # ── Database (Supabase Postgres) ───────────────────────────────────────────────
 # supabase.com → Project Settings → Database → Connection string
-# Use "Transaction" mode (port 6543) for DATABASE_URL.
-# Use "Session" mode (port 5432) for DIRECT_URL.
+# Use "Transaction" mode (port 6543) for DATABASE_URL (pooled).
+# Use "Session" mode (port 5432) for DIRECT_URL (used by Prisma migrations).
 DATABASE_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true"
 DIRECT_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres"
 
-# ── Resend (email service) ─────────────────────────────────────────────────────
-# https://resend.com → API Keys
-RESEND_API_KEY="re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-CONTACT_EMAIL_TO="your@email.com"
-CONTACT_EMAIL_FROM="onboarding@resend.dev"
-
-# ── Identity ────────────────────────────────────────────────────────────────────
+# ── Seed ───────────────────────────────────────────────────────────────────────
+# Admin user created by packages/infra/prisma/seed.ts
 ADMIN_EMAIL="admin@portfolio.dev"
-
-# ── Supabase Auth ───────────────────────────────────────────────────────────────
-# supabase.com → Project Settings → API
-SUPABASE_URL="https://[project-ref].supabase.co"
-SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,26 @@
-NEXT_PUBLIC_CONTACT_EMAIL=
-NEXT_PUBLIC_CONTACT_NUMBER=
-NEXT_PUBLIC_GITHUB_URL=
-NEXT_PUBLIC_LINKEDIN_URL=
-NEXT_PUBLIC_RESUME_URL=
-NEXT_PUBLIC_WHATSAPP_URL=
+# Next.js environment variables
+#
+# Do NOT add real credentials here — this file is committed to git.
+#
+# Copy to apps/web/.env.local and fill in your values for local development.
+# In production, set these variables through your hosting platform (e.g. Vercel).
+
+# ── Supabase Auth ──────────────────────────────────────────────────────────────
+# supabase.com → Project Settings → API
+SUPABASE_URL="https://[project-ref].supabase.co"
+SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+
+# ── Resend (email service) ─────────────────────────────────────────────────────
+# Used by POST /api/v1/contact → SendContactMessage use case
+# https://resend.com → API Keys
+RESEND_API_KEY="re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+CONTACT_EMAIL_TO="your@email.com"
+CONTACT_EMAIL_FROM="onboarding@resend.dev"
+
+# ── Public (exposed to the browser) ───────────────────────────────────────────
+NEXT_PUBLIC_CONTACT_EMAIL="your@email.com"
+NEXT_PUBLIC_CONTACT_NUMBER="5511999999999"
+NEXT_PUBLIC_GITHUB_URL="https://github.com/your-username"
+NEXT_PUBLIC_LINKEDIN_URL="https://www.linkedin.com/in/your-profile/"
+NEXT_PUBLIC_RESUME_URL="https://docs.google.com/..."
+NEXT_PUBLIC_WHATSAPP_URL="https://api.whatsapp.com/send?phone=5511999999999"


### PR DESCRIPTION
## Summary

- **Root `.env.example`**: trimmed to only `DATABASE_URL`, `DIRECT_URL` (Prisma CLI) and `ADMIN_EMAIL` (seed). Removed `SUPABASE_*`, `RESEND_*`, `CONTACT_EMAIL_*` — those belong to the Next.js scope.
- **`apps/web/.env.example`**: now contains all Next.js server-side vars (`SUPABASE_*`, `RESEND_*`, `CONTACT_EMAIL_*`) and all `NEXT_PUBLIC_*` client vars, with descriptions pointing to where each value comes from.

Each file now reflects only the variables that the corresponding runtime actually reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)