### PR TITLE
feat(web): connect projects page to GET /api/v1/projects (T-26)

### DIFF
--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -61,5 +61,11 @@
     "required": "Required field.",
     "min": "Minimum of 3 characters.",
     "email": "Enter a valid e-mail address."
+  },
+  "Projects": {
+    "hero_title": "Portfolio",
+    "hero_caption": "Discover some of my projects",
+    "hero_content": "A selection of projects I've worked on — from product features to full-stack applications.",
+    "hero_image_alt": "Professional Picture 1 of Wallace Ferreira"
   }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -61,5 +61,11 @@
     "required": "Campo obligatorio.",
     "min": "Mínimo de 3 caracteres.",
     "email": "Introduce un correo electrónico válido."
+  },
+  "Projects": {
+    "hero_title": "Portafolio",
+    "hero_caption": "Conoce algunos de mis proyectos",
+    "hero_content": "Una selección de proyectos en los que he trabajado — desde funcionalidades de producto hasta aplicaciones full-stack.",
+    "hero_image_alt": "Foto profesional 1 de Wallace Ferreira"
   }
 }

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -61,5 +61,11 @@
     "required": "Campo obrigatório.",
     "min": "Mínimo de 3 caracteres.",
     "email": "Informe um e-mail válido."
+  },
+  "Projects": {
+    "hero_title": "Portfólio",
+    "hero_caption": "Conheça alguns dos meus projetos",
+    "hero_content": "Uma seleção de projetos em que trabalhei — de funcionalidades de produto a aplicações full-stack.",
+    "hero_image_alt": "Foto profissional 1 de Wallace Ferreira"
   }
 }

--- a/apps/web/src/app/[locale]/projects/page.tsx
+++ b/apps/web/src/app/[locale]/projects/page.tsx
@@ -1,6 +1,12 @@
+import { getLocale, getTranslations } from 'next-intl/server';
+
 import HeroProjects from '~assets/images/hero-projects.png';
-import { HeroBanner } from '~components/View';
+import { HeroBanner, ProjectList } from '~components/View';
 import { applyDevSimulations } from '~/dev/simulate';
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
+
+import { ProjectSummary } from '~components/View/ProjectList';
 
 interface ProjectsPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
@@ -9,16 +15,34 @@ interface ProjectsPageProps {
 export default async function Projects({ searchParams }: ProjectsPageProps) {
   await applyDevSimulations(await searchParams);
 
+  const [t, locale, baseUrl] = await Promise.all([
+    getTranslations('Projects'),
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const projectsRes = await fetch(
+    `${baseUrl}/api/v1/projects?locale=${locale}`,
+    { cache: 'no-store' },
+  ).catch(() => null);
+
+  let projects: ProjectSummary[] = [];
+  if (projectsRes?.ok) {
+    const body: ApiResponse<ProjectSummary[]> = await projectsRes.json();
+    if (!body.error) projects = body.data;
+  }
+
   return (
     <>
       <HeroBanner
         src={HeroProjects}
-        title="Portfólio"
-        caption="Conheça alguns dos meus projetos"
-        content="Lorem ipsum odor amet, consectetuer adipiscing elit. Nisl ad dictumst donec consequat sollicitudin mauris. Id inceptos nibh varius; maecenas congue ullamcorper. Senectus massa tellus metus, nullam diam amet fringilla."
-        alt="Professional Picture 1 of Wallace Ferreira"
+        title={t('hero_title')}
+        caption={t('hero_caption')}
+        content={t('hero_content')}
+        alt={t('hero_image_alt')}
         imageClassName="object-contain p-6 xl:py-8"
       />
+      <ProjectList projects={projects} view="grid" className="py-8 xl:py-20" />
     </>
   );
 }

--- a/apps/web/tests/app/[locale]/projects.test.tsx
+++ b/apps/web/tests/app/[locale]/projects.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue({ get: () => 'localhost:3000' }),
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/dev/simulate', () => ({
+  applyDevSimulations: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('~assets/images/hero-projects.png', () => ({
+  default: '/hero-projects.png',
+}));
+
+vi.mock('~components/View', () => ({
+  HeroBanner: ({ title, caption }: { title: string; caption: string }) => (
+    <div data-testid="hero">
+      <span data-testid="hero-title">{title}</span>
+      <span data-testid="hero-caption">{caption}</span>
+    </div>
+  ),
+  ProjectList: ({ projects }: { projects: { id: string; title: string }[] }) => (
+    <ul data-testid="project-list">
+      {projects.map((p) => (
+        <li key={p.id}>{p.title}</li>
+      ))}
+    </ul>
+  ),
+}));
+
+vi.mock('~components/View/ProjectList', () => ({}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const PROJECTS = [
+  { id: '1', slug: 'proj-a', title: 'Project A', caption: 'Cap A', coverImage: { url: '', alt: '' }, skills: [] },
+  { id: '2', slug: 'proj-b', title: 'Project B', caption: 'Cap B', coverImage: { url: '', alt: '' }, skills: [] },
+];
+
+function mockApi(projects: unknown[] | null) {
+  mockFetch.mockResolvedValue(
+    projects === null
+      ? { ok: false, json: async () => ({ data: null, error: { code: 'INTERNAL_ERROR', message: '' } }) }
+      : { ok: true, json: async () => ({ data: projects, error: null }) },
+  );
+}
+
+describe('Projects page', () => {
+  it('should render hero with i18n translations', async () => {
+    mockApi([]);
+
+    const { default: Projects } = await import('~/app/[locale]/projects/page');
+    render(await Projects({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
+    expect(screen.getByTestId('hero-caption')).toHaveTextContent('t.hero_caption');
+  });
+
+  it('should render project list with fetched projects', async () => {
+    mockApi(PROJECTS);
+
+    const { default: Projects } = await import('~/app/[locale]/projects/page');
+    render(await Projects({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText('Project A')).toBeInTheDocument();
+    expect(screen.getByText('Project B')).toBeInTheDocument();
+  });
+
+  it('should render empty project list when API fails', async () => {
+    mockApi(null);
+
+    const { default: Projects } = await import('~/app/[locale]/projects/page');
+    render(await Projects({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
+  });
+
+  it('should render empty project list when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { default: Projects } = await import('~/app/[locale]/projects/page');
+    render(await Projects({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## Summary

- `projects/page.tsx` now fetches `GET /api/v1/projects?locale={locale}` as an async Server Component
- Replaces all hardcoded Portuguese strings with `getTranslations('Projects')` namespace
- Adds `Projects` i18n namespace to `en-US.json`, `pt-BR.json`, and `es.json`
- Renders `ProjectList` with API response; graceful fallback to empty array on fetch failure or error envelope

## Test plan

- [x] 4 new tests: i18n hero renders, fetched projects render, API failure → empty list, network error → empty list
- [x] 104 total tests passing
- [x] TypeScript, lint, format, commitlint hooks all pass
- [ ] Manual: verify projects render at `/pt-BR/projects` and `/en-US/projects` with seed data

Refs #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)