### PR TITLE
refactor(utils): segregate React hooks into @repo/utils/hooks subpath

### DIFF
--- a/packages/ui/src/Control/Button/Clipboard/index.tsx
+++ b/packages/ui/src/Control/Button/Clipboard/index.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useCallback, useId, type ReactNode } from 'react';
 
-import { useThrottle } from '@repo/utils';
+import { useThrottle } from '@repo/utils/hooks';
 import { Tooltip } from 'react-tooltip';
 import { useBoolean, useCopyToClipboard } from 'usehooks-ts';
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,6 +8,7 @@
   "main": "src/index.ts",
   "exports": {
     ".": { "types": "./dist/types/index.d.ts", "default": "./src/index.ts" },
+    "./hooks": { "types": "./dist/types/hooks/index.d.ts", "default": "./src/hooks/index.ts" },
     "./validator": { "types": "./dist/types/validator/index.d.ts", "default": "./src/validator/index.ts" },
     "./env": { "types": "./dist/types/env/index.d.ts", "default": "./src/env/index.ts" }
   },

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,7 +1,6 @@
 export * from './constants';
 export * from './env';
 export * from './formatters';
-export * from './hooks';
 export * from './types';
 export * from './validations';
 export * from './validator';

--- a/packages/utils/test/browser/useThrottle.test.ts
+++ b/packages/utils/test/browser/useThrottle.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 
-import { useThrottle } from '../../src';
+import { useThrottle } from '../../src/hooks';
 
 describe('useThrottle', () => {
   it('should throttle the function calls', () => {


### PR DESCRIPTION
## Summary

- Removes `export * from './hooks'` from the `@repo/utils` main barrel, making it React-free
- Adds `"./hooks"` subpath export in `packages/utils/package.json` so React hooks are available via `@repo/utils/hooks`
- Updates `packages/ui/src/Control/Button/Clipboard/index.tsx` (the only consumer of `useThrottle`) to import from `@repo/utils/hooks`
- Fixes `packages/utils/test/browser/useThrottle.test.ts` to import from the hooks subpath

## Test plan

- [x] `pnpm --filter @repo/utils test` — 81 tests pass
- [x] `pnpm types` — clean across all packages
- [x] Pre-commit hooks pass (format, test, types, lint)

Refs #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)