### PR TITLE
feat(web): project detail page via GET /api/v1/projects/:slug (T-21)

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -3932,7 +3932,7 @@
         "dependencies": [
           "17"
         ],
-        "status": "pending",
+        "status": "in-progress",
         "subtasks": [
           {
             "id": 1,
@@ -3965,7 +3965,7 @@
             "parentId": "undefined"
           }
         ],
-        "updatedAt": "2026-04-02T03:21:49.111Z"
+        "updatedAt": "2026-05-10T21:35:21.710Z"
       },
       {
         "id": "22",
@@ -4151,7 +4151,7 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-05-10T21:29:32.671Z",
+      "lastModified": "2026-05-10T21:35:21.710Z",
       "taskCount": 16,
       "completedCount": 13,
       "tags": [

--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -76,5 +76,14 @@
   },
   "Header": {
     "logo_alt": "Logo"
+  },
+  "ProjectDetail": {
+    "breadcrumb_home": "Home",
+    "breadcrumb_projects": "Projects",
+    "related_title": "Other projects",
+    "summary_label": "Summary",
+    "objectives_label": "Objectives",
+    "role_label": "Role",
+    "period_label": "Period"
   }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -76,5 +76,14 @@
   },
   "Header": {
     "logo_alt": "Logo"
+  },
+  "ProjectDetail": {
+    "breadcrumb_home": "Inicio",
+    "breadcrumb_projects": "Proyectos",
+    "related_title": "Otros proyectos",
+    "summary_label": "Resumen",
+    "objectives_label": "Objetivos",
+    "role_label": "Rol",
+    "period_label": "Período"
   }
 }

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -76,5 +76,14 @@
   },
   "Header": {
     "logo_alt": "Logo"
+  },
+  "ProjectDetail": {
+    "breadcrumb_home": "Início",
+    "breadcrumb_projects": "Projetos",
+    "related_title": "Outros projetos",
+    "summary_label": "Resumo",
+    "objectives_label": "Objetivos",
+    "role_label": "Função",
+    "period_label": "Período"
   }
 }

--- a/apps/web/src/app/[locale]/projects/[slug]/error.tsx
+++ b/apps/web/src/app/[locale]/projects/[slug]/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { ErrorView } from '~components/View';
+
+interface ProjectDetailErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ProjectDetailError({ reset }: ProjectDetailErrorProps) {
+  return <ErrorView reset={reset} />;
+}

--- a/apps/web/src/app/[locale]/projects/[slug]/loading.tsx
+++ b/apps/web/src/app/[locale]/projects/[slug]/loading.tsx
@@ -1,0 +1,44 @@
+import { getTranslations } from 'next-intl/server';
+
+export default async function ProjectDetailLoading() {
+  const t = await getTranslations('Common');
+  return (
+    <div className="animate-pulse" aria-busy="true" aria-label={t('loading')}>
+      <div className="w-full h-[240px] xl:h-[400px] bg-gray-700" />
+      <div className="mx-4 xl:mx-auto xl:max-w-237.5 flex flex-col gap-y-6 mt-8">
+        <div className="flex gap-x-2">
+          {[12, 16, 24].map((w) => (
+            <div key={w} className={`h-4 w-${w} bg-gray-700 rounded`} />
+          ))}
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <div className="h-8 w-3/4 bg-gray-700 rounded" />
+          <div className="h-4 w-1/4 bg-gray-700 rounded" />
+          <div className="h-4 w-full bg-gray-700 rounded" />
+        </div>
+        <div className="flex gap-x-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-6 w-16 bg-gray-700 rounded-full" />
+          ))}
+        </div>
+        <div className="grid grid-cols-2 gap-4 bg-dark-300 rounded-xl p-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="flex flex-col gap-y-1">
+              <div className="h-3 w-16 bg-gray-700 rounded" />
+              <div className="h-4 w-24 bg-gray-700 rounded" />
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col gap-y-2">
+          {[100, 90, 95, 80, 85].map((w, i) => (
+            <div
+              key={i}
+              className="h-4 bg-gray-700 rounded"
+              style={{ width: `${w}%` }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/projects/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/projects/[slug]/page.tsx
@@ -1,0 +1,59 @@
+import { getLocale } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+
+import {
+  ProjectDetail,
+  IProjectDetailProps,
+} from '~components/View/ProjectDetail';
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
+
+type ProjectDetailData = IProjectDetailProps & { id: string };
+
+interface ProjectDetailPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function ProjectDetailPage({
+  params,
+}: ProjectDetailPageProps) {
+  const { slug } = await params;
+  const [locale, baseUrl] = await Promise.all([
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const res = await fetch(
+    `${baseUrl}/api/v1/projects/${slug}?locale=${locale}`,
+    { cache: 'no-store' },
+  ).catch(() => null);
+
+  if (!res || res.status === 404 || !res.ok) notFound();
+
+  const body: ApiResponse<ProjectDetailData> = await res.json();
+  if (body.error) notFound();
+
+  const project = body.data;
+
+  return <ProjectDetail {...project} />;
+}
+
+export async function generateStaticParams() {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_URL ??
+    (process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : 'http://localhost:3000');
+
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/projects`, {
+      cache: 'force-cache',
+    });
+    if (!res.ok) return [];
+    const body: ApiResponse<{ slug: string }[]> = await res.json();
+    if (body.error) return [];
+    return body.data.map((p) => ({ slug: p.slug }));
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/src/components/View/Breadcrumb/index.tsx
+++ b/apps/web/src/components/View/Breadcrumb/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FC } from 'react';
 
 import { Link } from '~i18n/routing';

--- a/apps/web/src/components/View/Breadcrumb/index.tsx
+++ b/apps/web/src/components/View/Breadcrumb/index.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+
+import { Link } from '~i18n/routing';
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface IBreadcrumbProps {
+  items: BreadcrumbItem[];
+}
+
+export const Breadcrumb: FC<IBreadcrumbProps> = ({ items }) => (
+  <nav aria-label="breadcrumb">
+    <ol className="flex flex-row flex-wrap items-center gap-x-2 text-body-xs">
+      {items.map((item, i) => (
+        <li key={i} className="flex items-center gap-x-2">
+          {i > 0 && <span className="!text-dark-700">/</span>}
+          {item.href ? (
+            <Link
+              href={item.href}
+              className="!text-dark-700 hover:!text-white transition-colors"
+            >
+              {item.label}
+            </Link>
+          ) : (
+            <span className="!text-white">{item.label}</span>
+          )}
+        </li>
+      ))}
+    </ol>
+  </nav>
+);

--- a/apps/web/src/components/View/ProjectDetail/index.tsx
+++ b/apps/web/src/components/View/ProjectDetail/index.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { FC, useMemo } from 'react';
+
+import { TextRich } from '@repo/ui/View';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+
+import { Breadcrumb } from '../Breadcrumb';
+import { ProjectList, ProjectSummary } from '../ProjectList';
+import { ProjectMetaGrid } from '../ProjectMetaGrid';
+import { SkillGroup } from '../SkillGroup';
+
+export interface IProjectDetailProps {
+  slug: string;
+  title: string;
+  caption: string;
+  coverImage: { url: string; alt: string };
+  theme?: string;
+  skills: string[];
+  summary?: string;
+  objectives?: string;
+  role?: string;
+  period: { startAt: string; endAt?: string };
+  content: string;
+  relatedProjects: ProjectSummary[];
+}
+
+export const ProjectDetail: FC<IProjectDetailProps> = ({
+  title,
+  caption,
+  coverImage,
+  theme,
+  skills,
+  summary,
+  objectives,
+  role,
+  period,
+  content,
+  relatedProjects,
+}) => {
+  const t = useTranslations('ProjectDetail');
+
+  const breadcrumbItems = useMemo(
+    () => [
+      { label: t('breadcrumb_home'), href: '/' as const },
+      { label: t('breadcrumb_projects'), href: '/projects' as const },
+      { label: title },
+    ],
+    [t, title],
+  );
+
+  const metaLabels = useMemo(
+    () => ({
+      summary: t('summary_label'),
+      objectives: t('objectives_label'),
+      role: t('role_label'),
+      period: t('period_label'),
+    }),
+    [t],
+  );
+
+  return (
+    <article className="flex flex-col gap-y-8 pb-12">
+      <div className="relative w-full h-[240px] xl:h-[400px] overflow-hidden">
+        <Image
+          src={coverImage.url}
+          fill
+          alt={coverImage.alt}
+          className="object-cover"
+          priority
+        />
+      </div>
+
+      <div className="mx-4 xl:mx-auto xl:w-full xl:max-w-237.5 flex flex-col gap-y-6">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <header className="flex flex-col gap-y-2">
+          <h1 className="!text-2xl xl:!text-4xl !font-bold !text-white">
+            {title}
+          </h1>
+          {theme && (
+            <span className="text-body-xs !text-dark-700 uppercase tracking-wide">
+              {theme}
+            </span>
+          )}
+          <p className="text-body-sm !text-dark-900">{caption}</p>
+        </header>
+
+        <SkillGroup
+          skills={skills}
+          max={skills.length}
+          initializeWithMax={skills.length}
+          total={skills.length}
+        />
+
+        <ProjectMetaGrid
+          summary={summary}
+          objectives={objectives}
+          role={role}
+          period={period}
+          labels={metaLabels}
+        />
+
+        {content && (
+          <TextRich
+            content={content}
+            className="!text-white prose prose-invert max-w-none"
+          />
+        )}
+
+        {relatedProjects.length > 0 && (
+          <section className="flex flex-col gap-y-6">
+            <h2 className="!text-xl !font-bold !text-white">
+              {t('related_title')}
+            </h2>
+            <ProjectList projects={relatedProjects} view="row" compact />
+          </section>
+        )}
+      </div>
+    </article>
+  );
+};

--- a/apps/web/src/components/View/ProjectMetaGrid/index.tsx
+++ b/apps/web/src/components/View/ProjectMetaGrid/index.tsx
@@ -1,0 +1,49 @@
+import { FC } from 'react';
+
+interface IProjectMetaGridProps {
+  summary?: string;
+  objectives?: string;
+  role?: string;
+  period: { startAt: string; endAt?: string };
+  labels: {
+    summary: string;
+    objectives: string;
+    role: string;
+    period: string;
+  };
+}
+
+function formatPeriod(period: { startAt: string; endAt?: string }): string {
+  const start = new Date(period.startAt).getUTCFullYear();
+  if (!period.endAt) return String(start);
+  const end = new Date(period.endAt).getUTCFullYear();
+  return start === end ? String(start) : `${start} – ${end}`;
+}
+
+export const ProjectMetaGrid: FC<IProjectMetaGridProps> = ({
+  summary,
+  objectives,
+  role,
+  period,
+  labels,
+}) => {
+  const items = [
+    summary ? { label: labels.summary, value: summary } : null,
+    objectives ? { label: labels.objectives, value: objectives } : null,
+    role ? { label: labels.role, value: role } : null,
+    { label: labels.period, value: formatPeriod(period) },
+  ].filter((item): item is { label: string; value: string } => item !== null);
+
+  return (
+    <dl className="grid grid-cols-1 xl:grid-cols-2 gap-4 bg-dark-300 rounded-xl p-4">
+      {items.map(({ label, value }) => (
+        <div key={label} className="flex flex-col gap-y-1">
+          <dt className="text-body-xs !text-dark-700 uppercase tracking-wide">
+            {label}
+          </dt>
+          <dd className="text-body-sm !text-white">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+};

--- a/apps/web/src/components/View/index.ts
+++ b/apps/web/src/components/View/index.ts
@@ -1,3 +1,4 @@
+export * from './Breadcrumb';
 export * from './ContactInfo';
 export * from './ErrorView';
 export * from './ExperienceCard';

--- a/apps/web/tests/app/[locale]/project-detail.test.tsx
+++ b/apps/web/tests/app/[locale]/project-detail.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue({ get: () => 'localhost:3000' }),
+}));
+
+vi.mock('next-intl/server', () => ({
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+vi.mock('~components/View/ProjectDetail', () => ({
+  ProjectDetail: ({ title, caption }: { title: string; caption: string }) => (
+    <div data-testid="project-detail">
+      <h1>{title}</h1>
+      <p>{caption}</p>
+    </div>
+  ),
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const PROJECT = {
+  id: '1',
+  slug: 'my-project',
+  title: 'My Project',
+  caption: 'A great project',
+  coverImage: { url: 'https://example.com/img.jpg', alt: 'Cover' },
+  skills: ['React'],
+  content: '# Hello',
+  period: { startAt: '2024-01-01' },
+  relatedProjects: [],
+};
+
+function mockApiOk(data: unknown) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ data, error: null }),
+  });
+}
+
+function mockApiError(status: number) {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => ({
+      data: null,
+      error: { code: 'NOT_FOUND', message: '' },
+    }),
+  });
+}
+
+describe('ProjectDetailPage', () => {
+  it('should render project detail when API returns data', async () => {
+    mockApiOk(PROJECT);
+    const { default: Page } = await import(
+      '~/app/[locale]/projects/[slug]/page'
+    );
+    render(await Page({ params: Promise.resolve({ slug: 'my-project' }) }));
+    expect(screen.getByTestId('project-detail')).toBeInTheDocument();
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+  });
+
+  it('should call notFound when API returns 404', async () => {
+    mockApiError(404);
+    const { notFound } = await import('next/navigation');
+    const { default: Page } = await import(
+      '~/app/[locale]/projects/[slug]/page'
+    );
+    await expect(
+      Page({ params: Promise.resolve({ slug: 'missing' }) }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('should call notFound when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+    const { notFound } = await import('next/navigation');
+    const { default: Page } = await import(
+      '~/app/[locale]/projects/[slug]/page'
+    );
+    await expect(
+      Page({ params: Promise.resolve({ slug: 'my-project' }) }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('should call notFound when API returns an error envelope', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: null,
+        error: { code: 'INTERNAL', message: 'fail' },
+      }),
+    });
+    const { notFound } = await import('next/navigation');
+    const { default: Page } = await import(
+      '~/app/[locale]/projects/[slug]/page'
+    );
+    await expect(
+      Page({ params: Promise.resolve({ slug: 'my-project' }) }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/components/View/Breadcrumb/Breadcrumb.test.tsx
+++ b/apps/web/tests/components/View/Breadcrumb/Breadcrumb.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+
+vi.mock('~i18n/routing', () => ({
+  Link: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import { Breadcrumb } from '~/components/View/Breadcrumb';
+
+const items = [
+  { label: 'Home', href: '/' },
+  { label: 'Projects', href: '/projects' },
+  { label: 'My Project' },
+];
+
+describe('Breadcrumb', () => {
+  it('should render all breadcrumb items', () => {
+    render(<Breadcrumb items={items} />);
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+  });
+
+  it('should render items with href as links', () => {
+    render(<Breadcrumb items={items} />);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: 'Projects' })).toHaveAttribute(
+      'href',
+      '/projects',
+    );
+  });
+
+  it('should render the last item without a link', () => {
+    render(<Breadcrumb items={items} />);
+    expect(
+      screen.queryByRole('link', { name: 'My Project' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+  });
+
+  it('should render a nav landmark with accessible label', () => {
+    render(<Breadcrumb items={items} />);
+    expect(screen.getByRole('navigation', { name: 'breadcrumb' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/components/View/ProjectMetaGrid/ProjectMetaGrid.test.tsx
+++ b/apps/web/tests/components/View/ProjectMetaGrid/ProjectMetaGrid.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+
+import { ProjectMetaGrid } from '~/components/View/ProjectMetaGrid';
+
+const labels = {
+  summary: 'Summary',
+  objectives: 'Objectives',
+  role: 'Role',
+  period: 'Period',
+};
+
+describe('ProjectMetaGrid', () => {
+  it('should always render the period label', () => {
+    render(
+      <ProjectMetaGrid
+        period={{ startAt: '2024-01-01', endAt: '2024-12-31' }}
+        labels={labels}
+      />,
+    );
+    expect(screen.getByText('Period')).toBeInTheDocument();
+    expect(screen.getByText('2024')).toBeInTheDocument();
+  });
+
+  it('should format period as range when years differ', () => {
+    render(
+      <ProjectMetaGrid
+        period={{ startAt: '2022-01-01', endAt: '2024-12-31' }}
+        labels={labels}
+      />,
+    );
+    expect(screen.getByText('2022 – 2024')).toBeInTheDocument();
+  });
+
+  it('should render optional fields when provided', () => {
+    render(
+      <ProjectMetaGrid
+        summary="A great project"
+        role="Frontend Developer"
+        period={{ startAt: '2023-01-01' }}
+        labels={labels}
+      />,
+    );
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('A great project')).toBeInTheDocument();
+    expect(screen.getByText('Role')).toBeInTheDocument();
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument();
+  });
+
+  it('should not render absent optional fields', () => {
+    render(
+      <ProjectMetaGrid period={{ startAt: '2024-01-01' }} labels={labels} />,
+    );
+    expect(screen.queryByText('Summary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Objectives')).not.toBeInTheDocument();
+    expect(screen.queryByText('Role')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `[locale]/projects/[slug]/page.tsx` — RSC that fetches `GET /api/v1/projects/:slug`, calls `notFound()` on 404 or API error, and includes `generateStaticParams` (returns empty array gracefully if API unavailable at build time)
- Adds `loading.tsx` and `error.tsx` for the `[slug]` route segment
- Adds `ProjectDetail` client component: full-width cover image, breadcrumb, title/theme/caption, skills, meta grid, Markdown content (via `TextRich`), related projects section
- Adds `Breadcrumb` component: nav landmark with linked and unlinked items
- Adds `ProjectMetaGrid` component: summary/objectives/role/period grid using `getUTCFullYear()` for timezone-safe period formatting
- Adds `ProjectDetail` i18n namespace to all 3 locale files (en-US, pt-BR, es)

## Test plan

- [ ] `pnpm --filter web test` — 116 tests pass (26 test files, +12 new)
- [ ] `/en-US/projects/[slug]` renders project detail with cover image, breadcrumb, metadata, and related projects
- [ ] Non-existent slug shows 404 page
- [ ] Loading skeleton renders on slow connections
- [ ] Error boundary renders on API failure

Refs #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)