### PR TITLE
[T-54] admin endpoints /api/v1/admin/* with EnsureAdmin guard

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -4182,7 +4182,7 @@
         "dependencies": [
           "2"
         ],
-        "status": "pending",
+        "status": "in-progress",
         "subtasks": [
           {
             "id": 1,
@@ -4235,7 +4235,7 @@
             "parentId": "undefined"
           }
         ],
-        "updatedAt": "2026-04-02T03:21:49.111Z"
+        "updatedAt": "2026-05-12T05:14:23.894Z"
       },
       {
         "id": "2",
@@ -4330,7 +4330,7 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-05-12T04:56:59.235Z",
+      "lastModified": "2026-05-12T05:14:23.894Z",
       "taskCount": 8,
       "completedCount": 2,
       "tags": [

--- a/apps/web/src/app/api/v1/admin/experiences/[id]/route.ts
+++ b/apps/web/src/app/api/v1/admin/experiences/[id]/route.ts
@@ -1,0 +1,43 @@
+import { EnsureAdmin } from '@repo/application/identity';
+import { DeleteExperience, SaveExperience } from '@repo/application/portfolio';
+import { left } from '@repo/core/shared';
+import { getContainer } from '@repo/infra';
+import { NextRequest } from 'next/server';
+
+import { handleRequest } from '~/lib/api/handler';
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const body = await request.json();
+    const { experienceRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new SaveExperience(experienceRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      experienceProps: { ...body, id },
+    });
+  });
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const { experienceRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new DeleteExperience(experienceRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      experienceId: id,
+    });
+  }, 204);
+}

--- a/apps/web/src/app/api/v1/admin/experiences/route.ts
+++ b/apps/web/src/app/api/v1/admin/experiences/route.ts
@@ -1,0 +1,24 @@
+import { EnsureAdmin } from '@repo/application/identity';
+import { SaveExperience } from '@repo/application/portfolio';
+import { left } from '@repo/core/shared';
+import { getContainer } from '@repo/infra';
+import { NextRequest } from 'next/server';
+
+import { handleRequest } from '~/lib/api/handler';
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
+
+export async function POST(request: NextRequest) {
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const body = await request.json();
+    const { experienceRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new SaveExperience(experienceRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      experienceProps: body,
+    });
+  }, 201);
+}

--- a/apps/web/src/app/api/v1/admin/profile/route.ts
+++ b/apps/web/src/app/api/v1/admin/profile/route.ts
@@ -1,0 +1,24 @@
+import { EnsureAdmin } from '@repo/application/identity';
+import { UpdateProfile } from '@repo/application/portfolio';
+import { left } from '@repo/core/shared';
+import { getContainer } from '@repo/infra';
+import { NextRequest } from 'next/server';
+
+import { handleRequest } from '~/lib/api/handler';
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
+
+export async function PUT(request: NextRequest) {
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const body = await request.json();
+    const { profileRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new UpdateProfile(profileRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      profileProps: body,
+    });
+  });
+}

--- a/apps/web/src/app/api/v1/admin/projects/[id]/archive/route.ts
+++ b/apps/web/src/app/api/v1/admin/projects/[id]/archive/route.ts
@@ -1,0 +1,26 @@
+import { EnsureAdmin } from '@repo/application/identity';
+import { ArchiveProject } from '@repo/application/portfolio';
+import { left } from '@repo/core/shared';
+import { getContainer } from '@repo/infra';
+import { NextRequest } from 'next/server';
+
+import { handleRequest } from '~/lib/api/handler';
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const { projectRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new ArchiveProject(projectRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      projectId: id,
+    });
+  });
+}

--- a/apps/web/src/app/api/v1/admin/projects/[id]/publish/route.ts
+++ b/apps/web/src/app/api/v1/admin/projects/[id]/publish/route.ts
@@ -1,0 +1,26 @@
+import { EnsureAdmin } from '@repo/application/identity';
+import { PublishProject } from '@repo/application/portfolio';
+import { left } from '@repo/core/shared';
+import { getContainer } from '@repo/infra';
+import { NextRequest } from 'next/server';
+
+import { handleRequest } from '~/lib/api/handler';
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const { projectRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new PublishProject(projectRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      projectId: id,
+    });
+  });
+}

--- a/apps/web/src/app/api/v1/admin/projects/[id]/route.ts
+++ b/apps/web/src/app/api/v1/admin/projects/[id]/route.ts
@@ -1,0 +1,43 @@
+import { EnsureAdmin } from '@repo/application/identity';
+import { DeleteProject, SaveProject } from '@repo/application/portfolio';
+import { left } from '@repo/core/shared';
+import { getContainer } from '@repo/infra';
+import { NextRequest } from 'next/server';
+
+import { handleRequest } from '~/lib/api/handler';
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const body = await request.json();
+    const { projectRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new SaveProject(projectRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      projectProps: { ...body, id },
+    });
+  });
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const { projectRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new DeleteProject(projectRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      projectId: id,
+    });
+  }, 204);
+}

--- a/apps/web/src/app/api/v1/admin/projects/route.ts
+++ b/apps/web/src/app/api/v1/admin/projects/route.ts
@@ -1,0 +1,24 @@
+import { EnsureAdmin } from '@repo/application/identity';
+import { SaveProject } from '@repo/application/portfolio';
+import { left } from '@repo/core/shared';
+import { getContainer } from '@repo/infra';
+import { NextRequest } from 'next/server';
+
+import { handleRequest } from '~/lib/api/handler';
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
+
+export async function POST(request: NextRequest) {
+  return handleRequest(async () => {
+    const userIdResult = await resolveSessionUserId();
+    if (userIdResult.isLeft()) return left(userIdResult.value);
+
+    const body = await request.json();
+    const { projectRepository, userRepository } = getContainer();
+    const ensureAdmin = new EnsureAdmin(userRepository);
+
+    return new SaveProject(projectRepository, ensureAdmin).execute({
+      userId: userIdResult.value,
+      projectProps: body,
+    });
+  }, 201);
+}

--- a/apps/web/src/lib/api/handler.ts
+++ b/apps/web/src/lib/api/handler.ts
@@ -16,6 +16,9 @@ export async function handleRequest<T>(
         status,
       });
     }
+    if (successStatus === 204) {
+      return new NextResponse(null, { status: 204 });
+    }
     return NextResponse.json(successResponse(result.value), {
       status: successStatus,
     });

--- a/apps/web/src/lib/auth/ensure-admin.ts
+++ b/apps/web/src/lib/auth/ensure-admin.ts
@@ -1,0 +1,22 @@
+import { EnsureAppUserForAuthSession } from '@repo/application/identity';
+import { DomainError, Either, left } from '@repo/core/shared';
+import { getContainer } from '@repo/infra';
+
+import { createNextAuthCookieApi } from './cookie';
+
+export async function resolveSessionUserId(): Promise<
+  Either<DomainError, string>
+> {
+  const { authGateway, userRepository } = getContainer();
+  const cookieApi = await createNextAuthCookieApi();
+
+  const principalResult = await authGateway.getPrincipalFromCookies(cookieApi);
+  if (principalResult.isLeft()) return left(principalResult.value);
+
+  const principal = principalResult.value;
+
+  return new EnsureAppUserForAuthSession(userRepository).execute({
+    authSubject: principal.id,
+    email: principal.email,
+  });
+}

--- a/apps/web/tests/app/api/v1/admin/projects/[id]/route.test.ts
+++ b/apps/web/tests/app/api/v1/admin/projects/[id]/route.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment node
+ */
+import { DomainError, left, right } from '@repo/core/shared';
+import { type Container, getContainer } from '@repo/infra';
+
+import { DELETE, PUT } from '~/app/api/v1/admin/projects/[id]/route';
+
+vi.mock('@repo/infra', () => ({
+  getContainer: vi.fn(),
+}));
+
+const mockCookieStore = {
+  store: {} as Record<string, string>,
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('next/headers', () => ({
+  cookies: () => mockCookieStore,
+}));
+
+const mockGetPrincipal = vi.fn();
+const mockFindByAuthSubject = vi.fn();
+const mockFindByEmail = vi.fn();
+const mockFindById = vi.fn();
+const mockProjectSave = vi.fn();
+const mockProjectDelete = vi.fn();
+const mockLinkAuthSubject = vi.fn();
+
+const VALID_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const PROJECT_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d471';
+const PRINCIPAL = { id: VALID_UUID, email: 'admin@example.com', role: 'ADMIN' };
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function makeRequest(method: string, body?: unknown) {
+  return new Request(`http://localhost/api/v1/admin/projects/${PROJECT_UUID}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  }) as import('next/server').NextRequest;
+}
+
+const VALID_PROJECT_BODY = {
+  slug: 'updated-project',
+  coverImage: {
+    url: 'https://example.com/cover.png',
+    alt: { 'en-US': 'Cover', 'pt-BR': 'Capa' },
+  },
+  title: { 'en-US': 'Updated Project', 'pt-BR': 'Projeto Atualizado' },
+  caption: { 'en-US': 'A caption.', 'pt-BR': 'Uma legenda.' },
+  content: 'Lorem ipsum.',
+  skills: [],
+  period: { start: '2024-01-01' },
+  featured: false,
+  status: 'DRAFT',
+  relatedProjects: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCookieStore.store = {};
+  mockCookieStore.get.mockImplementation((name: string) => {
+    const value = mockCookieStore.store[name];
+    return value !== undefined ? { name, value } : undefined;
+  });
+  mockProjectSave.mockResolvedValue(undefined);
+  mockProjectDelete.mockResolvedValue(undefined);
+
+  vi.mocked(getContainer).mockReturnValue({
+    authGateway: {
+      getPrincipalFromCookies: mockGetPrincipal,
+      signInWithPassword: vi.fn(),
+      signOut: vi.fn(),
+      refreshSession: vi.fn(),
+    },
+    userRepository: {
+      findById: mockFindById,
+      findByEmail: mockFindByEmail,
+      findByAuthSubject: mockFindByAuthSubject,
+      linkAuthSubject: mockLinkAuthSubject,
+      save: vi.fn(),
+    },
+    projectRepository: {
+      findAll: vi.fn(),
+      findById: vi.fn(),
+      findBySlug: vi.fn(),
+      findPublished: vi.fn(),
+      findFeatured: vi.fn(),
+      findRelated: vi.fn(),
+      save: mockProjectSave,
+      delete: mockProjectDelete,
+    },
+  } as unknown as Container);
+});
+
+async function setupAdmin() {
+  const { Role, User } = await import('@repo/core/identity');
+  const admin = User.create({
+    name: 'Admin',
+    email: 'admin@example.com',
+    role: Role.ADMIN,
+    authSubject: VALID_UUID,
+  });
+  if (admin.isLeft()) throw admin.value;
+  mockGetPrincipal.mockResolvedValue(right(PRINCIPAL));
+  mockFindByAuthSubject.mockResolvedValue(admin.value);
+  mockFindById.mockResolvedValue(admin.value);
+  return admin.value;
+}
+
+describe('PUT /api/v1/admin/projects/[id]', () => {
+  it('should return 200 when admin updates a project', async () => {
+    await setupAdmin();
+
+    const response = await PUT(
+      makeRequest('PUT', VALID_PROJECT_BODY),
+      makeParams(PROJECT_UUID),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockProjectSave).toHaveBeenCalledOnce();
+  });
+
+  it('should return 401 when no session exists', async () => {
+    mockGetPrincipal.mockResolvedValue(
+      left(new DomainError('NO_ACCESS_TOKEN', { message: 'No session.' })),
+    );
+
+    const response = await PUT(
+      makeRequest('PUT', VALID_PROJECT_BODY),
+      makeParams(PROJECT_UUID),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('DELETE /api/v1/admin/projects/[id]', () => {
+  it('should return 204 when admin deletes a project', async () => {
+    await setupAdmin();
+
+    const response = await DELETE(
+      makeRequest('DELETE'),
+      makeParams(PROJECT_UUID),
+    );
+
+    expect(response.status).toBe(204);
+    expect(mockProjectDelete).toHaveBeenCalledOnce();
+  });
+
+  it('should return 401 when no session exists', async () => {
+    mockGetPrincipal.mockResolvedValue(
+      left(new DomainError('NO_ACCESS_TOKEN', { message: 'No session.' })),
+    );
+
+    const response = await DELETE(
+      makeRequest('DELETE'),
+      makeParams(PROJECT_UUID),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 400 when id is not a valid UUID', async () => {
+    await setupAdmin();
+
+    const response = await DELETE(
+      makeRequest('DELETE'),
+      makeParams('not-a-uuid'),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBeDefined();
+  });
+});

--- a/apps/web/tests/app/api/v1/admin/projects/route.test.ts
+++ b/apps/web/tests/app/api/v1/admin/projects/route.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment node
+ */
+import { UnauthorizedError } from '@repo/core/identity';
+import { DomainError, ValidationError, left, right } from '@repo/core/shared';
+import { type Container, getContainer } from '@repo/infra';
+
+import { POST } from '~/app/api/v1/admin/projects/route';
+
+vi.mock('@repo/infra', () => ({
+  getContainer: vi.fn(),
+}));
+
+const mockCookieStore = {
+  store: {} as Record<string, string>,
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('next/headers', () => ({
+  cookies: () => mockCookieStore,
+}));
+
+const mockGetPrincipal = vi.fn();
+const mockFindByAuthSubject = vi.fn();
+const mockFindByEmail = vi.fn();
+const mockFindById = vi.fn();
+const mockSave = vi.fn();
+const mockLinkAuthSubject = vi.fn();
+
+const VALID_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const PRINCIPAL = { id: VALID_UUID, email: 'admin@example.com', role: 'ADMIN' };
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/v1/admin/projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as import('next/server').NextRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCookieStore.store = {};
+  mockCookieStore.get.mockImplementation((name: string) => {
+    const value = mockCookieStore.store[name];
+    return value !== undefined ? { name, value } : undefined;
+  });
+
+  vi.mocked(getContainer).mockReturnValue({
+    authGateway: {
+      getPrincipalFromCookies: mockGetPrincipal,
+      signInWithPassword: vi.fn(),
+      signOut: vi.fn(),
+      refreshSession: vi.fn(),
+    },
+    userRepository: {
+      findById: mockFindById,
+      findByEmail: mockFindByEmail,
+      findByAuthSubject: mockFindByAuthSubject,
+      linkAuthSubject: mockLinkAuthSubject,
+      save: mockSave,
+    },
+    projectRepository: {
+      findAll: vi.fn(),
+      findById: vi.fn(),
+      findBySlug: vi.fn(),
+      findPublished: vi.fn(),
+      findFeatured: vi.fn(),
+      findRelated: vi.fn(),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+    },
+  } as unknown as Container);
+});
+
+const VALID_PROJECT_BODY = {
+  slug: 'my-project',
+  coverImage: {
+    url: 'https://example.com/cover.png',
+    alt: { 'en-US': 'Cover', 'pt-BR': 'Capa' },
+  },
+  title: { 'en-US': 'My Project', 'pt-BR': 'Meu Projeto' },
+  caption: { 'en-US': 'A caption.', 'pt-BR': 'Uma legenda.' },
+  content: 'Lorem ipsum.',
+  skills: [],
+  period: { start: '2024-01-01' },
+  featured: false,
+  status: 'DRAFT',
+  relatedProjects: [],
+};
+
+describe('POST /api/v1/admin/projects', () => {
+  it('should return 401 when no session exists', async () => {
+    mockGetPrincipal.mockResolvedValue(
+      left(new DomainError('NO_ACCESS_TOKEN', { message: 'No session.' })),
+    );
+
+    const response = await POST(makeRequest(VALID_PROJECT_BODY));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBeDefined();
+  });
+
+  it('should return 401 when user is not admin', async () => {
+    const { Role, User } = await import('@repo/core/identity');
+    const visitor = User.create({
+      name: 'Visitor',
+      email: 'v@example.com',
+      role: Role.VISITOR,
+      authSubject: VALID_UUID,
+    });
+    if (visitor.isLeft()) throw visitor.value;
+
+    mockGetPrincipal.mockResolvedValue(right(PRINCIPAL));
+    mockFindByAuthSubject.mockResolvedValue(visitor.value);
+    mockFindById.mockResolvedValue(visitor.value);
+
+    const response = await POST(makeRequest(VALID_PROJECT_BODY));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBeDefined();
+  });
+
+  it('should return 201 when admin creates a valid project', async () => {
+    const { Role, User } = await import('@repo/core/identity');
+    const admin = User.create({
+      name: 'Admin',
+      email: 'admin@example.com',
+      role: Role.ADMIN,
+      authSubject: VALID_UUID,
+    });
+    if (admin.isLeft()) throw admin.value;
+
+    mockGetPrincipal.mockResolvedValue(right(PRINCIPAL));
+    mockFindByAuthSubject.mockResolvedValue(admin.value);
+    mockFindById.mockResolvedValue(admin.value);
+    mockSave.mockResolvedValue(undefined);
+
+    const response = await POST(makeRequest(VALID_PROJECT_BODY));
+
+    expect(response.status).toBe(201);
+  });
+
+  it('should return 400 when project props are invalid', async () => {
+    const { Role, User } = await import('@repo/core/identity');
+    const admin = User.create({
+      name: 'Admin',
+      email: 'admin@example.com',
+      role: Role.ADMIN,
+      authSubject: VALID_UUID,
+    });
+    if (admin.isLeft()) throw admin.value;
+
+    mockGetPrincipal.mockResolvedValue(right(PRINCIPAL));
+    mockFindByAuthSubject.mockResolvedValue(admin.value);
+    mockFindById.mockResolvedValue(admin.value);
+
+    const response = await POST(makeRequest({ slug: '' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBeDefined();
+  });
+});

--- a/apps/web/tests/lib/auth/ensure-admin.test.ts
+++ b/apps/web/tests/lib/auth/ensure-admin.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment node
+ */
+import { DomainError, left, right } from '@repo/core/shared';
+import { type Container, getContainer } from '@repo/infra';
+
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
+
+vi.mock('@repo/infra', () => ({
+  getContainer: vi.fn(),
+}));
+
+const mockCookieStore = {
+  store: {} as Record<string, string>,
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('next/headers', () => ({
+  cookies: () => mockCookieStore,
+}));
+
+const mockGetPrincipal = vi.fn();
+const mockFindByAuthSubject = vi.fn();
+const mockFindByEmail = vi.fn();
+
+const VALID_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const PRINCIPAL = { id: VALID_UUID, email: 'admin@example.com', role: 'ADMIN' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCookieStore.store = {};
+  mockCookieStore.get.mockImplementation((name: string) => {
+    const value = mockCookieStore.store[name];
+    return value !== undefined ? { name, value } : undefined;
+  });
+
+  vi.mocked(getContainer).mockReturnValue({
+    authGateway: {
+      getPrincipalFromCookies: mockGetPrincipal,
+      signInWithPassword: vi.fn(),
+      signOut: vi.fn(),
+      refreshSession: vi.fn(),
+    },
+    userRepository: {
+      findById: vi.fn(),
+      findByEmail: mockFindByEmail,
+      findByAuthSubject: mockFindByAuthSubject,
+      linkAuthSubject: vi.fn(),
+      save: vi.fn(),
+    },
+  } as unknown as Container);
+});
+
+describe('resolveSessionUserId', () => {
+  it('should return Left when no session cookie exists', async () => {
+    mockGetPrincipal.mockResolvedValue(
+      left(new DomainError('NO_ACCESS_TOKEN', { message: 'No session.' })),
+    );
+
+    const result = await resolveSessionUserId();
+
+    expect(result.isLeft()).toBe(true);
+  });
+
+  it('should return Left when auth token is invalid', async () => {
+    mockGetPrincipal.mockResolvedValue(
+      left(
+        new DomainError('INVALID_ACCESS_TOKEN', { message: 'Token expired.' }),
+      ),
+    );
+
+    const result = await resolveSessionUserId();
+
+    expect(result.isLeft()).toBe(true);
+  });
+
+  it('should return Right(userId) when session is valid and user exists', async () => {
+    mockGetPrincipal.mockResolvedValue(right(PRINCIPAL));
+    mockFindByAuthSubject.mockResolvedValue(null);
+    mockFindByEmail.mockResolvedValue(null);
+    vi.mocked(getContainer).mockReturnValue({
+      ...vi.mocked(getContainer)(),
+      userRepository: {
+        findById: vi.fn(),
+        findByEmail: mockFindByEmail,
+        findByAuthSubject: mockFindByAuthSubject,
+        linkAuthSubject: vi.fn(),
+        save: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as Container);
+
+    const result = await resolveSessionUserId();
+
+    expect(result.isRight()).toBe(true);
+    expect(typeof result.value).toBe('string');
+  });
+
+  it('should return Right(userId) when user is already linked by authSubject', async () => {
+    const { Role, User } = await import('@repo/core/identity');
+    const userResult = User.create({
+      name: 'Admin',
+      email: 'admin@example.com',
+      role: Role.ADMIN,
+      authSubject: VALID_UUID,
+    });
+    if (userResult.isLeft()) throw userResult.value;
+    const user = userResult.value;
+
+    mockGetPrincipal.mockResolvedValue(right(PRINCIPAL));
+    mockFindByAuthSubject.mockResolvedValue(user);
+
+    const result = await resolveSessionUserId();
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toBe(user.id.value);
+  });
+});

--- a/packages/application/src/portfolio/use-cases/DeleteProject.ts
+++ b/packages/application/src/portfolio/use-cases/DeleteProject.ts
@@ -1,0 +1,64 @@
+import { UnauthorizedError } from '@repo/core/identity';
+import { IProjectRepository } from '@repo/core/portfolio';
+import {
+  DomainError,
+  Either,
+  Id,
+  NotFoundError,
+  ValidationError,
+  left,
+  right,
+} from '@repo/core/shared';
+
+import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { UseCase } from '../../shared/UseCase';
+
+export type DeleteProjectInput = {
+  userId: string;
+  projectId: string;
+};
+
+export class DeleteProject extends UseCase<
+  DeleteProjectInput,
+  void,
+  ValidationError | UnauthorizedError | NotFoundError | DomainError
+> {
+  constructor(
+    private readonly projectRepository: IProjectRepository,
+    private readonly ensureAdmin: EnsureAdmin,
+  ) {
+    super();
+  }
+
+  async execute(
+    input: DeleteProjectInput,
+  ): Promise<
+    Either<
+      ValidationError | UnauthorizedError | NotFoundError | DomainError,
+      void
+    >
+  > {
+    const adminCheck = await this.ensureAdmin.execute({ userId: input.userId });
+    if (adminCheck.isLeft()) return left(adminCheck.value);
+
+    const idResult = Id.create(input.projectId);
+    if (idResult.isLeft())
+      return left(
+        new ValidationError({
+          code: 'INVALID_PROJECT_ID',
+          message: idResult.value.message,
+        }),
+      );
+
+    try {
+      await this.projectRepository.delete(idResult.value);
+      return right(undefined);
+    } catch {
+      return left(
+        new DomainError('DELETE_FAILED', {
+          message: 'Failed to delete project',
+        }),
+      );
+    }
+  }
+}

--- a/packages/application/src/portfolio/use-cases/index.ts
+++ b/packages/application/src/portfolio/use-cases/index.ts
@@ -25,3 +25,4 @@ export {
   DeleteExperience,
   type DeleteExperienceInput,
 } from './DeleteExperience';
+export { DeleteProject, type DeleteProjectInput } from './DeleteProject';

--- a/packages/application/test/portfolio/use-cases/DeleteProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/DeleteProject.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  IUserRepository,
+  Role,
+  UnauthorizedError,
+  User,
+} from '@repo/core/identity';
+import { IProjectRepository } from '@repo/core/portfolio';
+import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+
+import { EnsureAdmin } from '~/identity/use-cases/EnsureAdmin';
+import { DeleteProject } from '~/portfolio/use-cases/DeleteProject';
+
+const ADMIN_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VISITOR_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d470';
+const PROJECT_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d471';
+
+function makeUser(role: Role): User {
+  const result = User.create({
+    name: 'Test User',
+    email: 'test@example.com',
+    role,
+  });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeUserRepo(user: User | null): IUserRepository {
+  return {
+    findById: vi.fn().mockResolvedValue(user),
+    findByEmail: vi.fn(),
+    findByAuthSubject: vi.fn(),
+    linkAuthSubject: vi.fn(),
+  };
+}
+
+function makeProjectRepo(
+  overrides: Partial<IProjectRepository> = {},
+): IProjectRepository {
+  return {
+    findAll: vi.fn(),
+    findById: vi.fn().mockResolvedValue(null),
+    findBySlug: vi.fn(),
+    findPublished: vi.fn(),
+    findFeatured: vi.fn(),
+    findRelated: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeUseCase(
+  user: User | null,
+  projectRepo?: Partial<IProjectRepository>,
+) {
+  const userRepo = makeUserRepo(user);
+  const ensureAdmin = new EnsureAdmin(userRepo);
+  const pRepo = makeProjectRepo(projectRepo);
+  return { useCase: new DeleteProject(pRepo, ensureAdmin), projectRepo: pRepo };
+}
+
+describe('DeleteProject', () => {
+  describe('when user is admin', () => {
+    it('should delete a project and return Right', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase, projectRepo } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(projectRepo.delete).toHaveBeenCalledOnce();
+    });
+
+    it('should return Left(ValidationError) when projectId is not a valid UUID', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: 'not-a-uuid',
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ValidationError);
+    });
+
+    it('should return Left(DomainError) when repository delete throws', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        delete: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+  });
+
+  describe('when user is not admin', () => {
+    it('should return Left(UnauthorizedError)', async () => {
+      const visitor = makeUser(Role.VISITOR);
+      const { useCase } = makeUseCase(visitor);
+
+      const result = await useCase.execute({
+        userId: VISITOR_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(UnauthorizedError);
+    });
+  });
+
+  describe('when user does not exist', () => {
+    it('should return Left(NotFoundError)', async () => {
+      const { useCase } = makeUseCase(null);
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectId: PROJECT_UUID,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `DeleteProject` use case to `@repo/application` (mirrors `DeleteExperience` pattern)
- Adds `resolveSessionUserId` helper (`apps/web/src/lib/auth/ensure-admin.ts`) to resolve DB user ID from session cookies — shared by all admin handlers
- Fixes `handleRequest` to return empty body for 204 No Content responses
- Implements all admin route handlers under `/api/v1/admin/*`:
  - `POST /api/v1/admin/projects` → `SaveProject` (201)
  - `PUT /api/v1/admin/projects/[id]` → `SaveProject` (200)
  - `DELETE /api/v1/admin/projects/[id]` → `DeleteProject` (204)
  - `POST /api/v1/admin/projects/[id]/publish` → `PublishProject`
  - `POST /api/v1/admin/projects/[id]/archive` → `ArchiveProject`
  - `POST /api/v1/admin/experiences` → `SaveExperience` (201)
  - `PUT /api/v1/admin/experiences/[id]` → `SaveExperience`
  - `DELETE /api/v1/admin/experiences/[id]` → `DeleteExperience` (204)
  - `PUT /api/v1/admin/profile` → `UpdateProfile`

## Test plan

- [x] `DeleteProject` unit tests (5 cases: happy path, invalid UUID, DB error, not-admin, user-not-found)
- [x] `resolveSessionUserId` unit tests (4 cases: no session, invalid token, new user, existing user)
- [x] `POST /api/v1/admin/projects` handler tests (4 cases: no session, not-admin, valid, invalid props)
- [x] `PUT /api/v1/admin/projects/[id]` and `DELETE` handler tests (5 cases total)
- [x] All 306 tests across application + web pass
- [x] TypeScript strict mode: no errors
- [x] Pre-commit hooks (format, lint, types, test) all green

Refs #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)