### PR TITLE
feat(ci): add github actions CI pipeline (T-36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '8.15.6'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm types:ci
+
+      - name: Lint
+        run: pnpm lint:check
+
+      - name: Test
+        run: pnpm test:ci


### PR DESCRIPTION
## Summary

- Creates `.github/workflows/ci.yml` triggered on PRs targeting `develop` and `master`
- Runs steps in order: **install → type check → lint → test** with fail-fast on first error
- Uses `pnpm types:ci` (excludes storybooks) and `pnpm test:ci` (excludes `@repo/infra` which requires a real DB connection)
- Caches pnpm store keyed on `pnpm-lock.yaml` hash for faster subsequent runs

## Test plan

- [x] `pnpm types:ci` passes locally (0 errors)
- [x] `pnpm lint:check` passes locally (0 errors, only warnings)
- [x] `pnpm test:ci` passes locally (156 tests across 35 files in `apps/web`, `packages/core`, `packages/application`, `packages/utils`)
- [ ] Verify CI triggers and goes green on this PR

Refs #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)