### PR TITLE
chore(taskmaster): mark sprint-3 tasks 17 and 28 as done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -3774,7 +3774,7 @@
         "dependencies": [
           "6"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -3847,7 +3847,7 @@
             "parentId": "undefined"
           }
         ],
-        "updatedAt": "2026-04-02T03:21:49.111Z"
+        "updatedAt": "2026-05-10T21:29:32.655Z"
       },
       {
         "id": "18",
@@ -4055,7 +4055,7 @@
         "dependencies": [
           "17"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -4108,7 +4108,7 @@
             "parentId": "undefined"
           }
         ],
-        "updatedAt": "2026-04-02T03:21:49.111Z"
+        "updatedAt": "2026-05-10T21:29:32.671Z"
       },
       {
         "id": "29",
@@ -4151,9 +4151,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-05-10T21:23:49.261Z",
+      "lastModified": "2026-05-10T21:29:32.671Z",
       "taskCount": 16,
-      "completedCount": 11,
+      "completedCount": 13,
       "tags": [
         "sprint-3"
       ]


### PR DESCRIPTION
Updates `.taskmaster/tasks/tasks.json` — T-17 (REST envelope + route handlers) and T-28 (auth/* + /me) were already fully implemented, confirmed by existing files and passing test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)