### PR TITLE
fix(web): use fill on HeroBanner Image + allow placehold.co domain

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -13,10 +13,8 @@ const nextConfig = {
   images: {
     qualities: [100, 75],
     remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'cdn.pixabay.com',
-      },
+      { protocol: 'https', hostname: 'cdn.pixabay.com' },
+      { protocol: 'https', hostname: 'placehold.co' },
     ],
   },
 };

--- a/apps/web/src/components/View/HeroBanner/index.tsx
+++ b/apps/web/src/components/View/HeroBanner/index.tsx
@@ -31,14 +31,15 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
         className,
       )}
     >
-      <section className="flex flex-row justify-center xl:order-1 xl:w-1/2">
+      <section className="relative h-64 flex flex-row justify-center xl:order-1 xl:h-full xl:w-1/2">
         <Image
           src={src}
           alt={alt}
           priority
           quality={100}
+          fill
           className={imageClassName}
-          sizes="100vw"
+          sizes="(max-width: 1280px) 100vw, 50vw"
         />
       </section>
       <section className="flex flex-col px-6 pb-6 xl:order-0 xl:py-20 xl:pl-20 xl:w-1/2">


### PR DESCRIPTION
## Summary

- **HeroBanner**: switch `<Image>` from implicit dimensions to `fill` + `relative` container

  Next.js `Image` infers `width`/`height` automatically only for `StaticImageData` (static imports). When `src` is a URL string (e.g. from the database), it throws:
  > Error: Image with src "..." is missing required "width" property.

  Using `fill` sidesteps the constraint and works for both static imports and external URLs. The image container becomes `relative h-64 xl:h-full` to give fill a sized parent.

- **next.config.mjs**: add `placehold.co` to `remotePatterns` so seed placeholder images are served without the "unconfigured host" error.

## Test plan

- [x] All pre-commit hooks pass
- [x] Dev server renders HeroBanner with profile photo URL without throwing
- [x] Static `HeroLandingPage` import still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)