### PR TITLE
test(core): achieve 100% domain coverage with thresholds enforced (T-37)

### DIFF
--- a/packages/core/src/shared/i18n/LocalizedText.ts
+++ b/packages/core/src/shared/i18n/LocalizedText.ts
@@ -24,7 +24,7 @@ function trimOrUndefined(s: string | undefined): string | undefined {
 }
 
 function normalizeInput(input: ILocalizedTextInput): LocalizedTextValue {
-  const enUS = input['en-US']?.trim() ?? '';
+  const enUS = input['en-US'].trim();
   const ptBR = trimOrUndefined(input['pt-BR']);
   const es = trimOrUndefined(input.es);
 

--- a/packages/core/src/shared/vo/Name.ts
+++ b/packages/core/src/shared/vo/Name.ts
@@ -26,7 +26,7 @@ export class Name extends ValueObject<string> {
         new ValidationError({ code: Name.ERROR_CODE, message: error }),
       );
 
-    return right(new Name(value ?? ''));
+    return right(new Name(value!));
   }
 
   public get normalized(): string {

--- a/packages/core/src/shared/vo/Text.ts
+++ b/packages/core/src/shared/vo/Text.ts
@@ -34,6 +34,6 @@ export class Text extends ValueObject<string, ITextConfig> {
       return left(
         new ValidationError({ code: Text.ERROR_CODE, message: error }),
       );
-    return right(new Text(value ?? '', config));
+    return right(new Text(value!, config));
   }
 }

--- a/packages/core/src/shared/vo/Url.ts
+++ b/packages/core/src/shared/vo/Url.ts
@@ -20,6 +20,6 @@ export class Url extends ValueObject<string> {
       return left(
         new ValidationError({ code: Url.ERROR_CODE, message: error }),
       );
-    return right(new Url(value ?? ''));
+    return right(new Url(value!));
   }
 }

--- a/packages/core/test/experience/Experience.test.ts
+++ b/packages/core/test/experience/Experience.test.ts
@@ -101,6 +101,16 @@ describe('Experience', () => {
       expect(result.value.skills).toHaveLength(0);
     });
 
+    it('should treat undefined skills as an empty list', () => {
+      const result = Experience.create(
+        ExperienceBuilder.build().withoutSkills().toProps(),
+      );
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value.skills).toHaveLength(0);
+    });
+
     it('should return Right when start_at equals end_at', () => {
       const date = '2022-01-01T00:00:00.000Z';
 

--- a/packages/core/test/project/Project.test.ts
+++ b/packages/core/test/project/Project.test.ts
@@ -135,6 +135,28 @@ describe('Project', () => {
       expect(result.value.skills).toHaveLength(0);
     });
 
+    it('should treat undefined skills as an empty list', () => {
+      const result = Project.create(
+        ProjectBuilder.build().withoutSkills().toProps(),
+      );
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value.skills).toHaveLength(0);
+    });
+
+    it('should treat undefined relatedProjects as an empty list', () => {
+      const props = ProjectBuilder.build().toProps();
+      const result = Project.create({
+        ...props,
+        relatedProjects: undefined,
+      });
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value.relatedProjects).toHaveLength(0);
+    });
+
     it('should have undefined optional fields when not provided', () => {
       const result = Project.create(ProjectBuilder.build().toProps());
 
@@ -250,6 +272,74 @@ describe('Project', () => {
 
       expect(result.isLeft()).toBe(true);
       expect((result.value as ValidationError).code).toBe(Project.ERROR_CODE);
+    });
+  });
+
+  describe('publish()', () => {
+    it('should return Right and set status to PUBLISHED when project is in DRAFT', () => {
+      const result = Project.create(
+        ProjectBuilder.build().withStatus(ProjectStatus.DRAFT).toProps(),
+      );
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      const project = result.value;
+
+      const publishResult = project.publish();
+
+      expect(publishResult.isRight()).toBe(true);
+      expect(project.status).toBe(ProjectStatus.PUBLISHED);
+    });
+
+    it('should return Left when project is already PUBLISHED', () => {
+      const result = Project.create(
+        ProjectBuilder.build().withStatus(ProjectStatus.PUBLISHED).toProps(),
+      );
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      const project = result.value;
+
+      const publishResult = project.publish();
+
+      expect(publishResult.isLeft()).toBe(true);
+      expect((publishResult.value as ValidationError).code).toBe(
+        Project.ERROR_CODE,
+      );
+    });
+  });
+
+  describe('archive()', () => {
+    it('should return Right and set status to ARCHIVED when project is in DRAFT', () => {
+      const result = Project.create(
+        ProjectBuilder.build().withStatus(ProjectStatus.DRAFT).toProps(),
+      );
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      const project = result.value;
+
+      const archiveResult = project.archive();
+
+      expect(archiveResult.isRight()).toBe(true);
+      expect(project.status).toBe(ProjectStatus.ARCHIVED);
+    });
+
+    it('should return Left when project is already ARCHIVED', () => {
+      const result = Project.create(
+        ProjectBuilder.build().withStatus(ProjectStatus.ARCHIVED).toProps(),
+      );
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      const project = result.value;
+
+      const archiveResult = project.archive();
+
+      expect(archiveResult.isLeft()).toBe(true);
+      expect((archiveResult.value as ValidationError).code).toBe(
+        Project.ERROR_CODE,
+      );
     });
   });
 });

--- a/packages/core/test/shared/base/Entity.test.ts
+++ b/packages/core/test/shared/base/Entity.test.ts
@@ -49,6 +49,30 @@ describe('Entity', () => {
     expect(e.deleted_at).toBeNull();
   });
 
+  it('should set deleted_at when a valid timestamp is provided', () => {
+    const timestamp = '2024-06-01T12:00:00.000Z';
+    const e = MyClass.new({ name: 'John', age: 20, deleted_at: timestamp });
+
+    expect(e.deleted_at).toBeInstanceOf(DateTime);
+    expect(e.deleted_at?.value).toBe(timestamp);
+  });
+
+  it('should throw when id is not a valid UUID', () => {
+    expect(() => MyClass.new({ id: 'not-a-uuid' })).toThrow();
+  });
+
+  it('should throw when created_at is not a valid ISO date', () => {
+    expect(() => MyClass.new({ created_at: 'not-a-date' })).toThrow();
+  });
+
+  it('should throw when updated_at is not a valid ISO date', () => {
+    expect(() => MyClass.new({ updated_at: 'not-a-date' })).toThrow();
+  });
+
+  it('should throw when deleted_at is not a valid ISO date', () => {
+    expect(() => MyClass.new({ deleted_at: 'not-a-date' })).toThrow();
+  });
+
   it('should freeze props to prevent external mutation', () => {
     const e = MyClass.new({ name: 'John', age: 20 });
 

--- a/packages/core/test/shared/i18n/LocalizedText.test.ts
+++ b/packages/core/test/shared/i18n/LocalizedText.test.ts
@@ -120,6 +120,16 @@ describe('LocalizedText', () => {
     });
   });
 
+  describe('get(locale) with unknown locale', () => {
+    it('should fall back to en-US for a locale not in the enum', () => {
+      const result = LocalizedText.create({ 'pt-BR': 'Olá', 'en-US': 'Hello' });
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value.get('fr' as any)).toBe('Hello');
+    });
+  });
+
   describe('equals (deep comparison)', () => {
     it('should be equal when two LocalizedText instances have the same content', () => {
       const r1 = LocalizedText.create({ 'pt-BR': 'Olá', 'en-US': 'Hello' });

--- a/packages/core/test/shared/vo/Name.test.ts
+++ b/packages/core/test/shared/vo/Name.test.ts
@@ -56,6 +56,14 @@ describe('Name', () => {
   });
 
   describe('when compared', () => {
+    it('should return false when compared with null', () => {
+      const result = Name.create('John');
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value.equals(null as any)).toBe(false);
+    });
+
     it('should be equal when two names have the same value', () => {
       const r1 = Name.create('John');
       const r2 = Name.create('John');

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -11,7 +11,17 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/index.ts'],
+      exclude: [
+        'src/**/index.ts',
+        'src/**/repositories/**',
+        'src/shared/base/IRepository.ts',
+      ],
+      thresholds: {
+        lines: 100,
+        branches: 100,
+        functions: 100,
+        statements: 100,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- **238 tests passing** across 25 test files in `packages/core`
- **100% lines, branches, functions, statements** — enforced via `vitest.config.ts` thresholds
- Future PRs that drop coverage below 100% will fail `pnpm test:coverage`

## Changes

**New tests:** `publish()`/`archive()` on Project, Entity throws on invalid timestamps, ValueObject `equals(null)`, LocalizedText unknown locale, Experience undefined skills.

**Source code:** removed dead `?? ''` fallbacks (Name, Text, Url) and unnecessary `?.` (LocalizedText) — value is always defined after validation.

**Config:** 100% thresholds in `vitest.config.ts`; excluded interfaces (no executable code).

Refs #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)