### PR TITLE
feat(web): connect experiences page to GET /api/v1/experiences (T-22)

### DIFF
--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -71,6 +71,9 @@
   "About": {
     "values_title": "My professional values"
   },
+  "ExperienceCard": {
+    "skills_label": "Skills"
+  },
   "Common": {
     "loading": "Loading"
   },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -71,6 +71,9 @@
   "About": {
     "values_title": "Mis valores profesionales"
   },
+  "ExperienceCard": {
+    "skills_label": "Habilidades"
+  },
   "Common": {
     "loading": "Cargando"
   },

--- a/apps/web/messages/pt-BR.json
+++ b/apps/web/messages/pt-BR.json
@@ -71,6 +71,9 @@
   "About": {
     "values_title": "Meus valores profissionais"
   },
+  "ExperienceCard": {
+    "skills_label": "Habilidades"
+  },
   "Common": {
     "loading": "Carregando"
   },

--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -1,16 +1,17 @@
-import {
-  EmploymentType,
-  IProfessionalValueProps,
-  IExperienceProps,
-  LocationType,
-} from '@repo/core/portfolio';
+import { getLocale, getTranslations } from 'next-intl/server';
+
 import { Divider } from '@repo/ui/View';
-import { getTranslations } from 'next-intl/server';
 
-import { ProfessionalValue, ExperienceCard } from '~components/View';
+import {
+  ExperienceCard,
+  IExperienceCardProps,
+  ProfessionalValue,
+} from '~components/View';
 import { applyDevSimulations } from '~/dev/simulate';
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
 
-const PROFESSIONAL_VALUES: IProfessionalValueProps[] = [
+const PROFESSIONAL_VALUES = [
   {
     id: '1',
     icon: 'material-symbols:acute-rounded',
@@ -37,87 +38,30 @@ const PROFESSIONAL_VALUES: IProfessionalValueProps[] = [
   },
 ];
 
-const EXPERIENCES: IExperienceProps[] = [
-  {
-    id: '1',
-    company: { 'en-US': 'WESF IT Services', 'pt-BR': 'WESF Serviços de TI' },
-    employment_type: EmploymentType.FREELANCE,
-    location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
-    position: {
-      'en-US': 'Full-Stack Developer',
-      'pt-BR': 'Desenvolvedor Full-Stack',
-    },
-    description: {
-      'en-US': 'Full-stack solution development for clients.',
-      'pt-BR': 'Desenvolvimento de soluções full-stack para clientes.',
-    },
-    logo: {
-      url: 'https://placehold.co/48x48',
-      alt: { 'en-US': 'WESF logo', 'pt-BR': 'WESF logo' },
-    },
-    location_type: LocationType.REMOTE,
-    skills: [],
-    start_at: '2021-01-01T00:00:00.000Z',
-    end_at: '2022-01-01T00:00:00.000Z',
-  },
-  {
-    id: '2',
-    company: { 'en-US': 'Galaxies', 'pt-BR': 'Galaxies' },
-    employment_type: EmploymentType.PART_TIME,
-    location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
-    position: {
-      'en-US': 'Front-end Developer',
-      'pt-BR': 'Desenvolvedor Front-end',
-    },
-    description: {
-      'en-US': 'Interface development for SaaS platform.',
-      'pt-BR': 'Desenvolvimento de interfaces para plataforma SaaS.',
-    },
-    logo: {
-      url: 'https://placehold.co/48x48',
-      alt: { 'en-US': 'Galaxies logo', 'pt-BR': 'Galaxies logo' },
-    },
-    location_type: LocationType.REMOTE,
-    skills: [],
-    start_at: '2022-01-01T00:00:00.000Z',
-    end_at: '2023-01-01T00:00:00.000Z',
-  },
-  {
-    id: '3',
-    company: {
-      'en-US':
-        'FDTE - Foundation for the Technological Development of Engineering',
-      'pt-BR':
-        'FDTE - Fundação para o Desenvolvimento Técnológico da Engenharia',
-    },
-    employment_type: EmploymentType.FULL_TIME,
-    location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
-    position: {
-      'en-US': 'Front-end Developer',
-      'pt-BR': 'Desenvolvedor Front-end',
-    },
-    description: {
-      'en-US': 'Systems development for engineering.',
-      'pt-BR': 'Desenvolvimento de sistemas para engenharia.',
-    },
-    logo: {
-      url: 'https://placehold.co/48x48',
-      alt: { 'en-US': 'FDTE logo', 'pt-BR': 'FDTE logo' },
-    },
-    location_type: LocationType.HYBRID,
-    skills: [],
-    start_at: '2023-01-01T00:00:00.000Z',
-    end_at: '2024-01-01T00:00:00.000Z',
-  },
-];
-
 interface AboutPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
 }
 
 export default async function About({ searchParams }: AboutPageProps) {
   await applyDevSimulations(await searchParams);
-  const t = await getTranslations('About');
+
+  const [t, locale, baseUrl] = await Promise.all([
+    getTranslations('About'),
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const experiencesRes = await fetch(
+    `${baseUrl}/api/v1/experiences?locale=${locale}`,
+    { cache: 'no-store' },
+  ).catch(() => null);
+
+  let experiences: IExperienceCardProps[] = [];
+  if (experiencesRes?.ok) {
+    const body: ApiResponse<IExperienceCardProps[]> =
+      await experiencesRes.json();
+    if (!body.error) experiences = body.data;
+  }
 
   return (
     <>
@@ -133,7 +77,7 @@ export default async function About({ searchParams }: AboutPageProps) {
       </ul>
       <Divider className="mx-4" />
       <ul className="flex flex-col mx-4 gap-y-3 xl:gap-y-0">
-        {EXPERIENCES.map((experience) => (
+        {experiences.map((experience) => (
           <li key={experience.id} className="[&:last-of-type>hr]:hidden">
             <ExperienceCard {...experience} />
             <Divider className="hidden xl:block" />

--- a/apps/web/src/components/View/ExperienceCard/index.tsx
+++ b/apps/web/src/components/View/ExperienceCard/index.tsx
@@ -2,43 +2,42 @@
 
 import { FC } from 'react';
 
-import { IExperienceProps } from '@repo/core/portfolio';
 import { TextRich } from '@repo/ui/View';
-import { useLocale } from 'next-intl';
 
-import { useBreakpoint } from '~hooks';
+import { SkillAccordion } from '../SkillAccordion';
 
-import { SkillGroup } from '../SkillGroup';
+export interface IExperienceCardProps {
+  id: string;
+  company: string;
+  position: string;
+  location: string;
+  description?: string;
+  logo?: { url: string; alt: string };
+  employmentType: string;
+  locationType: string;
+  startAt: string;
+  endAt?: string;
+  skills: string[];
+}
 
-export const ExperienceCard: FC<IExperienceProps> = ({
+export const ExperienceCard: FC<IExperienceCardProps> = ({
   company,
   position,
+  location,
   description,
+  skills,
 }) => {
-  const isXL = useBreakpoint('xl');
-  const locale = useLocale() as keyof typeof position;
-  const skillProps: string[] = [];
-
   return (
     <article className="flex flex-col py-6 px-3 bg-dark-200 rounded-xl gap-y-3">
       <header className="flex flex-col justify-center gap-y-2">
-        <h5 className="text-white line-clamp-2">
-          {position[locale] ?? position['en-US']}
-        </h5>
-        <h6 className="text-dark-700 line-clamp-3">
-          {company[locale] ?? company['en-US']}
-        </h6>
+        <h5 className="text-white line-clamp-2">{position}</h5>
+        <h6 className="text-dark-700 line-clamp-3">{company}</h6>
+        <span className="text-body-xs !text-dark-700">{location}</span>
       </header>
-      <TextRich
-        className="text-white line-clamp-4"
-        content={description[locale] ?? description['en-US']}
-      />
-      <SkillGroup
-        skills={skillProps}
-        max={isXL ? 3 : 2}
-        initializeWithMax={2}
-        total={skillProps.length}
-      />
+      {description && (
+        <TextRich className="text-white line-clamp-4" content={description} />
+      )}
+      <SkillAccordion skills={skills} />
     </article>
   );
 };

--- a/apps/web/src/components/View/SkillAccordion/index.tsx
+++ b/apps/web/src/components/View/SkillAccordion/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { FC } from 'react';
+
+import { Accordion } from '@repo/ui/Control';
+import { Icon } from '@repo/ui/Imagery';
+import { useTranslations } from 'next-intl';
+
+interface ISkillAccordionProps {
+  skills: string[];
+}
+
+export const SkillAccordion: FC<ISkillAccordionProps> = ({ skills }) => {
+  const t = useTranslations('ExperienceCard');
+
+  if (!skills.length) return null;
+
+  return (
+    <Accordion.Root>
+      {({ expanded }) => (
+        <>
+          <Accordion.Header className="py-2">
+            <span className="text-body-xs !text-dark-700">
+              {t('skills_label')}
+            </span>
+            <Icon
+              icon="ic:round-keyboard-arrow-down"
+              className={`text-dark-700 text-xl transition-transform duration-300 ${expanded ? 'rotate-180' : ''}`}
+            />
+          </Accordion.Header>
+          <Accordion.Body>
+            <ul className="flex flex-row gap-2 flex-wrap pt-2">
+              {skills.map((skill) => (
+                <li
+                  key={skill}
+                  className="flex flex-row items-center bg-dark-500 py-1 px-3 rounded-3.75 text-body-xs !text-white"
+                >
+                  {skill}
+                </li>
+              ))}
+            </ul>
+          </Accordion.Body>
+        </>
+      )}
+    </Accordion.Root>
+  );
+};

--- a/apps/web/src/components/View/index.ts
+++ b/apps/web/src/components/View/index.ts
@@ -10,4 +10,5 @@ export * from './ProjectCard';
 export * from './ProjectList';
 export * from './SideNavigation';
 export * from './Skill';
+export * from './SkillAccordion';
 export * from './StatCard';

--- a/apps/web/tests/app/[locale]/about.test.tsx
+++ b/apps/web/tests/app/[locale]/about.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue({ get: () => 'localhost:3000' }),
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/dev/simulate', () => ({
+  applyDevSimulations: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('@repo/ui/View', () => ({
+  Divider: () => <hr />,
+}));
+
+vi.mock('~components/View', () => ({
+  ProfessionalValue: ({ content }: { content: string }) => (
+    <div data-testid="professional-value">{content}</div>
+  ),
+  ExperienceCard: ({ company, position }: { company: string; position: string }) => (
+    <div data-testid="experience-card">
+      <span>{position}</span>
+      <span>{company}</span>
+    </div>
+  ),
+  IExperienceCardProps: undefined,
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const EXPERIENCES = [
+  {
+    id: '1',
+    company: 'Acme Corp',
+    position: 'Senior Developer',
+    location: 'São Paulo, Brazil',
+    employmentType: 'FULL_TIME',
+    locationType: 'REMOTE',
+    startAt: '2023-01-01T00:00:00.000Z',
+    skills: [],
+  },
+  {
+    id: '2',
+    company: 'Beta Inc',
+    position: 'Tech Lead',
+    location: 'Remote',
+    employmentType: 'FULL_TIME',
+    locationType: 'REMOTE',
+    startAt: '2024-01-01T00:00:00.000Z',
+    skills: [],
+  },
+];
+
+function mockApi(experiences: unknown[] | null) {
+  mockFetch.mockResolvedValue(
+    experiences === null
+      ? { ok: false, json: async () => ({ data: null, error: { code: 'INTERNAL_ERROR', message: '' } }) }
+      : { ok: true, json: async () => ({ data: experiences, error: null }) },
+  );
+}
+
+describe('About page', () => {
+  it('should render values title from i18n', async () => {
+    mockApi([]);
+    const { default: About } = await import('~/app/[locale]/about/page');
+    render(await About({ searchParams: Promise.resolve({}) }));
+    expect(screen.getByText('t.values_title')).toBeInTheDocument();
+  });
+
+  it('should render professional values', async () => {
+    mockApi([]);
+    const { default: About } = await import('~/app/[locale]/about/page');
+    render(await About({ searchParams: Promise.resolve({}) }));
+    expect(screen.getAllByTestId('professional-value').length).toBeGreaterThan(0);
+  });
+
+  it('should render experience cards from API response', async () => {
+    mockApi(EXPERIENCES);
+    const { default: About } = await import('~/app/[locale]/about/page');
+    render(await About({ searchParams: Promise.resolve({}) }));
+    expect(screen.getByText('Senior Developer')).toBeInTheDocument();
+    expect(screen.getByText('Tech Lead')).toBeInTheDocument();
+  });
+
+  it('should render no experience cards when API fails', async () => {
+    mockApi(null);
+    const { default: About } = await import('~/app/[locale]/about/page');
+    render(await About({ searchParams: Promise.resolve({}) }));
+    expect(screen.queryByTestId('experience-card')).not.toBeInTheDocument();
+  });
+
+  it('should render no experience cards when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+    const { default: About } = await import('~/app/[locale]/about/page');
+    render(await About({ searchParams: Promise.resolve({}) }));
+    expect(screen.queryByTestId('experience-card')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
+++ b/apps/web/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@repo/ui/View', () => ({
+  TextRich: ({ content, className }: { content: string; className?: string }) => (
+    <p className={className}>{content}</p>
+  ),
+}));
+
+vi.mock('~/components/View/SkillAccordion', () => ({
+  SkillAccordion: ({ skills }: { skills: string[] }) => (
+    <div data-testid="skill-accordion">{skills.join(',')}</div>
+  ),
+}));
+
+import { ExperienceCard } from '~/components/View/ExperienceCard';
+
+const defaultProps = {
+  id: '1',
+  company: 'Acme Corp',
+  position: 'Senior Developer',
+  location: 'São Paulo, Brazil',
+  description: 'Full-stack development.',
+  logo: { url: 'https://example.com/logo.png', alt: 'Acme logo' },
+  employmentType: 'FULL_TIME',
+  locationType: 'REMOTE',
+  startAt: '2023-01-01T00:00:00.000Z',
+  endAt: '2024-01-01T00:00:00.000Z',
+  skills: ['React', 'TypeScript'],
+};
+
+describe('ExperienceCard', () => {
+  it('should render position and company', () => {
+    render(<ExperienceCard {...defaultProps} />);
+    expect(screen.getByText('Senior Developer')).toBeInTheDocument();
+    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+  });
+
+  it('should render location', () => {
+    render(<ExperienceCard {...defaultProps} />);
+    expect(screen.getByText('São Paulo, Brazil')).toBeInTheDocument();
+  });
+
+  it('should render description when provided', () => {
+    render(<ExperienceCard {...defaultProps} />);
+    expect(screen.getByText('Full-stack development.')).toBeInTheDocument();
+  });
+
+  it('should not render description when not provided', () => {
+    const { description: _, ...props } = defaultProps;
+    render(<ExperienceCard {...props} />);
+    expect(screen.queryByText('Full-stack development.')).not.toBeInTheDocument();
+  });
+
+  it('should pass skills to SkillAccordion', () => {
+    render(<ExperienceCard {...defaultProps} />);
+    expect(screen.getByTestId('skill-accordion')).toHaveTextContent('React,TypeScript');
+  });
+});

--- a/apps/web/tests/components/View/SkillAccordion/SkillAccordion.test.tsx
+++ b/apps/web/tests/components/View/SkillAccordion/SkillAccordion.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('next-intl', () => ({
+  useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+vi.mock('@repo/ui/Imagery', () => ({
+  Icon: ({ icon }: { icon: string; className?: string }) => (
+    <span data-testid={`icon-${icon}`} />
+  ),
+}));
+
+vi.mock('@repo/ui/Control', () => {
+  const { useState } = require('react');
+  const Root = ({ children }: { children: (ctx: { expanded: boolean; toggle: () => void }) => React.ReactNode }) => {
+    const [expanded, setExpanded] = useState(false);
+    return <>{children({ expanded, toggle: () => setExpanded((v: boolean) => !v) })}</>;
+  };
+  const Header = ({ children, onClick }: { children: React.ReactNode; onClick?: () => void; className?: string }) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  );
+  const Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  return { Accordion: { Root, Header, Body } };
+});
+
+import { SkillAccordion } from '~/components/View/SkillAccordion';
+
+describe('SkillAccordion', () => {
+  it('should render nothing when skills list is empty', () => {
+    const { container } = render(<SkillAccordion skills={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render the skills label', () => {
+    render(<SkillAccordion skills={['React', 'TypeScript']} />);
+    expect(screen.getByText('ExperienceCard.skills_label')).toBeInTheDocument();
+  });
+
+  it('should render all skill items', () => {
+    render(<SkillAccordion skills={['React', 'TypeScript', 'Node.js']} />);
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    expect(screen.getByText('Node.js')).toBeInTheDocument();
+  });
+
+  it('should toggle expanded state on header click', async () => {
+    const user = userEvent.setup();
+    render(<SkillAccordion skills={['React']} />);
+    const button = screen.getByRole('button');
+    await user.click(button);
+    expect(button).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces hardcoded `EXPERIENCES` array in `about/page.tsx` with `fetch` to `GET /api/v1/experiences?locale={locale}`; falls back to an empty list on network/API error
- Updates `ExperienceCard` to accept flat, pre-translated props aligned with `ExperienceDTO` (removes dependency on `IExperienceProps` from `@repo/core`)
- Adds `SkillAccordion` component — collapsible accordion using `Accordion` from `@repo/ui/Control` — to display experience skills
- Adds `ExperienceCard.skills_label` i18n key across all three locales (`en-US`, `pt-BR`, `es`)
- Exports `SkillAccordion` from the `View` index

## Test plan

- [ ] `SkillAccordion` — renders nothing when skills empty, shows label, renders all skills, toggles on click
- [ ] `ExperienceCard` — renders position/company/location, conditionally renders description, passes skills to `SkillAccordion`
- [ ] `About` page — renders i18n title, professional values, experience cards from API, empty on API failure and network error

Refs #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)