### PR TITLE
feat(web): internationalize remaining hardcoded strings (T-31)

### DIFF
--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -67,5 +67,14 @@
     "hero_caption": "Discover some of my projects",
     "hero_content": "A selection of projects I've worked on — from product features to full-stack applications.",
     "hero_image_alt": "Professional Picture 1 of Wallace Ferreira"
+  },
+  "About": {
+    "values_title": "My professional values"
+  },
+  "Common": {
+    "loading": "Loading"
+  },
+  "Header": {
+    "logo_alt": "Logo"
   }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -67,5 +67,14 @@
     "hero_caption": "Conoce algunos de mis proyectos",
     "hero_content": "Una selección de proyectos en los que he trabajado — desde funcionalidades de producto hasta aplicaciones full-stack.",
     "hero_image_alt": "Foto profesional 1 de Wallace Ferreira"
+  },
+  "About": {
+    "values_title": "Mis valores profesionales"
+  },
+  "Common": {
+    "loading": "Cargando"
+  },
+  "Header": {
+    "logo_alt": "Logo"
   }
 }

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -67,5 +67,14 @@
     "hero_caption": "Conheça alguns dos meus projetos",
     "hero_content": "Uma seleção de projetos em que trabalhei — de funcionalidades de produto a aplicações full-stack.",
     "hero_image_alt": "Foto profissional 1 de Wallace Ferreira"
+  },
+  "About": {
+    "values_title": "Meus valores profissionais"
+  },
+  "Common": {
+    "loading": "Carregando"
+  },
+  "Header": {
+    "logo_alt": "Logo"
   }
 }

--- a/apps/web/src/app/[locale]/about/loading.tsx
+++ b/apps/web/src/app/[locale]/about/loading.tsx
@@ -1,6 +1,9 @@
-export default function AboutLoading() {
+import { getTranslations } from 'next-intl/server';
+
+export default async function AboutLoading() {
+  const t = await getTranslations('Common');
   return (
-    <div className="animate-pulse" aria-busy="true" aria-label="Loading">
+    <div className="animate-pulse" aria-busy="true" aria-label={t('loading')}>
       {/* Section title */}
       <div className="h-8 w-64 bg-gray-700 rounded mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
 

--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -5,6 +5,7 @@ import {
   LocationType,
 } from '@repo/core/portfolio';
 import { Divider } from '@repo/ui/View';
+import { getTranslations } from 'next-intl/server';
 
 import { ProfessionalValue, ExperienceCard } from '~components/View';
 import { applyDevSimulations } from '~/dev/simulate';
@@ -116,11 +117,12 @@ interface AboutPageProps {
 
 export default async function About({ searchParams }: AboutPageProps) {
   await applyDevSimulations(await searchParams);
+  const t = await getTranslations('About');
 
   return (
     <>
       <h4 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
-        Meus valores profissionais
+        {t('values_title')}
       </h4>
       <ul className="flex flex-row gap-x-4">
         {PROFESSIONAL_VALUES.map((professionalValue) => (

--- a/apps/web/src/app/[locale]/loading.tsx
+++ b/apps/web/src/app/[locale]/loading.tsx
@@ -1,6 +1,9 @@
-export default function HomeLoading() {
+import { getTranslations } from 'next-intl/server';
+
+export default async function HomeLoading() {
+  const t = await getTranslations('Common');
   return (
-    <div className="animate-pulse" aria-busy="true" aria-label="Loading">
+    <div className="animate-pulse" aria-busy="true" aria-label={t('loading')}>
       {/* HeroBanner — bg-dark-300, xl:h-[424px], two columns */}
       <section className="flex flex-col bg-dark-300 gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-[424px]">
         <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">

--- a/apps/web/src/app/[locale]/projects/loading.tsx
+++ b/apps/web/src/app/[locale]/projects/loading.tsx
@@ -1,6 +1,9 @@
-export default function ProjectsLoading() {
+import { getTranslations } from 'next-intl/server';
+
+export default async function ProjectsLoading() {
+  const t = await getTranslations('Common');
   return (
-    <div className="animate-pulse" aria-busy="true" aria-label="Loading">
+    <div className="animate-pulse" aria-busy="true" aria-label={t('loading')}>
       {/* HeroBanner — same structure as home */}
       <section className="flex flex-col bg-dark-300 gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-[424px]">
         <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">

--- a/apps/web/src/components/View/ExperienceCard/index.tsx
+++ b/apps/web/src/components/View/ExperienceCard/index.tsx
@@ -4,24 +4,34 @@ import { FC } from 'react';
 
 import { IExperienceProps } from '@repo/core/portfolio';
 import { TextRich } from '@repo/ui/View';
+import { useLocale } from 'next-intl';
 
 import { useBreakpoint } from '~hooks';
 
 import { SkillGroup } from '../SkillGroup';
 
-export const ExperienceCard: FC<IExperienceProps> = ({ company, position }) => {
+export const ExperienceCard: FC<IExperienceProps> = ({
+  company,
+  position,
+  description,
+}) => {
   const isXL = useBreakpoint('xl');
+  const locale = useLocale() as keyof typeof position;
   const skillProps: string[] = [];
 
   return (
     <article className="flex flex-col py-6 px-3 bg-dark-200 rounded-xl gap-y-3">
       <header className="flex flex-col justify-center gap-y-2">
-        <h5 className="text-white line-clamp-2">{position['pt-BR']}</h5>
-        <h6 className="text-dark-700 line-clamp-3">{company['pt-BR']}</h6>
+        <h5 className="text-white line-clamp-2">
+          {position[locale] ?? position['en-US']}
+        </h5>
+        <h6 className="text-dark-700 line-clamp-3">
+          {company[locale] ?? company['en-US']}
+        </h6>
       </header>
       <TextRich
         className="text-white line-clamp-4"
-        content="Lorem ipsum dolor sit amet consectetur adipisicing elit. Saepe dolore voluptas ab blanditiis beatae rem unde voluptatem animi error, perspiciatis, ratione quo ullam cupiditate aut illum numquam eos ducimus facere?"
+        content={description[locale] ?? description['en-US']}
       />
       <SkillGroup
         skills={skillProps}

--- a/apps/web/src/components/View/Header/index.tsx
+++ b/apps/web/src/components/View/Header/index.tsx
@@ -4,6 +4,7 @@ import { FC } from 'react';
 
 import { Button } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
+import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
 import logoDesktop from '~assets/images/logo-desktop.svg';
@@ -12,6 +13,7 @@ import { useLayout } from '~hooks';
 
 export const Header: FC = () => {
   const { open, toggle } = useLayout();
+  const t = useTranslations('Header');
 
   return (
     <header className="w-full xl:w-60 flex items-center xl:items-end justify-between xl:justify-center bg-dark-300 xl:!bg-dark-200 xl:bg-transparent px-4 py-3 xl:px-0 xl:py-0 transition-all duration-300 ease-linear h-header-mobile xl:h-header-desktop">
@@ -19,7 +21,7 @@ export const Header: FC = () => {
         src={logoDesktop}
         width={179}
         height={66}
-        alt="Logo"
+        alt={t('logo_alt')}
         className="hidden xl:block"
         priority
       />
@@ -27,7 +29,7 @@ export const Header: FC = () => {
         src={logoMobile}
         width={120}
         height={44}
-        alt="Logo"
+        alt={t('logo_alt')}
         className="block xl:hidden"
         priority
       />

--- a/apps/web/tests/app/loading.test.tsx
+++ b/apps/web/tests/app/loading.test.tsx
@@ -1,22 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
 import { render } from '@testing-library/react';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => key),
+}));
 
 import HomeLoading from '~/app/[locale]/loading';
 import ProjectsLoading from '~/app/[locale]/projects/loading';
 import AboutLoading from '~/app/[locale]/about/loading';
 
 describe('Loading skeletons', () => {
-  it('should render HomeLoading without crashing', () => {
-    const { container } = render(<HomeLoading />);
+  it('should render HomeLoading without crashing', async () => {
+    const { container } = render(await HomeLoading());
     expect(container.firstChild).toBeTruthy();
   });
 
-  it('should render ProjectsLoading without crashing', () => {
-    const { container } = render(<ProjectsLoading />);
+  it('should render ProjectsLoading without crashing', async () => {
+    const { container } = render(await ProjectsLoading());
     expect(container.firstChild).toBeTruthy();
   });
 
-  it('should render AboutLoading without crashing', () => {
-    const { container } = render(<AboutLoading />);
+  it('should render AboutLoading without crashing', async () => {
+    const { container } = render(await AboutLoading());
     expect(container.firstChild).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Add `About`, `Common`, `Header` namespaces to all 3 locale files (en-US, pt-BR, es)
- Make `loading.tsx` skeletons async; use `getTranslations('Common')` for `aria-label`
- About page heading (`Meus valores profissionais`) replaced with `t('values_title')`
- Header logo `alt` uses `t('logo_alt')` via `useTranslations('Header')`
- `ExperienceCard` renders locale-aware company/position/description via `useLocale()`
- Update `loading.test.tsx` to `await` async RSC loading components

Closes #301

## Test plan

- [ ] `pnpm --filter web exec vitest run` — all 104 tests pass
- [ ] `pnpm --filter web build` — build completes cleanly
- [ ] Navigate `/en-US`, `/pt-BR`, `/es` — verify About heading and loading aria-labels render in correct locale
- [ ] ExperienceCard shows locale-aware text (no hardcoded `pt-BR`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)