### PR TITLE
[T-55] Admin write use cases em @repo/application

### DIFF
--- a/packages/application/src/portfolio/use-cases/ArchiveProject.ts
+++ b/packages/application/src/portfolio/use-cases/ArchiveProject.ts
@@ -1,0 +1,77 @@
+import { UnauthorizedError } from '@repo/core/identity';
+import { IProjectRepository } from '@repo/core/portfolio';
+import {
+  DomainError,
+  Either,
+  Id,
+  NotFoundError,
+  ValidationError,
+  left,
+  right,
+} from '@repo/core/shared';
+
+import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { UseCase } from '../../shared/UseCase';
+
+export type ArchiveProjectInput = {
+  userId: string;
+  projectId: string;
+};
+
+export class ArchiveProject extends UseCase<
+  ArchiveProjectInput,
+  void,
+  ValidationError | UnauthorizedError | NotFoundError | DomainError
+> {
+  constructor(
+    private readonly projectRepository: IProjectRepository,
+    private readonly ensureAdmin: EnsureAdmin,
+  ) {
+    super();
+  }
+
+  async execute(
+    input: ArchiveProjectInput,
+  ): Promise<
+    Either<
+      ValidationError | UnauthorizedError | NotFoundError | DomainError,
+      void
+    >
+  > {
+    const adminCheck = await this.ensureAdmin.execute({ userId: input.userId });
+    if (adminCheck.isLeft()) return left(adminCheck.value);
+
+    const idResult = Id.create(input.projectId);
+    if (idResult.isLeft())
+      return left(
+        new ValidationError({
+          code: 'INVALID_PROJECT_ID',
+          message: idResult.value.message,
+        }),
+      );
+
+    let project;
+    try {
+      project = await this.projectRepository.findById(idResult.value);
+    } catch {
+      return left(
+        new DomainError('FETCH_FAILED', { message: 'Failed to fetch project' }),
+      );
+    }
+
+    if (!project)
+      return left(new NotFoundError({ projectId: input.projectId }));
+
+    const archiveResult = project.archive();
+    if (archiveResult.isLeft()) return left(archiveResult.value);
+
+    try {
+      await this.projectRepository.save(project);
+      return right(undefined);
+    } catch {
+      return left(
+        new DomainError('SAVE_FAILED', { message: 'Failed to save project' }),
+      );
+    }
+  }
+}

--- a/packages/application/src/portfolio/use-cases/DeleteExperience.ts
+++ b/packages/application/src/portfolio/use-cases/DeleteExperience.ts
@@ -1,0 +1,64 @@
+import { UnauthorizedError } from '@repo/core/identity';
+import { IExperienceRepository } from '@repo/core/portfolio';
+import {
+  DomainError,
+  Either,
+  Id,
+  NotFoundError,
+  ValidationError,
+  left,
+  right,
+} from '@repo/core/shared';
+
+import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { UseCase } from '../../shared/UseCase';
+
+export type DeleteExperienceInput = {
+  userId: string;
+  experienceId: string;
+};
+
+export class DeleteExperience extends UseCase<
+  DeleteExperienceInput,
+  void,
+  ValidationError | UnauthorizedError | NotFoundError | DomainError
+> {
+  constructor(
+    private readonly experienceRepository: IExperienceRepository,
+    private readonly ensureAdmin: EnsureAdmin,
+  ) {
+    super();
+  }
+
+  async execute(
+    input: DeleteExperienceInput,
+  ): Promise<
+    Either<
+      ValidationError | UnauthorizedError | NotFoundError | DomainError,
+      void
+    >
+  > {
+    const adminCheck = await this.ensureAdmin.execute({ userId: input.userId });
+    if (adminCheck.isLeft()) return left(adminCheck.value);
+
+    const idResult = Id.create(input.experienceId);
+    if (idResult.isLeft())
+      return left(
+        new ValidationError({
+          code: 'INVALID_EXPERIENCE_ID',
+          message: idResult.value.message,
+        }),
+      );
+
+    try {
+      await this.experienceRepository.delete(idResult.value);
+      return right(undefined);
+    } catch {
+      return left(
+        new DomainError('DELETE_FAILED', {
+          message: 'Failed to delete experience',
+        }),
+      );
+    }
+  }
+}

--- a/packages/application/src/portfolio/use-cases/PublishProject.ts
+++ b/packages/application/src/portfolio/use-cases/PublishProject.ts
@@ -1,0 +1,77 @@
+import { UnauthorizedError } from '@repo/core/identity';
+import { IProjectRepository } from '@repo/core/portfolio';
+import {
+  DomainError,
+  Either,
+  Id,
+  NotFoundError,
+  ValidationError,
+  left,
+  right,
+} from '@repo/core/shared';
+
+import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { UseCase } from '../../shared/UseCase';
+
+export type PublishProjectInput = {
+  userId: string;
+  projectId: string;
+};
+
+export class PublishProject extends UseCase<
+  PublishProjectInput,
+  void,
+  ValidationError | UnauthorizedError | NotFoundError | DomainError
+> {
+  constructor(
+    private readonly projectRepository: IProjectRepository,
+    private readonly ensureAdmin: EnsureAdmin,
+  ) {
+    super();
+  }
+
+  async execute(
+    input: PublishProjectInput,
+  ): Promise<
+    Either<
+      ValidationError | UnauthorizedError | NotFoundError | DomainError,
+      void
+    >
+  > {
+    const adminCheck = await this.ensureAdmin.execute({ userId: input.userId });
+    if (adminCheck.isLeft()) return left(adminCheck.value);
+
+    const idResult = Id.create(input.projectId);
+    if (idResult.isLeft())
+      return left(
+        new ValidationError({
+          code: 'INVALID_PROJECT_ID',
+          message: idResult.value.message,
+        }),
+      );
+
+    let project;
+    try {
+      project = await this.projectRepository.findById(idResult.value);
+    } catch {
+      return left(
+        new DomainError('FETCH_FAILED', { message: 'Failed to fetch project' }),
+      );
+    }
+
+    if (!project)
+      return left(new NotFoundError({ projectId: input.projectId }));
+
+    const publishResult = project.publish();
+    if (publishResult.isLeft()) return left(publishResult.value);
+
+    try {
+      await this.projectRepository.save(project);
+      return right(undefined);
+    } catch {
+      return left(
+        new DomainError('SAVE_FAILED', { message: 'Failed to save project' }),
+      );
+    }
+  }
+}

--- a/packages/application/src/portfolio/use-cases/SaveExperience.ts
+++ b/packages/application/src/portfolio/use-cases/SaveExperience.ts
@@ -1,0 +1,61 @@
+import { UnauthorizedError } from '@repo/core/identity';
+import {
+  Experience,
+  IExperienceProps,
+  IExperienceRepository,
+} from '@repo/core/portfolio';
+import {
+  DomainError,
+  Either,
+  NotFoundError,
+  ValidationError,
+  left,
+  right,
+} from '@repo/core/shared';
+
+import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { UseCase } from '../../shared/UseCase';
+
+export type SaveExperienceInput = {
+  userId: string;
+  experienceProps: IExperienceProps;
+};
+
+export class SaveExperience extends UseCase<
+  SaveExperienceInput,
+  void,
+  ValidationError | UnauthorizedError | NotFoundError | DomainError
+> {
+  constructor(
+    private readonly experienceRepository: IExperienceRepository,
+    private readonly ensureAdmin: EnsureAdmin,
+  ) {
+    super();
+  }
+
+  async execute(
+    input: SaveExperienceInput,
+  ): Promise<
+    Either<
+      ValidationError | UnauthorizedError | NotFoundError | DomainError,
+      void
+    >
+  > {
+    const adminCheck = await this.ensureAdmin.execute({ userId: input.userId });
+    if (adminCheck.isLeft()) return left(adminCheck.value);
+
+    const experienceResult = Experience.create(input.experienceProps);
+    if (experienceResult.isLeft()) return left(experienceResult.value);
+
+    try {
+      await this.experienceRepository.save(experienceResult.value);
+      return right(undefined);
+    } catch {
+      return left(
+        new DomainError('SAVE_FAILED', {
+          message: 'Failed to save experience',
+        }),
+      );
+    }
+  }
+}

--- a/packages/application/src/portfolio/use-cases/SaveProject.ts
+++ b/packages/application/src/portfolio/use-cases/SaveProject.ts
@@ -1,0 +1,59 @@
+import { UnauthorizedError } from '@repo/core/identity';
+import {
+  IProjectProps,
+  IProjectRepository,
+  Project,
+} from '@repo/core/portfolio';
+import {
+  DomainError,
+  Either,
+  NotFoundError,
+  ValidationError,
+  left,
+  right,
+} from '@repo/core/shared';
+
+import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { UseCase } from '../../shared/UseCase';
+
+export type SaveProjectInput = {
+  userId: string;
+  projectProps: IProjectProps;
+};
+
+export class SaveProject extends UseCase<
+  SaveProjectInput,
+  void,
+  ValidationError | UnauthorizedError | NotFoundError | DomainError
+> {
+  constructor(
+    private readonly projectRepository: IProjectRepository,
+    private readonly ensureAdmin: EnsureAdmin,
+  ) {
+    super();
+  }
+
+  async execute(
+    input: SaveProjectInput,
+  ): Promise<
+    Either<
+      ValidationError | UnauthorizedError | NotFoundError | DomainError,
+      void
+    >
+  > {
+    const adminCheck = await this.ensureAdmin.execute({ userId: input.userId });
+    if (adminCheck.isLeft()) return left(adminCheck.value);
+
+    const projectResult = Project.create(input.projectProps);
+    if (projectResult.isLeft()) return left(projectResult.value);
+
+    try {
+      await this.projectRepository.save(projectResult.value);
+      return right(undefined);
+    } catch {
+      return left(
+        new DomainError('SAVE_FAILED', { message: 'Failed to save project' }),
+      );
+    }
+  }
+}

--- a/packages/application/src/portfolio/use-cases/UpdateProfile.ts
+++ b/packages/application/src/portfolio/use-cases/UpdateProfile.ts
@@ -1,0 +1,59 @@
+import { UnauthorizedError } from '@repo/core/identity';
+import {
+  IProfileProps,
+  IProfileRepository,
+  Profile,
+} from '@repo/core/portfolio';
+import {
+  DomainError,
+  Either,
+  NotFoundError,
+  ValidationError,
+  left,
+  right,
+} from '@repo/core/shared';
+
+import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { UseCase } from '../../shared/UseCase';
+
+export type UpdateProfileInput = {
+  userId: string;
+  profileProps: IProfileProps;
+};
+
+export class UpdateProfile extends UseCase<
+  UpdateProfileInput,
+  void,
+  ValidationError | UnauthorizedError | NotFoundError | DomainError
+> {
+  constructor(
+    private readonly profileRepository: IProfileRepository,
+    private readonly ensureAdmin: EnsureAdmin,
+  ) {
+    super();
+  }
+
+  async execute(
+    input: UpdateProfileInput,
+  ): Promise<
+    Either<
+      ValidationError | UnauthorizedError | NotFoundError | DomainError,
+      void
+    >
+  > {
+    const adminCheck = await this.ensureAdmin.execute({ userId: input.userId });
+    if (adminCheck.isLeft()) return left(adminCheck.value);
+
+    const profileResult = Profile.create(input.profileProps);
+    if (profileResult.isLeft()) return left(profileResult.value);
+
+    try {
+      await this.profileRepository.save(profileResult.value);
+      return right(undefined);
+    } catch {
+      return left(
+        new DomainError('SAVE_FAILED', { message: 'Failed to save profile' }),
+      );
+    }
+  }
+}

--- a/packages/application/src/portfolio/use-cases/index.ts
+++ b/packages/application/src/portfolio/use-cases/index.ts
@@ -16,3 +16,12 @@ export {
   GetProjectBySlug,
   type GetProjectBySlugInput,
 } from './GetProjectBySlug';
+export { SaveProject, type SaveProjectInput } from './SaveProject';
+export { PublishProject, type PublishProjectInput } from './PublishProject';
+export { ArchiveProject, type ArchiveProjectInput } from './ArchiveProject';
+export { UpdateProfile, type UpdateProfileInput } from './UpdateProfile';
+export { SaveExperience, type SaveExperienceInput } from './SaveExperience';
+export {
+  DeleteExperience,
+  type DeleteExperienceInput,
+} from './DeleteExperience';

--- a/packages/application/test/portfolio/use-cases/ArchiveProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/ArchiveProject.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { IUserRepository, Role, UnauthorizedError, User } from '@repo/core/identity';
+import {
+  IProjectProps,
+  IProjectRepository,
+  Project,
+  ProjectStatus,
+} from '@repo/core/portfolio';
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { EnsureAdmin } from '~/identity/use-cases/EnsureAdmin';
+import { ArchiveProject } from '~/portfolio/use-cases/ArchiveProject';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VISITOR_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d470';
+const PROJECT_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d471';
+
+const BASE_PROJECT_PROPS: IProjectProps = {
+  slug: 'my-project',
+  coverImage: {
+    url: 'https://example.com/cover.png',
+    alt: { 'en-US': 'Cover', 'pt-BR': 'Capa' },
+  },
+  title: { 'en-US': 'My Project', 'pt-BR': 'Meu Projeto' },
+  caption: { 'en-US': 'A caption.', 'pt-BR': 'Uma legenda.' },
+  content: 'Lorem ipsum dolor sit amet.',
+  skills: ['a0000000-0000-4000-8000-000000000001'],
+  period: { start: '2024-01-01' },
+  featured: false,
+  status: ProjectStatus.PUBLISHED,
+  relatedProjects: [],
+};
+
+function makeProject(status: ProjectStatus): Project {
+  const result = Project.create({ ...BASE_PROJECT_PROPS, status });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUser(role: Role): User {
+  const result = User.create({ name: 'Test User', email: 'test@example.com', role });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUserRepo(user: User | null): IUserRepository {
+  return {
+    findById: vi.fn().mockResolvedValue(user),
+    findByEmail: vi.fn(),
+    findByAuthSubject: vi.fn(),
+    linkAuthSubject: vi.fn(),
+  };
+}
+
+function makeProjectRepo(
+  overrides: Partial<IProjectRepository> = {},
+): IProjectRepository {
+  return {
+    findAll: vi.fn(),
+    findById: vi.fn().mockResolvedValue(null),
+    findBySlug: vi.fn(),
+    findPublished: vi.fn(),
+    findFeatured: vi.fn(),
+    findRelated: vi.fn(),
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeUseCase(user: User | null, projectRepo?: Partial<IProjectRepository>) {
+  const userRepo = makeUserRepo(user);
+  const ensureAdmin = new EnsureAdmin(userRepo);
+  const pRepo = makeProjectRepo(projectRepo);
+  return { useCase: new ArchiveProject(pRepo, ensureAdmin), projectRepo: pRepo };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ArchiveProject', () => {
+  describe('when user is admin', () => {
+    it('should archive a PUBLISHED project and return Right', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const project = makeProject(ProjectStatus.PUBLISHED);
+      const { useCase, projectRepo } = makeUseCase(admin, {
+        findById: vi.fn().mockResolvedValue(project),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(project.status).toBe(ProjectStatus.ARCHIVED);
+      expect(projectRepo.save).toHaveBeenCalledWith(project);
+    });
+
+    it('should return Left(ValidationError) when project is already archived', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const project = makeProject(ProjectStatus.ARCHIVED);
+      const { useCase } = makeUseCase(admin, {
+        findById: vi.fn().mockResolvedValue(project),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(NotFoundError) when project does not exist', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        findById: vi.fn().mockResolvedValue(null),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+
+    it('should return Left(ValidationError) when projectId is not a valid UUID', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: 'not-a-uuid',
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(DomainError) when repository fetch throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        findById: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+
+    it('should return Left(DomainError) when repository save throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const project = makeProject(ProjectStatus.PUBLISHED);
+      const { useCase } = makeUseCase(admin, {
+        findById: vi.fn().mockResolvedValue(project),
+        save: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+  });
+
+  describe('when user is not admin', () => {
+    it('should return Left(UnauthorizedError)', async () => {
+      const visitor = makeUser(Role.VISITOR);
+      const { useCase } = makeUseCase(visitor);
+
+      const result = await useCase.execute({
+        userId: VISITOR_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(UnauthorizedError);
+    });
+  });
+
+  describe('when user does not exist', () => {
+    it('should return Left(NotFoundError)', async () => {
+      const { useCase } = makeUseCase(null);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+  });
+});

--- a/packages/application/test/portfolio/use-cases/DeleteExperience.test.ts
+++ b/packages/application/test/portfolio/use-cases/DeleteExperience.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { IUserRepository, Role, UnauthorizedError, User } from '@repo/core/identity';
+import { IExperienceRepository } from '@repo/core/portfolio';
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { EnsureAdmin } from '~/identity/use-cases/EnsureAdmin';
+import { DeleteExperience } from '~/portfolio/use-cases/DeleteExperience';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VISITOR_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d470';
+const EXPERIENCE_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d471';
+
+function makeUser(role: Role): User {
+  const result = User.create({ name: 'Test User', email: 'test@example.com', role });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUserRepo(user: User | null): IUserRepository {
+  return {
+    findById: vi.fn().mockResolvedValue(user),
+    findByEmail: vi.fn(),
+    findByAuthSubject: vi.fn(),
+    linkAuthSubject: vi.fn(),
+  };
+}
+
+function makeExperienceRepo(
+  overrides: Partial<IExperienceRepository> = {},
+): IExperienceRepository {
+  return {
+    findAll: vi.fn(),
+    findById: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeUseCase(user: User | null, experienceRepo?: Partial<IExperienceRepository>) {
+  const userRepo = makeUserRepo(user);
+  const ensureAdmin = new EnsureAdmin(userRepo);
+  const eRepo = makeExperienceRepo(experienceRepo);
+  return { useCase: new DeleteExperience(eRepo, ensureAdmin), experienceRepo: eRepo };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DeleteExperience', () => {
+  describe('when user is admin', () => {
+    it('should delete experience and return Right', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase, experienceRepo } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        experienceId: EXPERIENCE_UUID,
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(experienceRepo.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return Left(ValidationError) when experienceId is not a valid UUID', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        experienceId: 'not-a-uuid',
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(DomainError) when repository throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        delete: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        experienceId: EXPERIENCE_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+  });
+
+  describe('when user is not admin', () => {
+    it('should return Left(UnauthorizedError)', async () => {
+      const visitor = makeUser(Role.VISITOR);
+      const { useCase } = makeUseCase(visitor);
+
+      const result = await useCase.execute({
+        userId: VISITOR_UUID,
+        experienceId: EXPERIENCE_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(UnauthorizedError);
+    });
+  });
+
+  describe('when user does not exist', () => {
+    it('should return Left(NotFoundError)', async () => {
+      const { useCase } = makeUseCase(null);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        experienceId: EXPERIENCE_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+  });
+});

--- a/packages/application/test/portfolio/use-cases/PublishProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/PublishProject.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { IUserRepository, Role, UnauthorizedError, User } from '@repo/core/identity';
+import {
+  IProjectProps,
+  IProjectRepository,
+  Project,
+  ProjectStatus,
+} from '@repo/core/portfolio';
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { EnsureAdmin } from '~/identity/use-cases/EnsureAdmin';
+import { PublishProject } from '~/portfolio/use-cases/PublishProject';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VISITOR_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d470';
+const PROJECT_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d471';
+
+const BASE_PROJECT_PROPS: IProjectProps = {
+  slug: 'my-project',
+  coverImage: {
+    url: 'https://example.com/cover.png',
+    alt: { 'en-US': 'Cover', 'pt-BR': 'Capa' },
+  },
+  title: { 'en-US': 'My Project', 'pt-BR': 'Meu Projeto' },
+  caption: { 'en-US': 'A caption.', 'pt-BR': 'Uma legenda.' },
+  content: 'Lorem ipsum dolor sit amet.',
+  skills: ['a0000000-0000-4000-8000-000000000001'],
+  period: { start: '2024-01-01' },
+  featured: false,
+  status: ProjectStatus.DRAFT,
+  relatedProjects: [],
+};
+
+function makeProject(status: ProjectStatus): Project {
+  const result = Project.create({ ...BASE_PROJECT_PROPS, status });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUser(role: Role): User {
+  const result = User.create({ name: 'Test User', email: 'test@example.com', role });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUserRepo(user: User | null): IUserRepository {
+  return {
+    findById: vi.fn().mockResolvedValue(user),
+    findByEmail: vi.fn(),
+    findByAuthSubject: vi.fn(),
+    linkAuthSubject: vi.fn(),
+  };
+}
+
+function makeProjectRepo(
+  overrides: Partial<IProjectRepository> = {},
+): IProjectRepository {
+  return {
+    findAll: vi.fn(),
+    findById: vi.fn().mockResolvedValue(null),
+    findBySlug: vi.fn(),
+    findPublished: vi.fn(),
+    findFeatured: vi.fn(),
+    findRelated: vi.fn(),
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeUseCase(user: User | null, projectRepo?: Partial<IProjectRepository>) {
+  const userRepo = makeUserRepo(user);
+  const ensureAdmin = new EnsureAdmin(userRepo);
+  const pRepo = makeProjectRepo(projectRepo);
+  return { useCase: new PublishProject(pRepo, ensureAdmin), projectRepo: pRepo };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PublishProject', () => {
+  describe('when user is admin', () => {
+    it('should publish a DRAFT project and return Right', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const project = makeProject(ProjectStatus.DRAFT);
+      const { useCase, projectRepo } = makeUseCase(admin, {
+        findById: vi.fn().mockResolvedValue(project),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(project.status).toBe(ProjectStatus.PUBLISHED);
+      expect(projectRepo.save).toHaveBeenCalledWith(project);
+    });
+
+    it('should return Left(ValidationError) when project is already published', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const project = makeProject(ProjectStatus.PUBLISHED);
+      const { useCase } = makeUseCase(admin, {
+        findById: vi.fn().mockResolvedValue(project),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(NotFoundError) when project does not exist', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        findById: vi.fn().mockResolvedValue(null),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+
+    it('should return Left(ValidationError) when projectId is not a valid UUID', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: 'not-a-uuid',
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(DomainError) when repository fetch throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        findById: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+
+    it('should return Left(DomainError) when repository save throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const project = makeProject(ProjectStatus.DRAFT);
+      const { useCase } = makeUseCase(admin, {
+        findById: vi.fn().mockResolvedValue(project),
+        save: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+  });
+
+  describe('when user is not admin', () => {
+    it('should return Left(UnauthorizedError)', async () => {
+      const visitor = makeUser(Role.VISITOR);
+      const { useCase } = makeUseCase(visitor);
+
+      const result = await useCase.execute({
+        userId: VISITOR_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(UnauthorizedError);
+    });
+  });
+
+  describe('when user does not exist', () => {
+    it('should return Left(NotFoundError)', async () => {
+      const { useCase } = makeUseCase(null);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+  });
+});

--- a/packages/application/test/portfolio/use-cases/SaveExperience.test.ts
+++ b/packages/application/test/portfolio/use-cases/SaveExperience.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { IUserRepository, Role, UnauthorizedError, User } from '@repo/core/identity';
+import {
+  EmploymentType,
+  IExperienceProps,
+  IExperienceRepository,
+  LocationType,
+} from '@repo/core/portfolio';
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { EnsureAdmin } from '~/identity/use-cases/EnsureAdmin';
+import { SaveExperience } from '~/portfolio/use-cases/SaveExperience';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VISITOR_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d470';
+
+const VALID_EXPERIENCE_PROPS: IExperienceProps = {
+  company: { 'en-US': 'Portfolio Inc', 'pt-BR': 'Portfolio Inc' },
+  position: { 'en-US': 'Software Engineer', 'pt-BR': 'Engenheiro de Software' },
+  location: { 'en-US': 'São Paulo, Brazil', 'pt-BR': 'São Paulo, Brasil' },
+  description: {
+    'en-US': 'Developed features for the platform.',
+    'pt-BR': 'Desenvolveu funcionalidades para a plataforma.',
+  },
+  logo: {
+    url: 'https://example.com/logo.png',
+    alt: { 'en-US': 'Logo', 'pt-BR': 'Logo' },
+  },
+  employment_type: EmploymentType.FULL_TIME,
+  location_type: LocationType.REMOTE,
+  start_at: '2022-01-01T00:00:00.000Z',
+  skills: ['a0000000-0000-4000-8000-000000000001'],
+};
+
+function makeUser(role: Role): User {
+  const result = User.create({ name: 'Test User', email: 'test@example.com', role });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUserRepo(user: User | null): IUserRepository {
+  return {
+    findById: vi.fn().mockResolvedValue(user),
+    findByEmail: vi.fn(),
+    findByAuthSubject: vi.fn(),
+    linkAuthSubject: vi.fn(),
+  };
+}
+
+function makeExperienceRepo(
+  overrides: Partial<IExperienceRepository> = {},
+): IExperienceRepository {
+  return {
+    findAll: vi.fn(),
+    findById: vi.fn(),
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeUseCase(user: User | null, experienceRepo?: Partial<IExperienceRepository>) {
+  const userRepo = makeUserRepo(user);
+  const ensureAdmin = new EnsureAdmin(userRepo);
+  const eRepo = makeExperienceRepo(experienceRepo);
+  return { useCase: new SaveExperience(eRepo, ensureAdmin), experienceRepo: eRepo };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SaveExperience', () => {
+  describe('when user is admin', () => {
+    it('should save experience and return Right', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase, experienceRepo } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        experienceProps: VALID_EXPERIENCE_PROPS,
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(experienceRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return Left(ValidationError) when experience props are invalid', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        experienceProps: {
+          ...VALID_EXPERIENCE_PROPS,
+          employment_type: 'INVALID' as EmploymentType,
+        },
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(DomainError) when repository throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        save: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        experienceProps: VALID_EXPERIENCE_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+  });
+
+  describe('when user is not admin', () => {
+    it('should return Left(UnauthorizedError)', async () => {
+      const visitor = makeUser(Role.VISITOR);
+      const { useCase } = makeUseCase(visitor);
+
+      const result = await useCase.execute({
+        userId: VISITOR_UUID,
+        experienceProps: VALID_EXPERIENCE_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(UnauthorizedError);
+    });
+  });
+
+  describe('when user does not exist', () => {
+    it('should return Left(NotFoundError)', async () => {
+      const { useCase } = makeUseCase(null);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        experienceProps: VALID_EXPERIENCE_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+  });
+});

--- a/packages/application/test/portfolio/use-cases/SaveProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/SaveProject.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { IUserRepository, Role, UnauthorizedError, User } from '@repo/core/identity';
+import {
+  IProjectProps,
+  IProjectRepository,
+  ProjectStatus,
+} from '@repo/core/portfolio';
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { EnsureAdmin } from '~/identity/use-cases/EnsureAdmin';
+import { SaveProject } from '~/portfolio/use-cases/SaveProject';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VISITOR_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d470';
+
+const VALID_PROJECT_PROPS: IProjectProps = {
+  slug: 'my-project',
+  coverImage: {
+    url: 'https://example.com/cover.png',
+    alt: { 'en-US': 'Cover', 'pt-BR': 'Capa' },
+  },
+  title: { 'en-US': 'My Project', 'pt-BR': 'Meu Projeto' },
+  caption: { 'en-US': 'A caption.', 'pt-BR': 'Uma legenda.' },
+  content: 'Lorem ipsum dolor sit amet.',
+  skills: ['a0000000-0000-4000-8000-000000000001'],
+  period: { start: '2024-01-01' },
+  featured: false,
+  status: ProjectStatus.DRAFT,
+  relatedProjects: [],
+};
+
+function makeUser(role: Role): User {
+  const result = User.create({ name: 'Test User', email: 'test@example.com', role });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUserRepo(user: User | null): IUserRepository {
+  return {
+    findById: vi.fn().mockResolvedValue(user),
+    findByEmail: vi.fn(),
+    findByAuthSubject: vi.fn(),
+    linkAuthSubject: vi.fn(),
+  };
+}
+
+function makeProjectRepo(
+  overrides: Partial<IProjectRepository> = {},
+): IProjectRepository {
+  return {
+    findAll: vi.fn(),
+    findById: vi.fn(),
+    findBySlug: vi.fn(),
+    findPublished: vi.fn(),
+    findFeatured: vi.fn(),
+    findRelated: vi.fn(),
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeUseCase(user: User | null, projectRepo?: Partial<IProjectRepository>) {
+  const userRepo = makeUserRepo(user);
+  const ensureAdmin = new EnsureAdmin(userRepo);
+  const pRepo = makeProjectRepo(projectRepo);
+  return { useCase: new SaveProject(pRepo, ensureAdmin), projectRepo: pRepo };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SaveProject', () => {
+  describe('when user is admin', () => {
+    it('should save project and return Right', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase, projectRepo } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectProps: VALID_PROJECT_PROPS,
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(projectRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return Left(ValidationError) when project props are invalid', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectProps: { ...VALID_PROJECT_PROPS, slug: '' },
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(DomainError) when repository throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        save: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectProps: VALID_PROJECT_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+  });
+
+  describe('when user is not admin', () => {
+    it('should return Left(UnauthorizedError)', async () => {
+      const visitor = makeUser(Role.VISITOR);
+      const { useCase } = makeUseCase(visitor);
+
+      const result = await useCase.execute({
+        userId: VISITOR_UUID,
+        projectProps: VALID_PROJECT_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(UnauthorizedError);
+    });
+  });
+
+  describe('when user does not exist', () => {
+    it('should return Left(NotFoundError)', async () => {
+      const { useCase } = makeUseCase(null);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectProps: VALID_PROJECT_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+  });
+});

--- a/packages/application/test/portfolio/use-cases/UpdateProfile.test.ts
+++ b/packages/application/test/portfolio/use-cases/UpdateProfile.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { IUserRepository, Role, UnauthorizedError, User } from '@repo/core/identity';
+import { IProfileProps, IProfileRepository } from '@repo/core/portfolio';
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { EnsureAdmin } from '~/identity/use-cases/EnsureAdmin';
+import { UpdateProfile } from '~/portfolio/use-cases/UpdateProfile';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VISITOR_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d470';
+
+const VALID_PROFILE_PROPS: IProfileProps = {
+  name: 'Wallace',
+  headline: { 'en-US': 'Software Engineer', 'pt-BR': 'Engenheiro de Software' },
+  bio: {
+    'en-US': 'Developer passionate about DDD.',
+    'pt-BR': 'Desenvolvedor apaixonado por DDD.',
+  },
+  photo: {
+    url: 'https://example.com/photo.png',
+    alt: { 'en-US': 'Photo', 'pt-BR': 'Foto' },
+  },
+  stats: [
+    { label: { 'en-US': 'Years', 'pt-BR': 'Anos' }, value: '5+', icon: 'briefcase' },
+  ],
+  featuredProjectSlugs: [],
+};
+
+function makeUser(role: Role): User {
+  const result = User.create({ name: 'Test User', email: 'test@example.com', role });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUserRepo(user: User | null): IUserRepository {
+  return {
+    findById: vi.fn().mockResolvedValue(user),
+    findByEmail: vi.fn(),
+    findByAuthSubject: vi.fn(),
+    linkAuthSubject: vi.fn(),
+  };
+}
+
+function makeProfileRepo(
+  overrides: Partial<IProfileRepository> = {},
+): IProfileRepository {
+  return {
+    find: vi.fn(),
+    save: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeUseCase(user: User | null, profileRepo?: Partial<IProfileRepository>) {
+  const userRepo = makeUserRepo(user);
+  const ensureAdmin = new EnsureAdmin(userRepo);
+  const pRepo = makeProfileRepo(profileRepo);
+  return { useCase: new UpdateProfile(pRepo, ensureAdmin), profileRepo: pRepo };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UpdateProfile', () => {
+  describe('when user is admin', () => {
+    it('should save profile and return Right', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase, profileRepo } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        profileProps: VALID_PROFILE_PROPS,
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(profileRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return Left(ValidationError) when profile has too many featured projects', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        profileProps: {
+          ...VALID_PROFILE_PROPS,
+          featuredProjectSlugs: ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'],
+        },
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(DomainError) when repository throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        save: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        profileProps: VALID_PROFILE_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+  });
+
+  describe('when user is not admin', () => {
+    it('should return Left(UnauthorizedError)', async () => {
+      const visitor = makeUser(Role.VISITOR);
+      const { useCase } = makeUseCase(visitor);
+
+      const result = await useCase.execute({
+        userId: VISITOR_UUID,
+        profileProps: VALID_PROFILE_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(UnauthorizedError);
+    });
+  });
+
+  describe('when user does not exist', () => {
+    it('should return Left(NotFoundError)', async () => {
+      const { useCase } = makeUseCase(null);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        profileProps: VALID_PROFILE_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+  });
+});

--- a/packages/core/src/portfolio/entities/project/model/Project.ts
+++ b/packages/core/src/portfolio/entities/project/model/Project.ts
@@ -61,7 +61,7 @@ export class Project extends AggregateRoot<Project, IProjectProps> {
   public readonly role: LocalizedText | undefined;
   public readonly period: DateRange;
   public readonly featured: boolean;
-  public readonly status: ProjectStatus;
+  public status: ProjectStatus;
   public readonly relatedProjects: Slug[];
 
   private constructor(
@@ -203,5 +203,35 @@ export class Project extends AggregateRoot<Project, IProjectProps> {
         relatedSlugs,
       ),
     );
+  }
+
+  publish(): Either<ValidationError, void> {
+    const { error, isValid } = Validator.of(this.status)
+      .refine(
+        (s) => s !== ProjectStatus.PUBLISHED,
+        'Project is already published.',
+      )
+      .validate();
+    if (!isValid && error)
+      return left(
+        new ValidationError({ code: Project.ERROR_CODE, message: error }),
+      );
+    this.status = ProjectStatus.PUBLISHED;
+    return right(undefined);
+  }
+
+  archive(): Either<ValidationError, void> {
+    const { error, isValid } = Validator.of(this.status)
+      .refine(
+        (s) => s !== ProjectStatus.ARCHIVED,
+        'Project is already archived.',
+      )
+      .validate();
+    if (!isValid && error)
+      return left(
+        new ValidationError({ code: Project.ERROR_CODE, message: error }),
+      );
+    this.status = ProjectStatus.ARCHIVED;
+    return right(undefined);
   }
 }


### PR DESCRIPTION
## Summary

- Adds `Project.publish()` and `Project.archive()` domain methods to `@repo/core` with business-rule guards (already-published/archived check via `Validator`)
- Implements 6 admin write use cases in `@repo/application`, each enforcing `EnsureAdmin` before persistence:
  - `SaveProject` — create/update project
  - `PublishProject` — publish via `project.publish()` domain method
  - `ArchiveProject` — archive via `project.archive()` domain method
  - `UpdateProfile` — update profile singleton
  - `SaveExperience` — create/update experience
  - `DeleteExperience` — delete experience by ID
- 36 new unit tests covering: happy path, auth failure (`UnauthorizedError`), not found (`NotFoundError`), validation failure (`ValidationError`), and persistence failure (`DomainError`)

## Test plan

- [x] `pnpm --filter @repo/core test` — 224 tests pass
- [x] `pnpm --filter @repo/application test` — 145 tests pass (36 new)
- [x] `pnpm --filter @repo/core tsc --noEmit` — clean
- [x] `pnpm --filter @repo/application tsc --noEmit` — clean
- [x] Pre-commit hooks pass (format, test, types, lint)

Refs #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)