### PR TITLE
chore(env): add DATABASE_URL and DIRECT_URL to apps/web/.env.example

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -5,6 +5,13 @@
 # Copy to apps/web/.env.local and fill in your values for local development.
 # In production, set these variables through your hosting platform (e.g. Vercel).
 
+# ── Database (Prisma) ─────────────────────────────────────────────────────────
+# supabase.com → Project Settings → Database → Connection string
+# Use the "Transaction" pooler URL for DATABASE_URL (runtime queries)
+# Use the "Session" / direct URL for DIRECT_URL (migrations)
+DATABASE_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true"
+DIRECT_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres"
+
 # ── Supabase Auth ──────────────────────────────────────────────────────────────
 # supabase.com → Project Settings → API
 SUPABASE_URL="https://[project-ref].supabase.co"


### PR DESCRIPTION
## Summary

- Add `DATABASE_URL` and `DIRECT_URL` to `apps/web/.env.example`

Prisma client is instantiated in `packages/infra` but executes inside the Next.js process, which only reads env vars from `apps/web/.env.local`. The root `.env.local` is only seen by `dotenv-cli` when running infra scripts directly (migrations, seed).

Without `DATABASE_URL` in `apps/web/.env.local`, every API route that touches Prisma throws a 500 at runtime.

## Test plan

- [x] All pre-commit hooks pass
- [x] Add `DATABASE_URL` and `DIRECT_URL` to `apps/web/.env.local` (copy from root `.env.local`) to fix the 500s locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)