### PR TITLE
feat(design-system): épico 4 — refactor pages to use self-fetching feature sections

### DIFF
--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -1,27 +1,7 @@
-import { getLocale, getTranslations } from 'next-intl/server';
-
-import { Divider } from '@repo/ui/View';
-
-import { HeroBanner } from '~features/shared/HeroBanner';
-import {
-  ExperienceCard,
-  IExperienceCardProps,
-} from '~features/about/ExperiencesSection';
-import {
-  ProfessionalValue,
-  IProfessionalValueCardProps,
-} from '~features/about/ValuesSection';
-import HeroAbout from '~assets/images/hero-about.png';
 import { applyDevSimulations } from '~/dev/simulate';
-import { ApiResponse } from '~/lib/api/envelope';
-import { getInternalBaseUrl } from '~/lib/api/internal';
-
-interface ProfileHero {
-  name: string;
-  headline: string;
-  bio: string;
-  photo: { url: string; alt: string };
-}
+import { HeroSection } from '~features/about/HeroSection';
+import { ValuesSection } from '~features/about/ValuesSection';
+import { ExperiencesSection } from '~features/about/ExperiencesSection';
 
 interface AboutPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
@@ -30,75 +10,11 @@ interface AboutPageProps {
 export default async function About({ searchParams }: AboutPageProps) {
   await applyDevSimulations(await searchParams);
 
-  const [t, locale, baseUrl] = await Promise.all([
-    getTranslations('About'),
-    getLocale(),
-    getInternalBaseUrl(),
-  ]);
-
-  const [experiencesRes, professionalValuesRes, profileRes] = await Promise.all(
-    [
-      fetch(`${baseUrl}/api/v1/experiences?locale=${locale}`, {
-        cache: 'no-store',
-      }).catch(() => null),
-      fetch(`${baseUrl}/api/v1/professional-values?locale=${locale}`, {
-        cache: 'no-store',
-      }).catch(() => null),
-      fetch(`${baseUrl}/api/v1/profile?locale=${locale}`, {
-        cache: 'no-store',
-      }).catch(() => null),
-    ],
-  );
-
-  let experiences: IExperienceCardProps[] = [];
-  if (experiencesRes?.ok) {
-    const body: ApiResponse<IExperienceCardProps[]> =
-      await experiencesRes.json();
-    if (!body.error) experiences = body.data;
-  }
-
-  let professionalValues: IProfessionalValueCardProps[] = [];
-  if (professionalValuesRes?.ok) {
-    const body: ApiResponse<IProfessionalValueCardProps[]> =
-      await professionalValuesRes.json();
-    if (!body.error) professionalValues = body.data;
-  }
-
-  let profile: ProfileHero | null = null;
-  if (profileRes?.ok) {
-    const body: ApiResponse<ProfileHero> = await profileRes.json();
-    if (!body.error) profile = body.data;
-  }
-
   return (
     <>
-      <HeroBanner
-        src={HeroAbout}
-        title={profile?.name ?? t('hero_title')}
-        caption={profile?.headline ?? t('hero_caption')}
-        content={profile?.bio ?? t('hero_content')}
-        alt={t('hero_image_alt')}
-        imageClassName="object-contain"
-      />
-      <h4 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
-        {t('values_title')}
-      </h4>
-      <ul className="flex flex-row gap-x-4">
-        {professionalValues.map((professionalValue) => (
-          <li key={professionalValue.id}>
-            <ProfessionalValue {...professionalValue} />
-          </li>
-        ))}
-      </ul>
-      <Divider className="mx-4" />
-      <ul className="flex flex-col mx-4 gap-y-3 xl:gap-y-0">
-        {experiences.map((experience) => (
-          <li key={experience.id} className="[&:last-of-type>hr]:hidden">
-            <ExperienceCard {...experience} />
-            <Divider className="hidden xl:block" />
-          </li>
-        ))}
-      </ul>
+      <HeroSection />
+      <ValuesSection />
+      <ExperiencesSection />
     </>
   );
 }

--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -1,7 +1,7 @@
 import { applyDevSimulations } from '~/dev/simulate';
+import { ExperiencesSection } from '~features/about/ExperiencesSection';
 import { HeroSection } from '~features/about/HeroSection';
 import { ValuesSection } from '~features/about/ValuesSection';
-import { ExperiencesSection } from '~features/about/ExperiencesSection';
 
 interface AboutPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,28 +1,7 @@
-import { Divider } from '@repo/ui/View';
-import { getLocale, getTranslations } from 'next-intl/server';
-
 import { applyDevSimulations } from '~/dev/simulate';
-import { getInternalBaseUrl } from '~/lib/api/internal';
-import { ApiResponse } from '~/lib/api/envelope';
 import { HeroSection } from '~features/home/HeroSection';
-import { ProjectList, ProjectSummary } from '~features/home/ProjectsSection';
-import { ContactForm } from '~features/contact/ContactForm';
-import { ContactInfo } from '~features/contact/ContactInfo';
-import { StatCard } from '~features/shared/StatCard';
-
-interface ProfileStat {
-  label: string;
-  value: string;
-  icon: string;
-}
-
-interface ProfileHero {
-  name: string;
-  headline: string;
-  bio: string;
-  photo: { url: string; alt: string };
-  stats: ProfileStat[];
-}
+import { ProjectsSection } from '~features/home/ProjectsSection';
+import { ContactSection } from '~features/contact/ContactSection';
 
 interface HomePageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
@@ -31,63 +10,11 @@ interface HomePageProps {
 export default async function Home({ searchParams }: HomePageProps) {
   await applyDevSimulations(await searchParams);
 
-  const [t, locale, baseUrl] = await Promise.all([
-    getTranslations('Home'),
-    getLocale(),
-    getInternalBaseUrl(),
-  ]);
-
-  const [projectsRes, profileRes] = await Promise.all([
-    fetch(`${baseUrl}/api/v1/projects/featured?locale=${locale}`, {
-      cache: 'no-store',
-    }).catch(() => null),
-    fetch(`${baseUrl}/api/v1/profile?locale=${locale}`, {
-      cache: 'no-store',
-    }).catch(() => null),
-  ]);
-
-  let projects: ProjectSummary[] = [];
-  if (projectsRes?.ok) {
-    const body: ApiResponse<ProjectSummary[]> = await projectsRes.json();
-    if (!body.error) projects = body.data;
-  }
-
-  let profile: ProfileHero | null = null;
-  if (profileRes?.ok) {
-    const body: ApiResponse<ProfileHero> = await profileRes.json();
-    if (!body.error) profile = body.data;
-  }
-
   return (
     <>
-      <HeroSection
-        profile={profile}
-        title={t('hero_title')}
-        caption={t('hero_caption')}
-        content={t('hero_content')}
-        alt={t('hero_image_alt')}
-      />
-      {profile?.stats && profile.stats.length > 0 && (
-        <section className="mx-4 my-6 grid grid-cols-2 gap-3 xl:mx-auto xl:my-8 xl:w-full xl:max-w-237.5 xl:grid-cols-4">
-          {profile.stats.map((stat) => (
-            <StatCard
-              key={stat.label}
-              label={stat.label}
-              value={stat.value}
-              icon={stat.icon}
-            />
-          ))}
-        </section>
-      )}
-      <h4 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
-        {t('projects_title')}
-      </h4>
-      <ProjectList projects={projects} view="grid" className="pb-8 xl:pb-20" />
-      <section className="flex flex-col gap-x-6 xl:flex-row mx-4 xl:mx-auto xl:w-full xl:max-w-237.5">
-        <ContactForm />
-        <Divider className="xl:hidden" />
-        <ContactInfo />
-      </section>
+      <HeroSection />
+      <ProjectsSection />
+      <ContactSection />
     </>
   );
 }

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import { applyDevSimulations } from '~/dev/simulate';
+import { ContactSection } from '~features/contact/ContactSection';
 import { HeroSection } from '~features/home/HeroSection';
 import { ProjectsSection } from '~features/home/ProjectsSection';
-import { ContactSection } from '~features/contact/ContactSection';
 
 interface HomePageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;

--- a/apps/web/src/app/[locale]/projects/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/projects/[slug]/page.tsx
@@ -1,12 +1,12 @@
 import { getLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
 import {
   ProjectDetail,
   IProjectDetailProps,
 } from '~features/projects/ProjectDetail';
-import { ApiResponse } from '~/lib/api/envelope';
-import { getInternalBaseUrl } from '~/lib/api/internal';
 
 type ProjectDetailData = IProjectDetailProps & { id: string };
 

--- a/apps/web/src/app/[locale]/projects/page.tsx
+++ b/apps/web/src/app/[locale]/projects/page.tsx
@@ -1,10 +1,6 @@
-import { getLocale, getTranslations } from 'next-intl/server';
-
-import { HeroSection } from '~features/projects/HeroSection';
-import { ProjectList, ProjectSummary } from '~features/home/ProjectsSection';
 import { applyDevSimulations } from '~/dev/simulate';
-import { ApiResponse } from '~/lib/api/envelope';
-import { getInternalBaseUrl } from '~/lib/api/internal';
+import { HeroSection } from '~features/projects/HeroSection';
+import { ProjectsSection } from '~features/projects/ProjectsSection';
 
 interface ProjectsPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
@@ -13,32 +9,10 @@ interface ProjectsPageProps {
 export default async function Projects({ searchParams }: ProjectsPageProps) {
   await applyDevSimulations(await searchParams);
 
-  const [t, locale, baseUrl] = await Promise.all([
-    getTranslations('Projects'),
-    getLocale(),
-    getInternalBaseUrl(),
-  ]);
-
-  const projectsRes = await fetch(
-    `${baseUrl}/api/v1/projects?locale=${locale}`,
-    { cache: 'no-store' },
-  ).catch(() => null);
-
-  let projects: ProjectSummary[] = [];
-  if (projectsRes?.ok) {
-    const body: ApiResponse<ProjectSummary[]> = await projectsRes.json();
-    if (!body.error) projects = body.data;
-  }
-
   return (
     <>
-      <HeroSection
-        title={t('hero_title')}
-        caption={t('hero_caption')}
-        content={t('hero_content')}
-        alt={t('hero_image_alt')}
-      />
-      <ProjectList projects={projects} view="grid" className="py-8 xl:py-20" />
+      <HeroSection />
+      <ProjectsSection />
     </>
   );
 }

--- a/apps/web/src/app/api/v1/experiences/route.ts
+++ b/apps/web/src/app/api/v1/experiences/route.ts
@@ -8,7 +8,9 @@ import { resolveLocale } from '~/lib/api/locale';
 export async function GET(request: NextRequest) {
   return handleRequest(() => {
     const locale = resolveLocale(request);
-    const { experienceRepository } = getContainer();
-    return new GetExperiences(experienceRepository).execute({ locale });
+    const { experienceRepository, skillRepository } = getContainer();
+    return new GetExperiences(experienceRepository, skillRepository).execute({
+      locale,
+    });
   });
 }

--- a/apps/web/src/app/api/v1/projects/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[slug]/route.ts
@@ -13,7 +13,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const { slug } = await params;
   return handleRequest(() => {
     const locale = resolveLocale(request);
-    const { projectRepository } = getContainer();
-    return new GetProjectBySlug(projectRepository).execute({ slug, locale });
+    const { projectRepository, skillRepository } = getContainer();
+    return new GetProjectBySlug(projectRepository, skillRepository).execute({
+      slug,
+      locale,
+    });
   });
 }

--- a/apps/web/src/app/api/v1/projects/featured/route.ts
+++ b/apps/web/src/app/api/v1/projects/featured/route.ts
@@ -8,7 +8,9 @@ import { resolveLocale } from '~/lib/api/locale';
 export async function GET(request: NextRequest) {
   return handleRequest(() => {
     const locale = resolveLocale(request);
-    const { projectRepository } = getContainer();
-    return new GetFeaturedProjects(projectRepository).execute({ locale });
+    const { projectRepository, skillRepository } = getContainer();
+    return new GetFeaturedProjects(projectRepository, skillRepository).execute({
+      locale,
+    });
   });
 }

--- a/apps/web/src/app/api/v1/projects/route.ts
+++ b/apps/web/src/app/api/v1/projects/route.ts
@@ -8,7 +8,9 @@ import { resolveLocale } from '~/lib/api/locale';
 export async function GET(request: NextRequest) {
   return handleRequest(() => {
     const locale = resolveLocale(request);
-    const { projectRepository } = getContainer();
-    return new GetPublishedProjects(projectRepository).execute({ locale });
+    const { projectRepository, skillRepository } = getContainer();
+    return new GetPublishedProjects(projectRepository, skillRepository).execute(
+      { locale },
+    );
   });
 }

--- a/apps/web/src/components/Layout/AppLayout/index.tsx
+++ b/apps/web/src/components/Layout/AppLayout/index.tsx
@@ -5,11 +5,12 @@ import { FC, useMemo, PropsWithChildren } from 'react';
 import classNames from 'classnames';
 import { useBoolean, useEventListener } from 'usehooks-ts';
 
-import { Header } from '../Header';
-import { SideNavigation } from '../SideNavigation';
 import { LayoutProvider } from '~contexts';
 import { useThrottle, useBodyClass } from '~hooks';
 import { BREAKPOINTS_NUMBERS } from '~utils';
+
+import { Header } from '../Header';
+import { SideNavigation } from '../SideNavigation';
 
 export const AppLayout: FC<PropsWithChildren> = ({ children }) => {
   const { value: open, setFalse: close, toggle } = useBoolean(false);

--- a/apps/web/src/features/about/ExperiencesSection/ExperiencesSection.tsx
+++ b/apps/web/src/features/about/ExperiencesSection/ExperiencesSection.tsx
@@ -1,0 +1,36 @@
+import { getLocale } from 'next-intl/server';
+
+import { Divider } from '@repo/ui/View';
+
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
+
+import { ExperienceCard, IExperienceCardProps } from './ExperienceCard';
+
+export async function ExperiencesSection() {
+  const [locale, baseUrl] = await Promise.all([
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const res = await fetch(`${baseUrl}/api/v1/experiences?locale=${locale}`, {
+    cache: 'no-store',
+  }).catch(() => null);
+
+  let experiences: IExperienceCardProps[] = [];
+  if (res?.ok) {
+    const body: ApiResponse<IExperienceCardProps[]> = await res.json();
+    if (!body.error) experiences = body.data;
+  }
+
+  return (
+    <ul className="flex flex-col mx-4 gap-y-3 xl:gap-y-0">
+      {experiences.map((experience) => (
+        <li key={experience.id} className="[&:last-of-type>hr]:hidden">
+          <ExperienceCard {...experience} />
+          <Divider className="hidden xl:block" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/features/about/ExperiencesSection/ExperiencesSection.tsx
+++ b/apps/web/src/features/about/ExperiencesSection/ExperiencesSection.tsx
@@ -1,6 +1,5 @@
-import { getLocale } from 'next-intl/server';
-
 import { Divider } from '@repo/ui/View';
+import { getLocale } from 'next-intl/server';
 
 import { ApiResponse } from '~/lib/api/envelope';
 import { getInternalBaseUrl } from '~/lib/api/internal';

--- a/apps/web/src/features/about/ExperiencesSection/index.ts
+++ b/apps/web/src/features/about/ExperiencesSection/index.ts
@@ -1,1 +1,2 @@
 export * from './ExperienceCard';
+export { ExperiencesSection } from './ExperiencesSection';

--- a/apps/web/src/features/about/HeroSection/index.tsx
+++ b/apps/web/src/features/about/HeroSection/index.tsx
@@ -1,0 +1,42 @@
+import { getLocale, getTranslations } from 'next-intl/server';
+
+import HeroAbout from '~assets/images/hero-about.png';
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
+import { HeroBanner } from '~features/shared/HeroBanner';
+
+interface ProfileHero {
+  name: string;
+  headline: string;
+  bio: string;
+  photo: { url: string; alt: string };
+}
+
+export async function HeroSection() {
+  const [t, locale, baseUrl] = await Promise.all([
+    getTranslations('About'),
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const profileRes = await fetch(`${baseUrl}/api/v1/profile?locale=${locale}`, {
+    cache: 'no-store',
+  }).catch(() => null);
+
+  let profile: ProfileHero | null = null;
+  if (profileRes?.ok) {
+    const body: ApiResponse<ProfileHero> = await profileRes.json();
+    if (!body.error) profile = body.data;
+  }
+
+  return (
+    <HeroBanner
+      src={HeroAbout}
+      title={profile?.name ?? t('hero_title')}
+      caption={profile?.headline ?? t('hero_caption')}
+      content={profile?.bio ?? t('hero_content')}
+      alt={t('hero_image_alt')}
+      imageClassName="object-contain"
+    />
+  );
+}

--- a/apps/web/src/features/about/HeroSection/index.tsx
+++ b/apps/web/src/features/about/HeroSection/index.tsx
@@ -1,8 +1,8 @@
 import { getLocale, getTranslations } from 'next-intl/server';
 
-import HeroAbout from '~assets/images/hero-about.png';
 import { ApiResponse } from '~/lib/api/envelope';
 import { getInternalBaseUrl } from '~/lib/api/internal';
+import HeroAbout from '~assets/images/hero-about.png';
 import { HeroBanner } from '~features/shared/HeroBanner';
 
 interface ProfileHero {

--- a/apps/web/src/features/about/ValuesSection/ValuesSection.tsx
+++ b/apps/web/src/features/about/ValuesSection/ValuesSection.tsx
@@ -1,6 +1,5 @@
-import { getLocale, getTranslations } from 'next-intl/server';
-
 import { Divider } from '@repo/ui/View';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { ApiResponse } from '~/lib/api/envelope';
 import { getInternalBaseUrl } from '~/lib/api/internal';

--- a/apps/web/src/features/about/ValuesSection/ValuesSection.tsx
+++ b/apps/web/src/features/about/ValuesSection/ValuesSection.tsx
@@ -1,0 +1,46 @@
+import { getLocale, getTranslations } from 'next-intl/server';
+
+import { Divider } from '@repo/ui/View';
+
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
+
+import {
+  IProfessionalValueCardProps,
+  ProfessionalValue,
+} from './ProfessionalValue';
+
+export async function ValuesSection() {
+  const [t, locale, baseUrl] = await Promise.all([
+    getTranslations('About'),
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const res = await fetch(
+    `${baseUrl}/api/v1/professional-values?locale=${locale}`,
+    { cache: 'no-store' },
+  ).catch(() => null);
+
+  let professionalValues: IProfessionalValueCardProps[] = [];
+  if (res?.ok) {
+    const body: ApiResponse<IProfessionalValueCardProps[]> = await res.json();
+    if (!body.error) professionalValues = body.data;
+  }
+
+  return (
+    <>
+      <h4 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
+        {t('values_title')}
+      </h4>
+      <ul className="flex flex-row gap-x-4">
+        {professionalValues.map((professionalValue) => (
+          <li key={professionalValue.id}>
+            <ProfessionalValue {...professionalValue} />
+          </li>
+        ))}
+      </ul>
+      <Divider className="mx-4" />
+    </>
+  );
+}

--- a/apps/web/src/features/about/ValuesSection/index.ts
+++ b/apps/web/src/features/about/ValuesSection/index.ts
@@ -1,1 +1,2 @@
 export * from './ProfessionalValue';
+export { ValuesSection } from './ValuesSection';

--- a/apps/web/src/features/contact/ContactInfo/index.tsx
+++ b/apps/web/src/features/contact/ContactInfo/index.tsx
@@ -7,8 +7,8 @@ import { Divider } from '@repo/ui/View';
 import { formatCellphone } from '@repo/utils';
 import { useTranslations } from 'next-intl';
 
-import { Link } from '~i18n/routing';
 import { MenuItem } from '~components/Layout/MenuItem';
+import { Link } from '~i18n/routing';
 
 export const ContactInfo: FC = () => {
   const t = useTranslations('ContactInfo');

--- a/apps/web/src/features/contact/ContactSection/index.tsx
+++ b/apps/web/src/features/contact/ContactSection/index.tsx
@@ -1,0 +1,14 @@
+import { Divider } from '@repo/ui/View';
+
+import { ContactForm } from '~features/contact/ContactForm';
+import { ContactInfo } from '~features/contact/ContactInfo';
+
+export function ContactSection() {
+  return (
+    <section className="flex flex-col gap-x-6 xl:flex-row mx-4 xl:mx-auto xl:w-full xl:max-w-237.5">
+      <ContactForm />
+      <Divider className="xl:hidden" />
+      <ContactInfo />
+    </section>
+  );
+}

--- a/apps/web/src/features/home/HeroSection/index.tsx
+++ b/apps/web/src/features/home/HeroSection/index.tsx
@@ -1,10 +1,10 @@
 import { getLocale, getTranslations } from 'next-intl/server';
 
-import HeroLandingPage from '~assets/images/hero-landing-page.png';
 import { ApiResponse } from '~/lib/api/envelope';
 import { getInternalBaseUrl } from '~/lib/api/internal';
-import { StatCard } from '~features/shared/StatCard';
+import HeroLandingPage from '~assets/images/hero-landing-page.png';
 import { HeroBanner } from '~features/shared/HeroBanner';
+import { StatCard } from '~features/shared/StatCard';
 
 interface ProfileStat {
   label: string;

--- a/apps/web/src/features/home/HeroSection/index.tsx
+++ b/apps/web/src/features/home/HeroSection/index.tsx
@@ -1,43 +1,59 @@
-import { FC } from 'react';
-
-import { StaticImageData } from 'next/image';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import HeroLandingPage from '~assets/images/hero-landing-page.png';
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
+import { StatCard } from '~features/shared/StatCard';
 import { HeroBanner } from '~features/shared/HeroBanner';
 
-interface ProfilePhoto {
-  url: string;
-  alt: string;
+interface ProfileStat {
+  label: string;
+  value: string;
+  icon: string;
 }
 
-interface IHeroSectionProps {
-  profile?: {
-    name: string;
-    headline: string;
-    bio: string;
-    photo: ProfilePhoto;
-  } | null;
-  title: string;
-  caption: string;
-  content: string;
-  alt: string;
-  fallbackSrc?: StaticImageData;
+interface ProfileHero {
+  name: string;
+  headline: string;
+  bio: string;
+  photo: { url: string; alt: string };
+  stats: ProfileStat[];
 }
 
-export const HeroSection: FC<IHeroSectionProps> = ({
-  profile,
-  title,
-  caption,
-  content,
-  alt,
-  fallbackSrc = HeroLandingPage,
-}) => (
-  <HeroBanner
-    src={profile?.photo.url ?? fallbackSrc}
-    title={profile?.name ?? title}
-    caption={profile?.headline ?? caption}
-    content={profile?.bio ?? content}
-    alt={profile?.photo.alt ?? alt}
-    imageClassName="object-contain 2xl:object-cover"
-  />
-);
+export async function HeroSection() {
+  const [t, locale, baseUrl] = await Promise.all([
+    getTranslations('Home'),
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const profileRes = await fetch(`${baseUrl}/api/v1/profile?locale=${locale}`, {
+    cache: 'no-store',
+  }).catch(() => null);
+
+  let profile: ProfileHero | null = null;
+  if (profileRes?.ok) {
+    const body: ApiResponse<ProfileHero> = await profileRes.json();
+    if (!body.error) profile = body.data;
+  }
+
+  return (
+    <>
+      <HeroBanner
+        src={profile?.photo.url ?? HeroLandingPage}
+        title={profile?.name ?? t('hero_title')}
+        caption={profile?.headline ?? t('hero_caption')}
+        content={profile?.bio ?? t('hero_content')}
+        alt={profile?.photo.alt ?? t('hero_image_alt')}
+        imageClassName="object-contain 2xl:object-cover"
+      />
+      {profile?.stats && profile.stats.length > 0 && (
+        <section className="mx-4 my-6 grid grid-cols-2 gap-3 xl:mx-auto xl:my-8 xl:w-full xl:max-w-237.5 xl:grid-cols-4">
+          {profile.stats.map((stat) => (
+            <StatCard key={stat.label} {...stat} />
+          ))}
+        </section>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/web/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -1,0 +1,34 @@
+import { getLocale, getTranslations } from 'next-intl/server';
+
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
+
+import { ProjectList, ProjectSummary } from './ProjectList';
+
+export async function ProjectsSection() {
+  const [t, locale, baseUrl] = await Promise.all([
+    getTranslations('Home'),
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const projectsRes = await fetch(
+    `${baseUrl}/api/v1/projects/featured?locale=${locale}`,
+    { cache: 'no-store' },
+  ).catch(() => null);
+
+  let projects: ProjectSummary[] = [];
+  if (projectsRes?.ok) {
+    const body: ApiResponse<ProjectSummary[]> = await projectsRes.json();
+    if (!body.error) projects = body.data;
+  }
+
+  return (
+    <>
+      <h4 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
+        {t('projects_title')}
+      </h4>
+      <ProjectList projects={projects} view="grid" className="pb-8 xl:pb-20" />
+    </>
+  );
+}

--- a/apps/web/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/web/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -7,9 +7,9 @@ import classNames from 'classnames';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
-import { Link } from '~i18n/routing';
-import { useBreakpoint } from '~hooks';
 import { SkillGroup } from '~features/shared/SkillGroup';
+import { useBreakpoint } from '~hooks';
+import { Link } from '~i18n/routing';
 
 export interface IProjectCardProps {
   view: 'grid' | 'row';

--- a/apps/web/src/features/home/ProjectsSection/index.ts
+++ b/apps/web/src/features/home/ProjectsSection/index.ts
@@ -1,2 +1,3 @@
 export * from './ProjectCard';
 export * from './ProjectList';
+export { ProjectsSection } from './HomeProjectsSection';

--- a/apps/web/src/features/projects/HeroSection/index.tsx
+++ b/apps/web/src/features/projects/HeroSection/index.tsx
@@ -1,19 +1,19 @@
-import { FC } from 'react';
+import { getTranslations } from 'next-intl/server';
 
 import HeroProjects from '~assets/images/hero-projects.png';
 import { HeroBanner } from '~features/shared/HeroBanner';
 
-interface IHeroSectionProps {
-  title: string;
-  caption: string;
-  content: string;
-  alt: string;
-}
+export async function HeroSection() {
+  const t = await getTranslations('Projects');
 
-export const HeroSection: FC<IHeroSectionProps> = (props) => (
-  <HeroBanner
-    {...props}
-    src={HeroProjects}
-    imageClassName="object-contain p-6 xl:py-8"
-  />
-);
+  return (
+    <HeroBanner
+      src={HeroProjects}
+      title={t('hero_title')}
+      caption={t('hero_caption')}
+      content={t('hero_content')}
+      alt={t('hero_image_alt')}
+      imageClassName="object-contain p-6 xl:py-8"
+    />
+  );
+}

--- a/apps/web/src/features/projects/ProjectsSection/index.tsx
+++ b/apps/web/src/features/projects/ProjectsSection/index.tsx
@@ -1,0 +1,26 @@
+import { getLocale } from 'next-intl/server';
+
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
+import { ProjectList, ProjectSummary } from '~features/home/ProjectsSection';
+
+export async function ProjectsSection() {
+  const [locale, baseUrl] = await Promise.all([
+    getLocale(),
+    getInternalBaseUrl(),
+  ]);
+
+  const res = await fetch(`${baseUrl}/api/v1/projects?locale=${locale}`, {
+    cache: 'no-store',
+  }).catch(() => null);
+
+  let projects: ProjectSummary[] = [];
+  if (res?.ok) {
+    const body: ApiResponse<ProjectSummary[]> = await res.json();
+    if (!body.error) projects = body.data;
+  }
+
+  return (
+    <ProjectList projects={projects} view="grid" className="py-8 xl:py-20" />
+  );
+}

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -1,5 +1,5 @@
-import { Redis } from '@upstash/redis';
 import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
 
 let ratelimit: Ratelimit | null = null;
 

--- a/apps/web/tests/app/[locale]/about.test.tsx
+++ b/apps/web/tests/app/[locale]/about.test.tsx
@@ -5,184 +5,29 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 
-vi.mock('next/headers', () => ({
-  headers: vi.fn().mockResolvedValue({ get: () => 'localhost:3000' }),
-}));
-
-vi.mock('next-intl/server', () => ({
-  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
-  getLocale: vi.fn().mockResolvedValue('en-US'),
-}));
-
 vi.mock('~/dev/simulate', () => ({
   applyDevSimulations: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('~/lib/api/internal', () => ({
-  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
-}));
-
-vi.mock('@repo/ui/View', () => ({
-  Divider: () => <hr />,
-}));
-
-vi.mock('~features/shared/HeroBanner', () => ({
-  HeroBanner: ({ title }: { title: string }) => (
-    <div data-testid="hero-banner">{title}</div>
-  ),
+vi.mock('~features/about/HeroSection', () => ({
+  HeroSection: () => <div data-testid="hero-section" />,
 }));
 
 vi.mock('~features/about/ValuesSection', () => ({
-  ProfessionalValue: ({ content }: { content: string }) => (
-    <div data-testid="professional-value">{content}</div>
-  ),
+  ValuesSection: () => <div data-testid="values-section" />,
 }));
 
 vi.mock('~features/about/ExperiencesSection', () => ({
-  ExperienceCard: ({
-    company,
-    position,
-  }: {
-    company: string;
-    position: string;
-  }) => (
-    <div data-testid="experience-card">
-      <span>{position}</span>
-      <span>{company}</span>
-    </div>
-  ),
+  ExperiencesSection: () => <div data-testid="experiences-section" />,
 }));
 
-const mockFetch = vi.fn();
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  global.fetch = mockFetch;
-});
-
-const EXPERIENCES = [
-  {
-    id: '1',
-    company: 'Acme Corp',
-    position: 'Senior Developer',
-    location: 'São Paulo, Brazil',
-    employmentType: 'FULL_TIME',
-    locationType: 'REMOTE',
-    startAt: '2023-01-01T00:00:00.000Z',
-    skills: [],
-  },
-  {
-    id: '2',
-    company: 'Beta Inc',
-    position: 'Tech Lead',
-    location: 'Remote',
-    employmentType: 'FULL_TIME',
-    locationType: 'REMOTE',
-    startAt: '2024-01-01T00:00:00.000Z',
-    skills: [],
-  },
-];
-
-const PROFESSIONAL_VALUES = [
-  {
-    id: '1',
-    icon: 'material-symbols:diamond',
-    content: 'High quality delivery',
-  },
-];
-
-function okResponse(data: unknown[]) {
-  return Promise.resolve({
-    ok: true,
-    json: async () => ({ data, error: null }),
-  });
-}
-
-function errorResponse() {
-  return Promise.resolve({
-    ok: false,
-    json: async () => ({
-      data: null,
-      error: { code: 'INTERNAL_ERROR', message: '' },
-    }),
-  });
-}
-
-const PROFILE = {
-  name: 'Wallace Ferreira',
-  headline: 'Frontend Engineer',
-  bio: 'Bio text.',
-  photo: { url: 'https://example.com/photo.jpg', alt: 'Profile photo' },
-};
-
-function mockApis({
-  experiences = [] as unknown[] | null,
-  professionalValues = [] as unknown[] | null,
-  fail = false,
-} = {}) {
-  if (fail) {
-    mockFetch.mockRejectedValue(new Error('Network error'));
-    return;
-  }
-  mockFetch.mockImplementation((url: string) => {
-    if (url.includes('/api/v1/professional-values'))
-      return professionalValues === null
-        ? errorResponse()
-        : okResponse(professionalValues);
-    if (url.includes('/api/v1/experiences'))
-      return experiences === null ? errorResponse() : okResponse(experiences);
-    if (url.includes('/api/v1/profile'))
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ data: PROFILE, error: null }),
-      });
-    return errorResponse();
-  });
-}
-
 describe('About page', () => {
-  it('should render values title from i18n', async () => {
-    mockApis();
+  it('should render all feature sections', async () => {
     const { default: About } = await import('~/app/[locale]/about/page');
     render(await About({ searchParams: Promise.resolve({}) }));
-    expect(screen.getByText('t.values_title')).toBeInTheDocument();
-  });
 
-  it('should render professional values from API response', async () => {
-    mockApis({ professionalValues: PROFESSIONAL_VALUES });
-    const { default: About } = await import('~/app/[locale]/about/page');
-    render(await About({ searchParams: Promise.resolve({}) }));
-    expect(screen.getAllByTestId('professional-value').length).toBeGreaterThan(
-      0,
-    );
-  });
-
-  it('should render no professional values when API returns empty', async () => {
-    mockApis({ professionalValues: [] });
-    const { default: About } = await import('~/app/[locale]/about/page');
-    render(await About({ searchParams: Promise.resolve({}) }));
-    expect(screen.queryByTestId('professional-value')).not.toBeInTheDocument();
-  });
-
-  it('should render experience cards from API response', async () => {
-    mockApis({ experiences: EXPERIENCES });
-    const { default: About } = await import('~/app/[locale]/about/page');
-    render(await About({ searchParams: Promise.resolve({}) }));
-    expect(screen.getByText('Senior Developer')).toBeInTheDocument();
-    expect(screen.getByText('Tech Lead')).toBeInTheDocument();
-  });
-
-  it('should render no experience cards when API fails', async () => {
-    mockApis({ experiences: null });
-    const { default: About } = await import('~/app/[locale]/about/page');
-    render(await About({ searchParams: Promise.resolve({}) }));
-    expect(screen.queryByTestId('experience-card')).not.toBeInTheDocument();
-  });
-
-  it('should render no experience cards when fetch throws', async () => {
-    mockApis({ fail: true });
-    const { default: About } = await import('~/app/[locale]/about/page');
-    render(await About({ searchParams: Promise.resolve({}) }));
-    expect(screen.queryByTestId('experience-card')).not.toBeInTheDocument();
+    expect(screen.getByTestId('hero-section')).toBeInTheDocument();
+    expect(screen.getByTestId('values-section')).toBeInTheDocument();
+    expect(screen.getByTestId('experiences-section')).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/app/[locale]/home.test.tsx
+++ b/apps/web/tests/app/[locale]/home.test.tsx
@@ -5,200 +5,29 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-vi.mock('next/headers', () => ({
-  headers: vi.fn().mockResolvedValue({ get: () => 'localhost:3000' }),
-}));
-
-vi.mock('next-intl/server', () => ({
-  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
-  getLocale: vi.fn().mockResolvedValue('en-US'),
-}));
-
 vi.mock('~/dev/simulate', () => ({
   applyDevSimulations: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('~/lib/api/internal', () => ({
-  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
-}));
-
-vi.mock('~assets/images/hero-landing-page.png', () => ({
-  default: '/hero.png',
-}));
-
 vi.mock('~features/home/HeroSection', () => ({
-  HeroSection: ({
-    profile,
-    title,
-    caption,
-  }: {
-    profile?: { name: string; headline: string } | null;
-    title: string;
-    caption: string;
-  }) => (
-    <div data-testid="hero">
-      <span data-testid="hero-title">{profile?.name ?? title}</span>
-      <span data-testid="hero-caption">{profile?.headline ?? caption}</span>
-    </div>
-  ),
+  HeroSection: () => <div data-testid="hero-section" />,
 }));
 
 vi.mock('~features/home/ProjectsSection', () => ({
-  ProjectList: ({ projects }: { projects: unknown[] }) => (
-    <ul data-testid="project-list">
-      {(projects as { id: string; title: string }[]).map((p) => (
-        <li key={p.id}>{p.title}</li>
-      ))}
-    </ul>
-  ),
+  ProjectsSection: () => <div data-testid="projects-section" />,
 }));
 
-vi.mock('~features/contact/ContactForm', () => ({
-  ContactForm: () => <div data-testid="contact-form" />,
+vi.mock('~features/contact/ContactSection', () => ({
+  ContactSection: () => <div data-testid="contact-section" />,
 }));
-
-vi.mock('~features/contact/ContactInfo', () => ({
-  ContactInfo: () => <div data-testid="contact-info" />,
-}));
-
-vi.mock('~features/shared/StatCard', () => ({
-  StatCard: () => null,
-}));
-
-vi.mock('@repo/ui/View', () => ({
-  Divider: () => <hr />,
-}));
-
-const mockFetch = vi.fn();
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  global.fetch = mockFetch;
-});
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const PROFILE = {
-  name: 'Alice Dev',
-  headline: 'Software Engineer',
-  bio: 'Bio text',
-  photo: { url: 'https://example.com/photo.jpg', alt: 'Alice photo' },
-};
-
-const PROJECTS = [
-  {
-    id: '1',
-    slug: 'proj-a',
-    title: 'Project A',
-    caption: 'Cap A',
-    coverImage: { url: '', alt: '' },
-    skills: [],
-  },
-  {
-    id: '2',
-    slug: 'proj-b',
-    title: 'Project B',
-    caption: 'Cap B',
-    coverImage: { url: '', alt: '' },
-    skills: [],
-  },
-];
-
-function mockApis(profile: unknown | null, projects: unknown[] | null) {
-  mockFetch.mockImplementation((url: string) => {
-    if (url.includes('/profile')) {
-      if (profile === null)
-        return Promise.resolve({
-          ok: false,
-          json: async () => ({
-            data: null,
-            error: { code: 'NOT_FOUND', message: '' },
-          }),
-        });
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ data: profile, error: null }),
-      });
-    }
-    if (url.includes('/projects/featured')) {
-      if (projects === null)
-        return Promise.resolve({
-          ok: false,
-          json: async () => ({
-            data: null,
-            error: { code: 'INTERNAL_ERROR', message: '' },
-          }),
-        });
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ data: projects, error: null }),
-      });
-    }
-    return Promise.resolve({ ok: false });
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('Home page', () => {
-  it('should render hero with profile data when profile fetch succeeds', async () => {
-    mockApis(PROFILE, []);
-
+  it('should render all feature sections', async () => {
     const { default: Home } = await import('~/app/[locale]/page');
     render(await Home({ searchParams: Promise.resolve({}) }));
 
-    expect(screen.getByTestId('hero-title')).toHaveTextContent('Alice Dev');
-    expect(screen.getByTestId('hero-caption')).toHaveTextContent(
-      'Software Engineer',
-    );
-  });
-
-  it('should render hero with i18n fallback when profile is not found', async () => {
-    mockApis(null, []);
-
-    const { default: Home } = await import('~/app/[locale]/page');
-    render(await Home({ searchParams: Promise.resolve({}) }));
-
-    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
-    expect(screen.getByTestId('hero-caption')).toHaveTextContent(
-      't.hero_caption',
-    );
-  });
-
-  it('should render project list with fetched projects', async () => {
-    mockApis(PROFILE, PROJECTS);
-
-    const { default: Home } = await import('~/app/[locale]/page');
-    render(await Home({ searchParams: Promise.resolve({}) }));
-
-    expect(screen.getByText('Project A')).toBeInTheDocument();
-    expect(screen.getByText('Project B')).toBeInTheDocument();
-  });
-
-  it('should render empty project list when projects fetch fails', async () => {
-    mockApis(PROFILE, null);
-
-    const { default: Home } = await import('~/app/[locale]/page');
-    render(await Home({ searchParams: Promise.resolve({}) }));
-
-    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
-  });
-
-  it('should always render contact form and contact info', async () => {
-    mockApis(null, []);
-
-    const { default: Home } = await import('~/app/[locale]/page');
-    render(await Home({ searchParams: Promise.resolve({}) }));
-
-    expect(screen.getByTestId('contact-form')).toBeInTheDocument();
-    expect(screen.getByTestId('contact-info')).toBeInTheDocument();
+    expect(screen.getByTestId('hero-section')).toBeInTheDocument();
+    expect(screen.getByTestId('projects-section')).toBeInTheDocument();
+    expect(screen.getByTestId('contact-section')).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/app/[locale]/projects.test.tsx
+++ b/apps/web/tests/app/[locale]/projects.test.tsx
@@ -5,102 +5,26 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 
-vi.mock('next/headers', () => ({
-  headers: vi.fn().mockResolvedValue({ get: () => 'localhost:3000' }),
-}));
-
-vi.mock('next-intl/server', () => ({
-  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
-  getLocale: vi.fn().mockResolvedValue('en-US'),
-}));
-
 vi.mock('~/dev/simulate', () => ({
   applyDevSimulations: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('~/lib/api/internal', () => ({
-  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
-}));
-
-vi.mock('~assets/images/hero-projects.png', () => ({
-  default: '/hero-projects.png',
-}));
-
 vi.mock('~features/projects/HeroSection', () => ({
-  HeroSection: ({ title, caption }: { title: string; caption: string }) => (
-    <div data-testid="hero">
-      <span data-testid="hero-title">{title}</span>
-      <span data-testid="hero-caption">{caption}</span>
-    </div>
-  ),
+  HeroSection: () => <div data-testid="hero-section" />,
 }));
 
-vi.mock('~features/home/ProjectsSection', () => ({
-  ProjectList: ({ projects }: { projects: { id: string; title: string }[] }) => (
-    <ul data-testid="project-list">
-      {projects.map((p) => (
-        <li key={p.id}>{p.title}</li>
-      ))}
-    </ul>
-  ),
+vi.mock('~features/projects/ProjectsSection', () => ({
+  ProjectsSection: () => <div data-testid="projects-section" />,
 }));
-
-const mockFetch = vi.fn();
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  global.fetch = mockFetch;
-});
-
-const PROJECTS = [
-  { id: '1', slug: 'proj-a', title: 'Project A', caption: 'Cap A', coverImage: { url: '', alt: '' }, skills: [] },
-  { id: '2', slug: 'proj-b', title: 'Project B', caption: 'Cap B', coverImage: { url: '', alt: '' }, skills: [] },
-];
-
-function mockApi(projects: unknown[] | null) {
-  mockFetch.mockResolvedValue(
-    projects === null
-      ? { ok: false, json: async () => ({ data: null, error: { code: 'INTERNAL_ERROR', message: '' } }) }
-      : { ok: true, json: async () => ({ data: projects, error: null }) },
-  );
-}
 
 describe('Projects page', () => {
-  it('should render hero with i18n translations', async () => {
-    mockApi([]);
-
-    const { default: Projects } = await import('~/app/[locale]/projects/page');
+  it('should render all feature sections', async () => {
+    const { default: Projects } = await import(
+      '~/app/[locale]/projects/page'
+    );
     render(await Projects({ searchParams: Promise.resolve({}) }));
 
-    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
-    expect(screen.getByTestId('hero-caption')).toHaveTextContent('t.hero_caption');
-  });
-
-  it('should render project list with fetched projects', async () => {
-    mockApi(PROJECTS);
-
-    const { default: Projects } = await import('~/app/[locale]/projects/page');
-    render(await Projects({ searchParams: Promise.resolve({}) }));
-
-    expect(screen.getByText('Project A')).toBeInTheDocument();
-    expect(screen.getByText('Project B')).toBeInTheDocument();
-  });
-
-  it('should render empty project list when API fails', async () => {
-    mockApi(null);
-
-    const { default: Projects } = await import('~/app/[locale]/projects/page');
-    render(await Projects({ searchParams: Promise.resolve({}) }));
-
-    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
-  });
-
-  it('should render empty project list when fetch throws', async () => {
-    mockFetch.mockRejectedValue(new Error('Network error'));
-
-    const { default: Projects } = await import('~/app/[locale]/projects/page');
-    render(await Projects({ searchParams: Promise.resolve({}) }));
-
-    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
+    expect(screen.getByTestId('hero-section')).toBeInTheDocument();
+    expect(screen.getByTestId('projects-section')).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/app/api/v1/projects/route.test.ts
+++ b/apps/web/tests/app/api/v1/projects/route.test.ts
@@ -14,6 +14,7 @@ vi.mock('@repo/infra', () => ({
 const mockFindPublished = vi.fn();
 const mockFindBySlug = vi.fn();
 const mockFindRelated = vi.fn();
+const mockFindNamesByIds = vi.fn();
 
 beforeEach(() => {
   vi.mocked(getContainer).mockReturnValue({
@@ -22,8 +23,12 @@ beforeEach(() => {
       findBySlug: mockFindBySlug,
       findRelated: mockFindRelated,
     },
+    skillRepository: {
+      findNamesByIds: mockFindNamesByIds,
+    },
   } as unknown as Container);
   mockFindRelated.mockResolvedValue([]);
+  mockFindNamesByIds.mockResolvedValue(new Map());
 });
 
 function makeRequest(url: string): NextRequest {

--- a/apps/web/tests/features/about/ExperiencesSection.test.tsx
+++ b/apps/web/tests/features/about/ExperiencesSection.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl/server', () => ({
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('@repo/ui/View', () => ({
+  Divider: () => <hr />,
+}));
+
+vi.mock('~features/about/ExperiencesSection/ExperienceCard', () => ({
+  ExperienceCard: ({
+    company,
+    position,
+  }: {
+    company: string;
+    position: string;
+  }) => (
+    <div data-testid="experience-card">
+      <span>{position}</span>
+      <span>{company}</span>
+    </div>
+  ),
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const EXPERIENCES = [
+  {
+    id: '1',
+    company: 'Acme Corp',
+    position: 'Senior Developer',
+    location: 'São Paulo',
+    employmentType: 'FULL_TIME',
+    locationType: 'REMOTE',
+    startAt: '2023-01-01T00:00:00.000Z',
+    skills: [],
+  },
+  {
+    id: '2',
+    company: 'Beta Inc',
+    position: 'Tech Lead',
+    location: 'Remote',
+    employmentType: 'FULL_TIME',
+    locationType: 'REMOTE',
+    startAt: '2024-01-01T00:00:00.000Z',
+    skills: [],
+  },
+];
+
+describe('about/ExperiencesSection', () => {
+  it('should render experience cards from API response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: EXPERIENCES, error: null }),
+    });
+
+    const { ExperiencesSection } = await import(
+      '~features/about/ExperiencesSection'
+    );
+    render(await ExperiencesSection());
+
+    expect(screen.getByText('Senior Developer')).toBeInTheDocument();
+    expect(screen.getByText('Tech Lead')).toBeInTheDocument();
+  });
+
+  it('should render no cards when API returns empty', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [], error: null }),
+    });
+
+    const { ExperiencesSection } = await import(
+      '~features/about/ExperiencesSection'
+    );
+    render(await ExperiencesSection());
+
+    expect(screen.queryByTestId('experience-card')).not.toBeInTheDocument();
+  });
+
+  it('should render no cards when fetch fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        data: null,
+        error: { code: 'INTERNAL_ERROR', message: '' },
+      }),
+    });
+
+    const { ExperiencesSection } = await import(
+      '~features/about/ExperiencesSection'
+    );
+    render(await ExperiencesSection());
+
+    expect(screen.queryByTestId('experience-card')).not.toBeInTheDocument();
+  });
+
+  it('should render no cards when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { ExperiencesSection } = await import(
+      '~features/about/ExperiencesSection'
+    );
+    render(await ExperiencesSection());
+
+    expect(screen.queryByTestId('experience-card')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/features/about/HeroSection.test.tsx
+++ b/apps/web/tests/features/about/HeroSection.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('~assets/images/hero-about.png', () => ({
+  default: '/hero-about.png',
+}));
+
+vi.mock('~features/shared/HeroBanner', () => ({
+  HeroBanner: ({
+    title,
+    caption,
+  }: {
+    title: string;
+    caption: string;
+  }) => (
+    <div data-testid="hero-banner">
+      <span data-testid="hero-title">{title}</span>
+      <span data-testid="hero-caption">{caption}</span>
+    </div>
+  ),
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const PROFILE = {
+  name: 'Wallace Ferreira',
+  headline: 'Frontend Engineer',
+  bio: 'Bio text.',
+  photo: { url: 'https://example.com/photo.jpg', alt: 'Profile photo' },
+};
+
+describe('about/HeroSection', () => {
+  it('should render banner with profile data when fetch succeeds', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: PROFILE, error: null }),
+    });
+
+    const { HeroSection } = await import('~features/about/HeroSection');
+    render(await HeroSection());
+
+    expect(screen.getByTestId('hero-title')).toHaveTextContent(
+      'Wallace Ferreira',
+    );
+    expect(screen.getByTestId('hero-caption')).toHaveTextContent(
+      'Frontend Engineer',
+    );
+  });
+
+  it('should render banner with i18n fallback when fetch fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        data: null,
+        error: { code: 'NOT_FOUND', message: '' },
+      }),
+    });
+
+    const { HeroSection } = await import('~features/about/HeroSection');
+    render(await HeroSection());
+
+    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
+    expect(screen.getByTestId('hero-caption')).toHaveTextContent(
+      't.hero_caption',
+    );
+  });
+
+  it('should render banner with i18n fallback when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { HeroSection } = await import('~features/about/HeroSection');
+    render(await HeroSection());
+
+    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
+  });
+});

--- a/apps/web/tests/features/about/ValuesSection.test.tsx
+++ b/apps/web/tests/features/about/ValuesSection.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('@repo/ui/View', () => ({
+  Divider: () => <hr />,
+}));
+
+vi.mock('~features/about/ValuesSection/ProfessionalValue', () => ({
+  ProfessionalValue: ({ content }: { content: string }) => (
+    <div data-testid="professional-value">{content}</div>
+  ),
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const PROFESSIONAL_VALUES = [
+  { id: '1', icon: 'material-symbols:diamond', content: 'High quality delivery' },
+  { id: '2', icon: 'material-symbols:code', content: 'Clean code' },
+];
+
+describe('about/ValuesSection', () => {
+  it('should render section title from i18n', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [], error: null }),
+    });
+
+    const { ValuesSection } = await import('~features/about/ValuesSection');
+    render(await ValuesSection());
+
+    expect(screen.getByText('t.values_title')).toBeInTheDocument();
+  });
+
+  it('should render professional values from API response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: PROFESSIONAL_VALUES, error: null }),
+    });
+
+    const { ValuesSection } = await import('~features/about/ValuesSection');
+    render(await ValuesSection());
+
+    expect(
+      screen.getAllByTestId('professional-value').length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText('High quality delivery')).toBeInTheDocument();
+  });
+
+  it('should render no values when API returns empty', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [], error: null }),
+    });
+
+    const { ValuesSection } = await import('~features/about/ValuesSection');
+    render(await ValuesSection());
+
+    expect(
+      screen.queryByTestId('professional-value'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render no values when fetch fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        data: null,
+        error: { code: 'INTERNAL_ERROR', message: '' },
+      }),
+    });
+
+    const { ValuesSection } = await import('~features/about/ValuesSection');
+    render(await ValuesSection());
+
+    expect(
+      screen.queryByTestId('professional-value'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/features/contact/ContactSection.test.tsx
+++ b/apps/web/tests/features/contact/ContactSection.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@repo/ui/View', () => ({
+  Divider: () => <hr />,
+}));
+
+vi.mock('~features/contact/ContactForm', () => ({
+  ContactForm: () => <div data-testid="contact-form" />,
+}));
+
+vi.mock('~features/contact/ContactInfo', () => ({
+  ContactInfo: () => <div data-testid="contact-info" />,
+}));
+
+describe('ContactSection', () => {
+  it('should render contact form and contact info', async () => {
+    const { ContactSection } = await import(
+      '~features/contact/ContactSection'
+    );
+    render(React.createElement(ContactSection));
+
+    expect(screen.getByTestId('contact-form')).toBeInTheDocument();
+    expect(screen.getByTestId('contact-info')).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/features/home/HeroSection.test.tsx
+++ b/apps/web/tests/features/home/HeroSection.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('~assets/images/hero-landing-page.png', () => ({
+  default: '/hero.png',
+}));
+
+vi.mock('~features/shared/HeroBanner', () => ({
+  HeroBanner: ({
+    title,
+    caption,
+  }: {
+    title: string;
+    caption: string;
+  }) => (
+    <div data-testid="hero-banner">
+      <span data-testid="hero-title">{title}</span>
+      <span data-testid="hero-caption">{caption}</span>
+    </div>
+  ),
+}));
+
+vi.mock('~features/shared/StatCard', () => ({
+  StatCard: ({ label, value }: { label: string; value: string }) => (
+    <div data-testid="stat-card">
+      {label}: {value}
+    </div>
+  ),
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const PROFILE = {
+  name: 'Wallace Ferreira',
+  headline: 'Frontend Engineer',
+  bio: 'Bio text.',
+  photo: { url: 'https://example.com/photo.jpg', alt: 'Profile photo' },
+  stats: [{ label: 'Years', value: '6+', icon: 'mdi:calendar' }],
+};
+
+describe('home/HeroSection', () => {
+  it('should render banner with profile data when fetch succeeds', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: PROFILE, error: null }),
+    });
+
+    const { HeroSection } = await import(
+      '~features/home/HeroSection'
+    );
+    render(await HeroSection());
+
+    expect(screen.getByTestId('hero-title')).toHaveTextContent(
+      'Wallace Ferreira',
+    );
+    expect(screen.getByTestId('hero-caption')).toHaveTextContent(
+      'Frontend Engineer',
+    );
+  });
+
+  it('should render banner with i18n fallback when fetch fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        data: null,
+        error: { code: 'NOT_FOUND', message: '' },
+      }),
+    });
+
+    const { HeroSection } = await import('~features/home/HeroSection');
+    render(await HeroSection());
+
+    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
+    expect(screen.getByTestId('hero-caption')).toHaveTextContent(
+      't.hero_caption',
+    );
+  });
+
+  it('should render banner with i18n fallback when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { HeroSection } = await import('~features/home/HeroSection');
+    render(await HeroSection());
+
+    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
+  });
+
+  it('should render stat cards when profile has stats', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: PROFILE, error: null }),
+    });
+
+    const { HeroSection } = await import('~features/home/HeroSection');
+    render(await HeroSection());
+
+    expect(screen.getByTestId('stat-card')).toBeInTheDocument();
+  });
+
+  it('should not render stat cards when profile has no stats', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: { ...PROFILE, stats: [] },
+        error: null,
+      }),
+    });
+
+    const { HeroSection } = await import('~features/home/HeroSection');
+    render(await HeroSection());
+
+    expect(screen.queryByTestId('stat-card')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/features/home/ProjectsSection.test.tsx
+++ b/apps/web/tests/features/home/ProjectsSection.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('~features/home/ProjectsSection/ProjectList', () => ({
+  ProjectList: ({
+    projects,
+  }: {
+    projects: { id: string; title: string }[];
+  }) => (
+    <ul data-testid="project-list">
+      {projects.map((p) => (
+        <li key={p.id}>{p.title}</li>
+      ))}
+    </ul>
+  ),
+  ProjectSummary: undefined,
+}));
+
+vi.mock('~features/home/ProjectsSection/ProjectCard', () => ({
+  ProjectCard: () => null,
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const PROJECTS = [
+  {
+    id: '1',
+    slug: 'proj-a',
+    title: 'Project A',
+    caption: 'Cap A',
+    coverImage: { url: '', alt: '' },
+    skills: [],
+  },
+  {
+    id: '2',
+    slug: 'proj-b',
+    title: 'Project B',
+    caption: 'Cap B',
+    coverImage: { url: '', alt: '' },
+    skills: [],
+  },
+];
+
+describe('home/ProjectsSection', () => {
+  it('should render section title and projects from API', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: PROJECTS, error: null }),
+    });
+
+    const { ProjectsSection } = await import(
+      '~features/home/ProjectsSection'
+    );
+    render(await ProjectsSection());
+
+    expect(screen.getByText('t.projects_title')).toBeInTheDocument();
+    expect(screen.getByText('Project A')).toBeInTheDocument();
+    expect(screen.getByText('Project B')).toBeInTheDocument();
+  });
+
+  it('should render empty list when fetch fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        data: null,
+        error: { code: 'INTERNAL_ERROR', message: '' },
+      }),
+    });
+
+    const { ProjectsSection } = await import(
+      '~features/home/ProjectsSection'
+    );
+    render(await ProjectsSection());
+
+    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
+  });
+
+  it('should render empty list when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { ProjectsSection } = await import(
+      '~features/home/ProjectsSection'
+    );
+    render(await ProjectsSection());
+
+    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/tests/features/projects/ProjectsSection.test.tsx
+++ b/apps/web/tests/features/projects/ProjectsSection.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl/server', () => ({
+  getLocale: vi.fn().mockResolvedValue('en-US'),
+}));
+
+vi.mock('~/lib/api/internal', () => ({
+  getInternalBaseUrl: vi.fn().mockResolvedValue('http://localhost:3000'),
+}));
+
+vi.mock('~features/home/ProjectsSection', () => ({
+  ProjectList: ({
+    projects,
+  }: {
+    projects: { id: string; title: string }[];
+  }) => (
+    <ul data-testid="project-list">
+      {projects.map((p) => (
+        <li key={p.id}>{p.title}</li>
+      ))}
+    </ul>
+  ),
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+const PROJECTS = [
+  {
+    id: '1',
+    slug: 'proj-a',
+    title: 'Project A',
+    caption: 'Cap A',
+    coverImage: { url: '', alt: '' },
+    skills: [],
+  },
+  {
+    id: '2',
+    slug: 'proj-b',
+    title: 'Project B',
+    caption: 'Cap B',
+    coverImage: { url: '', alt: '' },
+    skills: [],
+  },
+];
+
+describe('projects/ProjectsSection', () => {
+  it('should render projects from API response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: PROJECTS, error: null }),
+    });
+
+    const { ProjectsSection } = await import(
+      '~features/projects/ProjectsSection'
+    );
+    render(await ProjectsSection());
+
+    expect(screen.getByText('Project A')).toBeInTheDocument();
+    expect(screen.getByText('Project B')).toBeInTheDocument();
+  });
+
+  it('should render empty list when fetch fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        data: null,
+        error: { code: 'INTERNAL_ERROR', message: '' },
+      }),
+    });
+
+    const { ProjectsSection } = await import(
+      '~features/projects/ProjectsSection'
+    );
+    render(await ProjectsSection());
+
+    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
+  });
+
+  it('should render empty list when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const { ProjectsSection } = await import(
+      '~features/projects/ProjectsSection'
+    );
+    render(await ProjectsSection());
+
+    expect(screen.getByTestId('project-list')).toBeEmptyDOMElement();
+  });
+});

--- a/packages/application/src/portfolio/use-cases/GetExperiences.ts
+++ b/packages/application/src/portfolio/use-cases/GetExperiences.ts
@@ -1,4 +1,8 @@
-import { Experience, IExperienceRepository } from '@repo/core/portfolio';
+import {
+  Experience,
+  IExperienceRepository,
+  ISkillRepository,
+} from '@repo/core/portfolio';
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
 import { UseCase } from '../../shared/UseCase';
@@ -12,7 +16,10 @@ export class GetExperiences extends UseCase<
   GetExperiencesInput,
   ExperienceDTO[]
 > {
-  constructor(private readonly experienceRepository: IExperienceRepository) {
+  constructor(
+    private readonly experienceRepository: IExperienceRepository,
+    private readonly skillRepository: ISkillRepository,
+  ) {
     super();
   }
 
@@ -24,7 +31,14 @@ export class GetExperiences extends UseCase<
       const sorted = [...experiences].sort(
         (a, b) => b.period.startAt.ms - a.period.startAt.ms,
       );
-      return right(sorted.map((e) => this.toDTO(e, input.locale)));
+      const allIds = [
+        ...new Set(sorted.flatMap((e) => e.skills.map((s) => s.value))),
+      ];
+      const skillNames = await this.skillRepository.findNamesByIds(
+        allIds,
+        input.locale,
+      );
+      return right(sorted.map((e) => this.toDTO(e, input.locale, skillNames)));
     } catch {
       return left(
         new DomainError('FETCH_FAILED', {
@@ -34,7 +48,11 @@ export class GetExperiences extends UseCase<
     }
   }
 
-  private toDTO(experience: Experience, locale: Locale): ExperienceDTO {
+  private toDTO(
+    experience: Experience,
+    locale: Locale,
+    skillNames: Map<string, string>,
+  ): ExperienceDTO {
     return {
       id: experience.id.value,
       company: experience.company.get(locale),
@@ -49,7 +67,9 @@ export class GetExperiences extends UseCase<
       locationType: experience.location_type,
       startAt: experience.period.startAt.value,
       endAt: experience.period.endAt?.value,
-      skills: experience.skills.map((id) => id.value),
+      skills: experience.skills.map(
+        (id) => skillNames.get(id.value) ?? id.value,
+      ),
     };
   }
 }

--- a/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
@@ -1,4 +1,8 @@
-import { IProjectRepository, Project } from '@repo/core/portfolio';
+import {
+  IProjectRepository,
+  ISkillRepository,
+  Project,
+} from '@repo/core/portfolio';
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
 import { UseCase } from '../../shared/UseCase';
@@ -12,7 +16,10 @@ export class GetFeaturedProjects extends UseCase<
   GetFeaturedProjectsInput,
   ProjectSummaryDTO[]
 > {
-  constructor(private readonly projectRepository: IProjectRepository) {
+  constructor(
+    private readonly projectRepository: IProjectRepository,
+    private readonly skillRepository: ISkillRepository,
+  ) {
     super();
   }
 
@@ -21,7 +28,16 @@ export class GetFeaturedProjects extends UseCase<
   ): Promise<Either<DomainError, ProjectSummaryDTO[]>> {
     try {
       const projects = await this.projectRepository.findFeatured();
-      return right(projects.map((p) => this.toDTO(p, input.locale)));
+      const allIds = [
+        ...new Set(projects.flatMap((p) => p.skills.map((s) => s.value))),
+      ];
+      const skillNames = await this.skillRepository.findNamesByIds(
+        allIds,
+        input.locale,
+      );
+      return right(
+        projects.map((p) => this.toDTO(p, input.locale, skillNames)),
+      );
     } catch {
       return left(
         new DomainError('FETCH_FAILED', {
@@ -31,7 +47,11 @@ export class GetFeaturedProjects extends UseCase<
     }
   }
 
-  private toDTO(project: Project, locale: Locale): ProjectSummaryDTO {
+  private toDTO(
+    project: Project,
+    locale: Locale,
+    skillNames: Map<string, string>,
+  ): ProjectSummaryDTO {
     return {
       id: project.id.value,
       slug: project.slug.value,
@@ -42,7 +62,7 @@ export class GetFeaturedProjects extends UseCase<
         alt: project.coverImage.alt.get(locale),
       },
       theme: project.theme?.get(locale),
-      skills: project.skills.map((id) => id.value),
+      skills: project.skills.map((id) => skillNames.get(id.value) ?? id.value),
       publishedAt: project.period.startAt.value,
     };
   }

--- a/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
+++ b/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
@@ -1,4 +1,8 @@
-import { IProjectRepository, Project } from '@repo/core/portfolio';
+import {
+  IProjectRepository,
+  ISkillRepository,
+  Project,
+} from '@repo/core/portfolio';
 import {
   DomainError,
   Either,
@@ -24,7 +28,10 @@ export class GetProjectBySlug extends UseCase<
   ProjectDetailDTO,
   NotFoundError | ValidationError | DomainError
 > {
-  constructor(private readonly projectRepository: IProjectRepository) {
+  constructor(
+    private readonly projectRepository: IProjectRepository,
+    private readonly skillRepository: ISkillRepository,
+  ) {
     super();
   }
 
@@ -56,16 +63,28 @@ export class GetProjectBySlug extends UseCase<
       relatedProjects = [];
     }
 
-    const relatedDTOs = relatedProjects.map((p) =>
-      this.toSummaryDTO(p, input.locale),
+    const allProjects = [project, ...relatedProjects];
+    const allIds = [
+      ...new Set(allProjects.flatMap((p) => p.skills.map((s) => s.value))),
+    ];
+    const skillNames = await this.skillRepository.findNamesByIds(
+      allIds,
+      input.locale,
     );
-    return right(this.toDetailDTO(project, input.locale, relatedDTOs));
+
+    const relatedDTOs = relatedProjects.map((p) =>
+      this.toSummaryDTO(p, input.locale, skillNames),
+    );
+    return right(
+      this.toDetailDTO(project, input.locale, relatedDTOs, skillNames),
+    );
   }
 
   private toDetailDTO(
     project: Project,
     locale: Locale,
     relatedProjects: ProjectSummaryDTO[],
+    skillNames: Map<string, string>,
   ): ProjectDetailDTO {
     return {
       id: project.id.value,
@@ -77,7 +96,7 @@ export class GetProjectBySlug extends UseCase<
         alt: project.coverImage.alt.get(locale),
       },
       theme: project.theme?.get(locale),
-      skills: project.skills.map((id) => id.value),
+      skills: project.skills.map((id) => skillNames.get(id.value) ?? id.value),
       publishedAt: project.period.startAt.value,
       content: project.content.value,
       summary: project.summary?.get(locale),
@@ -91,7 +110,11 @@ export class GetProjectBySlug extends UseCase<
     };
   }
 
-  private toSummaryDTO(project: Project, locale: Locale): ProjectSummaryDTO {
+  private toSummaryDTO(
+    project: Project,
+    locale: Locale,
+    skillNames: Map<string, string>,
+  ): ProjectSummaryDTO {
     return {
       id: project.id.value,
       slug: project.slug.value,
@@ -102,7 +125,7 @@ export class GetProjectBySlug extends UseCase<
         alt: project.coverImage.alt.get(locale),
       },
       theme: project.theme?.get(locale),
-      skills: project.skills.map((id) => id.value),
+      skills: project.skills.map((id) => skillNames.get(id.value) ?? id.value),
       publishedAt: project.period.startAt.value,
     };
   }

--- a/packages/application/src/portfolio/use-cases/GetPublishedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetPublishedProjects.ts
@@ -1,4 +1,8 @@
-import { IProjectRepository, Project } from '@repo/core/portfolio';
+import {
+  IProjectRepository,
+  ISkillRepository,
+  Project,
+} from '@repo/core/portfolio';
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
 import { UseCase } from '../../shared/UseCase';
@@ -12,7 +16,10 @@ export class GetPublishedProjects extends UseCase<
   GetPublishedProjectsInput,
   ProjectSummaryDTO[]
 > {
-  constructor(private readonly projectRepository: IProjectRepository) {
+  constructor(
+    private readonly projectRepository: IProjectRepository,
+    private readonly skillRepository: ISkillRepository,
+  ) {
     super();
   }
 
@@ -24,7 +31,14 @@ export class GetPublishedProjects extends UseCase<
       const sorted = [...projects].sort(
         (a, b) => b.period.startAt.ms - a.period.startAt.ms,
       );
-      return right(sorted.map((p) => this.toDTO(p, input.locale)));
+      const allIds = [
+        ...new Set(sorted.flatMap((p) => p.skills.map((s) => s.value))),
+      ];
+      const skillNames = await this.skillRepository.findNamesByIds(
+        allIds,
+        input.locale,
+      );
+      return right(sorted.map((p) => this.toDTO(p, input.locale, skillNames)));
     } catch {
       return left(
         new DomainError('FETCH_FAILED', {
@@ -34,7 +48,11 @@ export class GetPublishedProjects extends UseCase<
     }
   }
 
-  private toDTO(project: Project, locale: Locale): ProjectSummaryDTO {
+  private toDTO(
+    project: Project,
+    locale: Locale,
+    skillNames: Map<string, string>,
+  ): ProjectSummaryDTO {
     return {
       id: project.id.value,
       slug: project.slug.value,
@@ -45,7 +63,7 @@ export class GetPublishedProjects extends UseCase<
         alt: project.coverImage.alt.get(locale),
       },
       theme: project.theme?.get(locale),
-      skills: project.skills.map((id) => id.value),
+      skills: project.skills.map((id) => skillNames.get(id.value) ?? id.value),
       publishedAt: project.period.startAt.value,
     };
   }

--- a/packages/application/test/portfolio/GetExperiences.test.ts
+++ b/packages/application/test/portfolio/GetExperiences.test.ts
@@ -5,6 +5,7 @@ import {
   Experience,
   IExperienceProps,
   IExperienceRepository,
+  ISkillRepository,
   LocationType,
 } from '@repo/core/portfolio';
 import { DomainError } from '@repo/core/shared';
@@ -54,6 +55,14 @@ function makeRepository(
   };
 }
 
+function makeSkillRepository(
+  map: Map<string, string> = new Map(),
+): ISkillRepository {
+  return {
+    findNamesByIds: vi.fn().mockResolvedValue(map),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -62,7 +71,7 @@ describe('GetExperiences', () => {
   describe('execute()', () => {
     it('should return Right with empty array when repository returns no experiences', async () => {
       const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([]) });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -75,7 +84,7 @@ describe('GetExperiences', () => {
       const repo = makeRepository({
         findAll: vi.fn().mockResolvedValue([experience]),
       });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -103,7 +112,7 @@ describe('GetExperiences', () => {
       const repo = makeRepository({
         findAll: vi.fn().mockResolvedValue([oldest, newest, middle]),
       });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -128,7 +137,7 @@ describe('GetExperiences', () => {
       const repo = makeRepository({
         findAll: vi.fn().mockResolvedValue(original),
       });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       await useCase.execute({ locale: 'pt-BR' });
 
@@ -145,7 +154,7 @@ describe('GetExperiences', () => {
       const repo = makeRepository({
         findAll: vi.fn().mockResolvedValue([experience]),
       });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -172,7 +181,7 @@ describe('GetExperiences', () => {
       const repo = makeRepository({
         findAll: vi.fn().mockResolvedValue([experience]),
       });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       const ptResult = await useCase.execute({ locale: 'pt-BR' });
       const enResult = await useCase.execute({ locale: 'en-US' });
@@ -189,14 +198,17 @@ describe('GetExperiences', () => {
       expect(enDto.position).toBe('Software Engineer');
     });
 
-    it('should map skill IDs as strings in the DTO', async () => {
+    it('should resolve skill names from the skill repository', async () => {
       const experience = makeExperience({
         skills: [SKILL_ID_1, SKILL_ID_2],
       });
       const repo = makeRepository({
         findAll: vi.fn().mockResolvedValue([experience]),
       });
-      const useCase = new GetExperiences(repo);
+      const skillRepo = makeSkillRepository(
+        new Map([[SKILL_ID_1, 'TypeScript'], [SKILL_ID_2, 'React']]),
+      );
+      const useCase = new GetExperiences(repo, skillRepo);
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -204,8 +216,8 @@ describe('GetExperiences', () => {
       const dto = (result.value as ExperienceDTO[])[0]!;
 
       expect(dto.skills).toHaveLength(2);
-      expect(dto.skills[0]).toBe(SKILL_ID_1);
-      expect(dto.skills[1]).toBe(SKILL_ID_2);
+      expect(dto.skills[0]).toBe('TypeScript');
+      expect(dto.skills[1]).toBe('React');
     });
 
     it('should map skills as empty array when experience has no skills', async () => {
@@ -213,7 +225,7 @@ describe('GetExperiences', () => {
       const repo = makeRepository({
         findAll: vi.fn().mockResolvedValue([experience]),
       });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -227,7 +239,7 @@ describe('GetExperiences', () => {
       const repo = makeRepository({
         findAll: vi.fn().mockResolvedValue([experience]),
       });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -240,7 +252,7 @@ describe('GetExperiences', () => {
       const repo = makeRepository({
         findAll: vi.fn().mockRejectedValue(new Error('DB connection failed')),
       });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -252,7 +264,7 @@ describe('GetExperiences', () => {
     it('should call findAll() on the repository', async () => {
       const findAll = vi.fn().mockResolvedValue([]);
       const repo = makeRepository({ findAll });
-      const useCase = new GetExperiences(repo);
+      const useCase = new GetExperiences(repo, makeSkillRepository());
 
       await useCase.execute({ locale: 'pt-BR' });
 

--- a/packages/application/test/portfolio/GetFeaturedProjects.test.ts
+++ b/packages/application/test/portfolio/GetFeaturedProjects.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   IProjectProps,
   IProjectRepository,
+  ISkillRepository,
   Project,
   ProjectStatus,
 } from '@repo/core/portfolio';
@@ -50,6 +51,14 @@ function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRe
   };
 }
 
+function makeSkillRepository(
+  map: Map<string, string> = new Map(),
+): ISkillRepository {
+  return {
+    findNamesByIds: vi.fn().mockResolvedValue(map),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -58,7 +67,7 @@ describe('GetFeaturedProjects', () => {
   describe('execute()', () => {
     it('should return Right with empty array when repository returns no projects', async () => {
       const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([]) });
-      const useCase = new GetFeaturedProjects(repo);
+      const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -69,7 +78,7 @@ describe('GetFeaturedProjects', () => {
     it('should return Right with mapped DTOs when repository returns projects', async () => {
       const project = makeProject();
       const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
-      const useCase = new GetFeaturedProjects(repo);
+      const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -80,7 +89,7 @@ describe('GetFeaturedProjects', () => {
     it('should map all DTO fields correctly for pt-BR locale', async () => {
       const project = makeProject();
       const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
-      const useCase = new GetFeaturedProjects(repo);
+      const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -103,7 +112,7 @@ describe('GetFeaturedProjects', () => {
         theme: { 'pt-BR': 'Tema PT', 'en-US': 'Theme EN' },
       });
       const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
-      const useCase = new GetFeaturedProjects(repo);
+      const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const ptResult = await useCase.execute({ locale: 'pt-BR' });
       const enResult = await useCase.execute({ locale: 'en-US' });
@@ -120,27 +129,28 @@ describe('GetFeaturedProjects', () => {
       expect(enDto.theme).toBe('Theme EN');
     });
 
-    it('should include skill IDs in DTO', async () => {
-      const skillIds = [
-        'a0000000-0000-4000-8000-000000000001',
-        'a0000000-0000-4000-8000-000000000002',
-      ];
-      const project = makeProject({ skills: skillIds });
+    it('should include resolved skill names in DTO', async () => {
+      const skillId1 = 'a0000000-0000-4000-8000-000000000001';
+      const skillId2 = 'a0000000-0000-4000-8000-000000000002';
+      const project = makeProject({ skills: [skillId1, skillId2] });
       const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
-      const useCase = new GetFeaturedProjects(repo);
+      const skillRepo = makeSkillRepository(
+        new Map([[skillId1, 'TypeScript'], [skillId2, 'React']]),
+      );
+      const useCase = new GetFeaturedProjects(repo, skillRepo);
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
       expect(result.isRight()).toBe(true);
       const dto = (result.value as ProjectSummaryDTO[])[0]!;
-      expect(dto.skills).toEqual(skillIds);
+      expect(dto.skills).toEqual(['TypeScript', 'React']);
     });
 
     it('should return Left with DomainError when repository throws', async () => {
       const repo = makeRepository({
         findFeatured: vi.fn().mockRejectedValue(new Error('DB connection failed')),
       });
-      const useCase = new GetFeaturedProjects(repo);
+      const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -152,7 +162,7 @@ describe('GetFeaturedProjects', () => {
     it('should call findFeatured() on the repository', async () => {
       const findFeatured = vi.fn().mockResolvedValue([]);
       const repo = makeRepository({ findFeatured });
-      const useCase = new GetFeaturedProjects(repo);
+      const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       await useCase.execute({ locale: 'pt-BR' });
 

--- a/packages/application/test/portfolio/GetProjectBySlug.test.ts
+++ b/packages/application/test/portfolio/GetProjectBySlug.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   IProjectProps,
   IProjectRepository,
+  ISkillRepository,
   Project,
   ProjectStatus,
 } from '@repo/core/portfolio';
@@ -50,6 +51,14 @@ function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRe
   };
 }
 
+function makeSkillRepository(
+  map: Map<string, string> = new Map(),
+): ISkillRepository {
+  return {
+    findNamesByIds: vi.fn().mockResolvedValue(map),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -62,7 +71,7 @@ describe('GetProjectBySlug', () => {
         findBySlug: vi.fn().mockResolvedValue(project),
         findRelated: vi.fn().mockResolvedValue([]),
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
 
@@ -80,7 +89,7 @@ describe('GetProjectBySlug', () => {
         findBySlug: vi.fn().mockResolvedValue(project),
         findRelated: vi.fn().mockResolvedValue([]),
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
 
@@ -108,7 +117,7 @@ describe('GetProjectBySlug', () => {
         findBySlug: vi.fn().mockResolvedValue(project),
         findRelated: vi.fn().mockResolvedValue([]),
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
 
@@ -130,7 +139,7 @@ describe('GetProjectBySlug', () => {
         findBySlug: vi.fn().mockResolvedValue(project),
         findRelated: vi.fn().mockResolvedValue([]),
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const enResult = await useCase.execute({ slug: 'my-project', locale: 'en-US' });
 
@@ -149,7 +158,7 @@ describe('GetProjectBySlug', () => {
         findBySlug: vi.fn().mockResolvedValue(project),
         findRelated: vi.fn().mockResolvedValue([related]),
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
 
@@ -167,7 +176,7 @@ describe('GetProjectBySlug', () => {
         findBySlug: vi.fn().mockResolvedValue(project),
         findRelated,
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
 
@@ -179,7 +188,7 @@ describe('GetProjectBySlug', () => {
         findBySlug: vi.fn().mockResolvedValue(null),
         findRelated: vi.fn().mockResolvedValue([]),
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const result = await useCase.execute({ slug: 'non-existent', locale: 'pt-BR' });
 
@@ -189,7 +198,7 @@ describe('GetProjectBySlug', () => {
 
     it('should return Left with ValidationError when slug is invalid', async () => {
       const repo = makeRepository();
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const result = await useCase.execute({ slug: 'ab', locale: 'pt-BR' });
 
@@ -200,7 +209,7 @@ describe('GetProjectBySlug', () => {
     it('should not call repository when slug is invalid', async () => {
       const findBySlug = vi.fn();
       const repo = makeRepository({ findBySlug });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       await useCase.execute({ slug: '', locale: 'pt-BR' });
 
@@ -211,7 +220,7 @@ describe('GetProjectBySlug', () => {
       const repo = makeRepository({
         findBySlug: vi.fn().mockRejectedValue(new Error('DB error')),
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
 
@@ -226,7 +235,7 @@ describe('GetProjectBySlug', () => {
         findBySlug: vi.fn().mockResolvedValue(project),
         findRelated: vi.fn().mockRejectedValue(new Error('DB error')),
       });
-      const useCase = new GetProjectBySlug(repo);
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
 
       const result = await useCase.execute({ slug: 'my-project', locale: 'pt-BR' });
 

--- a/packages/application/test/portfolio/GetPublishedProjects.test.ts
+++ b/packages/application/test/portfolio/GetPublishedProjects.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   IProjectProps,
   IProjectRepository,
+  ISkillRepository,
   Project,
   ProjectStatus,
 } from '@repo/core/portfolio';
@@ -50,6 +51,14 @@ function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRe
   };
 }
 
+function makeSkillRepository(
+  map: Map<string, string> = new Map(),
+): ISkillRepository {
+  return {
+    findNamesByIds: vi.fn().mockResolvedValue(map),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -58,7 +67,7 @@ describe('GetPublishedProjects', () => {
   describe('execute()', () => {
     it('should return Right with empty array when repository returns no projects', async () => {
       const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([]) });
-      const useCase = new GetPublishedProjects(repo);
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -69,7 +78,7 @@ describe('GetPublishedProjects', () => {
     it('should return Right with mapped DTOs when repository returns projects', async () => {
       const project = makeProject();
       const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([project]) });
-      const useCase = new GetPublishedProjects(repo);
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -85,7 +94,7 @@ describe('GetPublishedProjects', () => {
       const repo = makeRepository({
         findPublished: vi.fn().mockResolvedValue([oldest, newest, middle]),
       });
-      const useCase = new GetPublishedProjects(repo);
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -102,7 +111,7 @@ describe('GetPublishedProjects', () => {
       const original = [oldest, newest];
 
       const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue(original) });
-      const useCase = new GetPublishedProjects(repo);
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       await useCase.execute({ locale: 'pt-BR' });
 
@@ -113,7 +122,7 @@ describe('GetPublishedProjects', () => {
     it('should map all DTO fields correctly for pt-BR locale', async () => {
       const project = makeProject();
       const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([project]) });
-      const useCase = new GetPublishedProjects(repo);
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -136,7 +145,7 @@ describe('GetPublishedProjects', () => {
         theme: { 'pt-BR': 'Tema PT', 'en-US': 'Theme EN' },
       });
       const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([project]) });
-      const useCase = new GetPublishedProjects(repo);
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const ptResult = await useCase.execute({ locale: 'pt-BR' });
       const enResult = await useCase.execute({ locale: 'en-US' });
@@ -153,27 +162,28 @@ describe('GetPublishedProjects', () => {
       expect(enDto.theme).toBe('Theme EN');
     });
 
-    it('should include skill IDs in DTO', async () => {
-      const skillIds = [
-        'a0000000-0000-4000-8000-000000000001',
-        'a0000000-0000-4000-8000-000000000002',
-      ];
-      const project = makeProject({ skills: skillIds });
+    it('should include resolved skill names in DTO', async () => {
+      const skillId1 = 'a0000000-0000-4000-8000-000000000001';
+      const skillId2 = 'a0000000-0000-4000-8000-000000000002';
+      const project = makeProject({ skills: [skillId1, skillId2] });
       const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([project]) });
-      const useCase = new GetPublishedProjects(repo);
+      const skillRepo = makeSkillRepository(
+        new Map([[skillId1, 'TypeScript'], [skillId2, 'React']]),
+      );
+      const useCase = new GetPublishedProjects(repo, skillRepo);
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
       expect(result.isRight()).toBe(true);
       const dto = (result.value as ProjectSummaryDTO[])[0]!;
-      expect(dto.skills).toEqual(skillIds);
+      expect(dto.skills).toEqual(['TypeScript', 'React']);
     });
 
     it('should return Left with DomainError when repository throws', async () => {
       const repo = makeRepository({
         findPublished: vi.fn().mockRejectedValue(new Error('DB connection failed')),
       });
-      const useCase = new GetPublishedProjects(repo);
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
 
@@ -185,7 +195,7 @@ describe('GetPublishedProjects', () => {
     it('should call findPublished() on the repository', async () => {
       const findPublished = vi.fn().mockResolvedValue([]);
       const repo = makeRepository({ findPublished });
-      const useCase = new GetPublishedProjects(repo);
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       await useCase.execute({ locale: 'pt-BR' });
 

--- a/packages/core/src/portfolio/entities/professional-value/repositories/IProfessionalValueRepository.ts
+++ b/packages/core/src/portfolio/entities/professional-value/repositories/IProfessionalValueRepository.ts
@@ -1,5 +1,4 @@
 import { IRepository } from '../../../../shared/base/IRepository';
-
 import { ProfessionalValue } from '../model/ProfessionalValue';
 
 export interface IProfessionalValueRepository

--- a/packages/core/src/portfolio/entities/skill/index.ts
+++ b/packages/core/src/portfolio/entities/skill/index.ts
@@ -1,3 +1,4 @@
 export * from './factory/SkillFactory';
 export * from './model/Skill';
 export * from './model/SkillType';
+export * from './repositories/ISkillRepository';

--- a/packages/core/src/portfolio/entities/skill/repositories/ISkillRepository.ts
+++ b/packages/core/src/portfolio/entities/skill/repositories/ISkillRepository.ts
@@ -1,0 +1,5 @@
+import { Locale } from '../../../../shared';
+
+export interface ISkillRepository {
+  findNamesByIds(ids: string[], locale: Locale): Promise<Map<string, string>>;
+}

--- a/packages/infra/src/container.ts
+++ b/packages/infra/src/container.ts
@@ -6,6 +6,7 @@ import {
   IProfessionalValueRepository,
   IProfileRepository,
   IProjectRepository,
+  ISkillRepository,
 } from '@repo/core/portfolio';
 import { validateEnv } from '@repo/utils/env';
 import { Resend } from 'resend';
@@ -14,14 +15,16 @@ import { env } from './env';
 import { SupabaseAuthenticationGateway } from './identity/SupabaseAuthenticationGateway';
 import { prisma } from './prisma/client';
 import { PrismaExperienceRepository } from './repositories/experience/PrismaExperienceRepository';
-import { PrismaProfileRepository } from './repositories/profile/PrismaProfileRepository';
 import { PrismaProfessionalValueRepository } from './repositories/professional-value/PrismaProfessionalValueRepository';
+import { PrismaProfileRepository } from './repositories/profile/PrismaProfileRepository';
 import { PrismaProjectRepository } from './repositories/project/PrismaProjectRepository';
+import { PrismaSkillRepository } from './repositories/skill/PrismaSkillRepository';
 import { PrismaUserRepository } from './repositories/user/PrismaUserRepository';
 import { ResendEmailService } from './services/ResendEmailService';
 
 export type Container = {
   projectRepository: IProjectRepository;
+  skillRepository: ISkillRepository;
   experienceRepository: IExperienceRepository;
   professionalValueRepository: IProfessionalValueRepository;
   profileRepository: IProfileRepository;
@@ -37,6 +40,7 @@ export function makeContainer(): Container {
 
   return {
     projectRepository: new PrismaProjectRepository(prisma),
+    skillRepository: new PrismaSkillRepository(prisma),
     experienceRepository: new PrismaExperienceRepository(prisma),
     professionalValueRepository: new PrismaProfessionalValueRepository(prisma),
     profileRepository: new PrismaProfileRepository(prisma),

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -5,6 +5,7 @@ export { prisma } from './prisma/client';
 export { InfrastructureError } from './errors/InfrastructureError';
 export { ProjectMapper } from './repositories/project/ProjectMapper';
 export { PrismaProjectRepository } from './repositories/project/PrismaProjectRepository';
+export { PrismaSkillRepository } from './repositories/skill/PrismaSkillRepository';
 export { ExperienceMapper } from './repositories/experience/ExperienceMapper';
 export { PrismaExperienceRepository } from './repositories/experience/PrismaExperienceRepository';
 export { ProfessionalValueMapper } from './repositories/professional-value/ProfessionalValueMapper';

--- a/packages/infra/src/repositories/skill/PrismaSkillRepository.ts
+++ b/packages/infra/src/repositories/skill/PrismaSkillRepository.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from '@prisma/client';
+import { ISkillRepository } from '@repo/core/portfolio';
+import { Locale } from '@repo/core/shared';
+
+export class PrismaSkillRepository implements ISkillRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async findNamesByIds(
+    ids: string[],
+    locale: Locale,
+  ): Promise<Map<string, string>> {
+    if (ids.length === 0) return new Map();
+    const rows = await this.db.skill.findMany({ where: { id: { in: ids } } });
+    return new Map(
+      rows.map((row) => {
+        const desc = row.description as Record<string, string>;
+        return [row.id, desc[locale] ?? desc['en-US'] ?? row.id];
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Pages (`/`, `/about`, `/projects`) simplified to pure section orchestrators — no inline fetch or render logic
- Data fetching moved into self-fetching Server Component sections: `home/HeroSection`, `home/ProjectsSection`, `contact/ContactSection`, `about/HeroSection`, `about/ValuesSection`, `about/ExperiencesSection`, `projects/HeroSection`, `projects/ProjectsSection`
- 7 new feature section test files added; page-level tests simplified to composition checks

Refs #561

## Test plan

- [ ] All 178 tests pass (`pnpm exec vitest run` in `apps/web`)
- [ ] `/` renders hero banner + stats + project list + contact section
- [ ] `/about` renders hero + values + experiences sections
- [ ] `/projects` renders hero + projects list

🤖 Generated with [Claude Code](https://claude.com/claude-code)