### PR TITLE
fix(web): streaming layout, missing CSS classes, skill icons, and build error

### DIFF
--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import { applyDevSimulations } from '~/dev/simulate';
 import { ExperiencesSection } from '~features/about/ExperiencesSection';
 import { HeroSection } from '~features/about/HeroSection';
@@ -7,14 +9,79 @@ interface AboutPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
 }
 
+function HeroSkeleton() {
+  return (
+    <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
+      <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
+        <div className="h-8 w-48 bg-gray-700 rounded" />
+        <div className="h-8 w-64 bg-gray-700 rounded" />
+        <div className="flex flex-col gap-y-2 pt-4">
+          <div className="h-4 bg-gray-700 rounded w-full" />
+          <div className="h-4 bg-gray-700 rounded w-5/6" />
+          <div className="h-4 bg-gray-700 rounded w-4/6" />
+        </div>
+      </section>
+      <section className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
+    </section>
+  );
+}
+
+function ValuesSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="h-8 w-64 bg-gray-700 rounded mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
+      <ul className="flex flex-row gap-x-4 mx-4 xl:mx-auto xl:max-w-237.5">
+        {(['val-1', 'val-2', 'val-3', 'val-4'] as const).map((key) => (
+          <li
+            key={key}
+            className="w-full max-w-56 border border-dark-300 px-4 py-6 rounded-xl bg-dark-300/20 flex flex-col gap-y-3"
+          >
+            <div className="h-12 w-12 bg-gray-700 rounded" />
+            <div className="h-4 bg-gray-700 rounded w-full" />
+            <div className="h-4 bg-gray-700 rounded w-4/5" />
+            <div className="h-4 bg-gray-700 rounded w-3/5" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ExperiencesSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="h-px bg-gray-700 mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
+      <ul className="flex flex-col mx-4 gap-y-3 xl:mx-auto xl:max-w-237.5">
+        {(['exp-1', 'exp-2', 'exp-3'] as const).map((key) => (
+          <li
+            key={key}
+            className="flex flex-col py-6 px-3 bg-dark-200 rounded-xl gap-y-3"
+          >
+            <div className="h-5 w-3/5 bg-gray-700 rounded" />
+            <div className="h-4 w-2/5 bg-gray-700 rounded" />
+            <div className="h-4 bg-gray-700 rounded w-full" />
+            <div className="h-4 bg-gray-700 rounded w-5/6" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export default async function About({ searchParams }: AboutPageProps) {
   await applyDevSimulations(await searchParams);
 
   return (
     <>
-      <HeroSection />
-      <ValuesSection />
-      <ExperiencesSection />
+      <Suspense fallback={<HeroSkeleton />}>
+        <HeroSection />
+      </Suspense>
+      <Suspense fallback={<ValuesSkeleton />}>
+        <ValuesSection />
+      </Suspense>
+      <Suspense fallback={<ExperiencesSkeleton />}>
+        <ExperiencesSection />
+      </Suspense>
     </>
   );
 }

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import { applyDevSimulations } from '~/dev/simulate';
 import { ContactSection } from '~features/contact/ContactSection';
 import { HeroSection } from '~features/home/HeroSection';
@@ -7,13 +9,55 @@ interface HomePageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
 }
 
+function HeroSkeleton() {
+  return (
+    <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
+      <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
+        <div className="h-8 w-48 bg-gray-700 rounded" />
+        <div className="h-8 w-64 bg-gray-700 rounded" />
+        <div className="flex flex-col gap-y-2 pt-4">
+          <div className="h-4 bg-gray-700 rounded w-full" />
+          <div className="h-4 bg-gray-700 rounded w-5/6" />
+          <div className="h-4 bg-gray-700 rounded w-4/6" />
+        </div>
+      </section>
+      <section className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
+    </section>
+  );
+}
+
+function ProjectsSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="w-full flex justify-start mx-4 my-6 xl:mx-auto xl:max-w-237.5">
+        <div className="h-8 w-32 bg-gray-700 rounded" />
+      </div>
+      <ul className="mx-auto grid max-w-237.5 gap-4 md:grid-cols-2 xl:gap-6 pb-8 xl:pb-20">
+        {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
+          <li key={key} className="bg-surface p-3 rounded-5">
+            <div className="h-45 xl:h-61 bg-gray-700 rounded-lg mb-4" />
+            <div className="h-5 w-3/4 bg-gray-700 rounded mb-2" />
+            <div className="h-4 bg-gray-700 rounded mb-1" />
+            <div className="h-4 w-5/6 bg-gray-700 rounded mb-5" />
+            <div className="h-10 bg-gray-700 rounded" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export default async function Home({ searchParams }: HomePageProps) {
   await applyDevSimulations(await searchParams);
 
   return (
     <>
-      <HeroSection />
-      <ProjectsSection />
+      <Suspense fallback={<HeroSkeleton />}>
+        <HeroSection />
+      </Suspense>
+      <Suspense fallback={<ProjectsSkeleton />}>
+        <ProjectsSection />
+      </Suspense>
       <ContactSection />
     </>
   );

--- a/apps/web/src/app/[locale]/projects/page.tsx
+++ b/apps/web/src/app/[locale]/projects/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import { applyDevSimulations } from '~/dev/simulate';
 import { HeroSection } from '~features/projects/HeroSection';
 import { ProjectsSection } from '~features/projects/ProjectsSection';
@@ -6,13 +8,55 @@ interface ProjectsPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
 }
 
+function HeroSkeleton() {
+  return (
+    <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
+      <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
+        <div className="h-8 w-36 bg-gray-700 rounded" />
+        <div className="h-8 w-56 bg-gray-700 rounded" />
+        <div className="flex flex-col gap-y-2 pt-4">
+          <div className="h-4 bg-gray-700 rounded w-full" />
+          <div className="h-4 bg-gray-700 rounded w-5/6" />
+          <div className="h-4 bg-gray-700 rounded w-4/6" />
+        </div>
+      </section>
+      <section className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
+    </section>
+  );
+}
+
+function ProjectsSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="w-full flex justify-start mx-4 my-6 xl:mx-auto xl:max-w-237.5">
+        <div className="h-8 w-32 bg-gray-700 rounded" />
+      </div>
+      <ul className="mx-auto grid max-w-237.5 gap-4 md:grid-cols-2 xl:gap-6 pb-8 xl:pb-20">
+        {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
+          <li key={key} className="bg-surface p-3 rounded-5">
+            <div className="h-45 xl:h-61 bg-gray-700 rounded-lg mb-4" />
+            <div className="h-5 w-3/4 bg-gray-700 rounded mb-2" />
+            <div className="h-4 bg-gray-700 rounded mb-1" />
+            <div className="h-4 w-5/6 bg-gray-700 rounded mb-5" />
+            <div className="h-10 bg-gray-700 rounded" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export default async function Projects({ searchParams }: ProjectsPageProps) {
   await applyDevSimulations(await searchParams);
 
   return (
     <>
-      <HeroSection />
-      <ProjectsSection />
+      <Suspense fallback={<HeroSkeleton />}>
+        <HeroSection />
+      </Suspense>
+      <Suspense fallback={<ProjectsSkeleton />}>
+        <ProjectsSection />
+      </Suspense>
     </>
   );
 }

--- a/apps/web/src/features/about/ExperiencesSection/ExperienceCard.tsx
+++ b/apps/web/src/features/about/ExperiencesSection/ExperienceCard.tsx
@@ -17,7 +17,7 @@ export interface IExperienceCardProps {
   locationType: string;
   startAt: string;
   endAt?: string;
-  skills: string[];
+  skills: { name: string; icon: string }[];
 }
 
 export const ExperienceCard: FC<IExperienceCardProps> = ({

--- a/apps/web/src/features/about/ExperiencesSection/SkillAccordion.tsx
+++ b/apps/web/src/features/about/ExperiencesSection/SkillAccordion.tsx
@@ -7,7 +7,7 @@ import { Icon } from '@repo/ui/Imagery';
 import { useTranslations } from 'next-intl';
 
 interface ISkillAccordionProps {
-  skills: string[];
+  skills: { name: string; icon: string }[];
 }
 
 export const SkillAccordion: FC<ISkillAccordionProps> = ({ skills }) => {
@@ -32,10 +32,13 @@ export const SkillAccordion: FC<ISkillAccordionProps> = ({ skills }) => {
             <ul className="flex flex-row gap-2 flex-wrap pt-2">
               {skills.map((skill) => (
                 <li
-                  key={skill}
-                  className="flex flex-row items-center bg-surface-raised py-1 px-3 rounded-3.75 text-body-xs !text-content-primary"
+                  key={skill.name}
+                  className="flex flex-row items-center bg-surface-raised py-1 px-3 gap-x-2 rounded-3.75 text-body-xs !text-content-primary"
                 >
-                  {skill}
+                  {skill.icon && (
+                    <Icon icon={skill.icon} className="text-base min-w-fit" />
+                  )}
+                  <span>{skill.name}</span>
                 </li>
               ))}
             </ul>

--- a/apps/web/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/web/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -18,7 +18,7 @@ export interface IProjectCardProps {
   caption: string;
   coverImage: { url: string; alt: string };
   theme?: string;
-  skills: string[];
+  skills: { name: string; icon: string }[];
   compact?: boolean;
 }
 

--- a/apps/web/src/features/home/ProjectsSection/ProjectList.tsx
+++ b/apps/web/src/features/home/ProjectsSection/ProjectList.tsx
@@ -13,7 +13,7 @@ export interface ProjectSummary {
   caption: string;
   coverImage: { url: string; alt: string };
   theme?: string;
-  skills: string[];
+  skills: { name: string; icon: string }[];
 }
 
 interface IProjectListProps {

--- a/apps/web/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/web/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -6,7 +6,10 @@ import { TextRich } from '@repo/ui/View';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
-import { ProjectList, ProjectSummary } from '~features/home/ProjectsSection';
+import {
+  ProjectList,
+  ProjectSummary,
+} from '~features/home/ProjectsSection/ProjectList';
 import { Breadcrumb } from '~features/shared/Breadcrumb';
 import { SkillGroup } from '~features/shared/SkillGroup';
 

--- a/apps/web/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/web/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -18,7 +18,7 @@ export interface IProjectDetailProps {
   caption: string;
   coverImage: { url: string; alt: string };
   theme?: string;
-  skills: string[];
+  skills: { name: string; icon: string }[];
   summary?: string;
   objectives?: string;
   role?: string;

--- a/apps/web/src/features/shared/SkillGroup/index.tsx
+++ b/apps/web/src/features/shared/SkillGroup/index.tsx
@@ -2,12 +2,15 @@
 
 import { FC, useMemo, useState } from 'react';
 
+import { Icon } from '@repo/ui/Imagery';
 import { useIsomorphicLayoutEffect } from 'usehooks-ts';
+
+export type SkillSummary = { name: string; icon: string };
 
 interface ISkillGroupProps {
   max: number;
   total: number;
-  skills: string[];
+  skills: SkillSummary[];
   initializeWithMax: number;
 }
 
@@ -21,12 +24,15 @@ export const SkillGroup: FC<ISkillGroupProps> = ({
 
   const renderedSkills = useMemo(
     () =>
-      skills.slice(0, storedMax).map((skillId) => (
+      skills.slice(0, storedMax).map((skill) => (
         <li
-          key={skillId}
-          className="flex flex-row items-center bg-surface-raised py-1 px-3 rounded-3.75 text-body-xs !text-content-primary"
+          key={skill.name}
+          className="flex flex-row items-center bg-surface-raised py-1 px-3 gap-x-2 rounded-3.75 text-body-xs !text-content-primary"
         >
-          {skillId}
+          {skill.icon && (
+            <Icon icon={skill.icon} className="text-base min-w-fit" />
+          )}
+          <span>{skill.name}</span>
         </li>
       )),
     [skills, storedMax],

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/features/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
     'node_modules/@repo/ui/dist/**/*.js',
   ],

--- a/apps/web/tests/app/[locale]/project-detail.test.tsx
+++ b/apps/web/tests/app/[locale]/project-detail.test.tsx
@@ -45,7 +45,7 @@ const PROJECT = {
   title: 'My Project',
   caption: 'A great project',
   coverImage: { url: 'https://example.com/img.jpg', alt: 'Cover' },
-  skills: ['React'],
+  skills: [{ name: 'React', icon: '' }],
   content: '# Hello',
   period: { startAt: '2024-01-01' },
   relatedProjects: [],

--- a/apps/web/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
+++ b/apps/web/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
@@ -1,14 +1,24 @@
 import { render, screen } from '@testing-library/react';
 
 vi.mock('@repo/ui/View', () => ({
-  TextRich: ({ content, className }: { content: string; className?: string }) => (
-    <p className={className}>{content}</p>
-  ),
+  TextRich: ({
+    content,
+    className,
+  }: {
+    content: string;
+    className?: string;
+  }) => <p className={className}>{content}</p>,
 }));
 
 vi.mock('~/features/about/ExperiencesSection/SkillAccordion', () => ({
-  SkillAccordion: ({ skills }: { skills: string[] }) => (
-    <div data-testid="skill-accordion">{skills.join(',')}</div>
+  SkillAccordion: ({
+    skills,
+  }: {
+    skills: { name: string; icon: string }[];
+  }) => (
+    <div data-testid="skill-accordion">
+      {skills.map((s) => s.name).join(',')}
+    </div>
   ),
 }));
 
@@ -25,7 +35,10 @@ const defaultProps = {
   locationType: 'REMOTE',
   startAt: '2023-01-01T00:00:00.000Z',
   endAt: '2024-01-01T00:00:00.000Z',
-  skills: ['React', 'TypeScript'],
+  skills: [
+    { name: 'React', icon: '' },
+    { name: 'TypeScript', icon: '' },
+  ],
 };
 
 describe('ExperienceCard', () => {
@@ -48,11 +61,15 @@ describe('ExperienceCard', () => {
   it('should not render description when not provided', () => {
     const { description: _, ...props } = defaultProps;
     render(<ExperienceCard {...props} />);
-    expect(screen.queryByText('Full-stack development.')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Full-stack development.'),
+    ).not.toBeInTheDocument();
   });
 
   it('should pass skills to SkillAccordion', () => {
     render(<ExperienceCard {...defaultProps} />);
-    expect(screen.getByTestId('skill-accordion')).toHaveTextContent('React,TypeScript');
+    expect(screen.getByTestId('skill-accordion')).toHaveTextContent(
+      'React,TypeScript',
+    );
   });
 });

--- a/apps/web/tests/components/View/ProjectCard/ProjectCard.test.tsx
+++ b/apps/web/tests/components/View/ProjectCard/ProjectCard.test.tsx
@@ -50,7 +50,7 @@ const defaultProps = {
   title: 'My Project',
   caption: 'A great project',
   coverImage: { url: 'https://example.com/image.jpg', alt: 'My project cover' },
-  skills: ['React', 'TypeScript'],
+  skills: [{ name: 'React', icon: '' }, { name: 'TypeScript', icon: '' }],
 };
 
 describe('ProjectCard', () => {

--- a/apps/web/tests/components/View/SkillAccordion/SkillAccordion.test.tsx
+++ b/apps/web/tests/components/View/SkillAccordion/SkillAccordion.test.tsx
@@ -13,14 +13,36 @@ vi.mock('@repo/ui/Imagery', () => ({
 
 vi.mock('@repo/ui/Control', () => {
   const { useState } = require('react');
-  const Root = ({ children }: { children: (ctx: { expanded: boolean; toggle: () => void }) => React.ReactNode }) => {
+  const Root = ({
+    children,
+  }: {
+    children: (ctx: {
+      expanded: boolean;
+      toggle: () => void;
+    }) => React.ReactNode;
+  }) => {
     const [expanded, setExpanded] = useState(false);
-    return <>{children({ expanded, toggle: () => setExpanded((v: boolean) => !v) })}</>;
+    return (
+      <>
+        {children({ expanded, toggle: () => setExpanded((v: boolean) => !v) })}
+      </>
+    );
   };
-  const Header = ({ children, onClick }: { children: React.ReactNode; onClick?: () => void; className?: string }) => (
-    <button type="button" onClick={onClick}>{children}</button>
+  const Header = ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    className?: string;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
   );
-  const Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Body = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
   return { Accordion: { Root, Header, Body } };
 });
 
@@ -33,12 +55,27 @@ describe('SkillAccordion', () => {
   });
 
   it('should render the skills label', () => {
-    render(<SkillAccordion skills={['React', 'TypeScript']} />);
+    render(
+      <SkillAccordion
+        skills={[
+          { name: 'React', icon: '' },
+          { name: 'TypeScript', icon: '' },
+        ]}
+      />,
+    );
     expect(screen.getByText('ExperienceCard.skills_label')).toBeInTheDocument();
   });
 
   it('should render all skill items', () => {
-    render(<SkillAccordion skills={['React', 'TypeScript', 'Node.js']} />);
+    render(
+      <SkillAccordion
+        skills={[
+          { name: 'React', icon: '' },
+          { name: 'TypeScript', icon: '' },
+          { name: 'Node.js', icon: '' },
+        ]}
+      />,
+    );
     expect(screen.getByText('React')).toBeInTheDocument();
     expect(screen.getByText('TypeScript')).toBeInTheDocument();
     expect(screen.getByText('Node.js')).toBeInTheDocument();
@@ -46,7 +83,7 @@ describe('SkillAccordion', () => {
 
   it('should toggle expanded state on header click', async () => {
     const user = userEvent.setup();
-    render(<SkillAccordion skills={['React']} />);
+    render(<SkillAccordion skills={[{ name: 'React', icon: '' }]} />);
     const button = screen.getByRole('button');
     await user.click(button);
     expect(button).toBeInTheDocument();

--- a/packages/application/src/portfolio/dtos/ExperienceDTO.ts
+++ b/packages/application/src/portfolio/dtos/ExperienceDTO.ts
@@ -1,3 +1,5 @@
+import { SkillSummary } from './ProjectSummaryDTO';
+
 export type ExperienceDTO = {
   id: string;
   company: string;
@@ -9,5 +11,5 @@ export type ExperienceDTO = {
   locationType: string;
   startAt: string;
   endAt?: string;
-  skills: string[];
+  skills: SkillSummary[];
 };

--- a/packages/application/src/portfolio/dtos/ProjectSummaryDTO.ts
+++ b/packages/application/src/portfolio/dtos/ProjectSummaryDTO.ts
@@ -1,3 +1,5 @@
+export type SkillSummary = { name: string; icon: string };
+
 export type ProjectSummaryDTO = {
   id: string;
   slug: string;
@@ -5,6 +7,6 @@ export type ProjectSummaryDTO = {
   caption: string;
   coverImage: { url: string; alt: string };
   theme?: string;
-  skills: string[];
+  skills: SkillSummary[];
   publishedAt: string;
 };

--- a/packages/application/src/portfolio/use-cases/GetExperiences.ts
+++ b/packages/application/src/portfolio/use-cases/GetExperiences.ts
@@ -7,6 +7,7 @@ import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
 import { UseCase } from '../../shared/UseCase';
 import { ExperienceDTO } from '../dtos/ExperienceDTO';
+import { SkillSummary } from '../dtos/ProjectSummaryDTO';
 
 export type GetExperiencesInput = {
   locale: Locale;
@@ -51,7 +52,7 @@ export class GetExperiences extends UseCase<
   private toDTO(
     experience: Experience,
     locale: Locale,
-    skillNames: Map<string, string>,
+    skillNames: Map<string, SkillSummary>,
   ): ExperienceDTO {
     return {
       id: experience.id.value,
@@ -68,7 +69,7 @@ export class GetExperiences extends UseCase<
       startAt: experience.period.startAt.value,
       endAt: experience.period.endAt?.value,
       skills: experience.skills.map(
-        (id) => skillNames.get(id.value) ?? id.value,
+        (id) => skillNames.get(id.value) ?? { name: id.value, icon: '' },
       ),
     };
   }

--- a/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
@@ -6,7 +6,7 @@ import {
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
 import { UseCase } from '../../shared/UseCase';
-import { ProjectSummaryDTO } from '../dtos/ProjectSummaryDTO';
+import { ProjectSummaryDTO, SkillSummary } from '../dtos/ProjectSummaryDTO';
 
 export type GetFeaturedProjectsInput = {
   locale: Locale;
@@ -50,7 +50,7 @@ export class GetFeaturedProjects extends UseCase<
   private toDTO(
     project: Project,
     locale: Locale,
-    skillNames: Map<string, string>,
+    skillNames: Map<string, SkillSummary>,
   ): ProjectSummaryDTO {
     return {
       id: project.id.value,
@@ -62,7 +62,9 @@ export class GetFeaturedProjects extends UseCase<
         alt: project.coverImage.alt.get(locale),
       },
       theme: project.theme?.get(locale),
-      skills: project.skills.map((id) => skillNames.get(id.value) ?? id.value),
+      skills: project.skills.map(
+        (id) => skillNames.get(id.value) ?? { name: id.value, icon: '' },
+      ),
       publishedAt: project.period.startAt.value,
     };
   }

--- a/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
+++ b/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
@@ -16,7 +16,7 @@ import {
 
 import { UseCase } from '../../shared/UseCase';
 import { ProjectDetailDTO } from '../dtos/ProjectDetailDTO';
-import { ProjectSummaryDTO } from '../dtos/ProjectSummaryDTO';
+import { ProjectSummaryDTO, SkillSummary } from '../dtos/ProjectSummaryDTO';
 
 export type GetProjectBySlugInput = {
   slug: string;
@@ -84,7 +84,7 @@ export class GetProjectBySlug extends UseCase<
     project: Project,
     locale: Locale,
     relatedProjects: ProjectSummaryDTO[],
-    skillNames: Map<string, string>,
+    skillNames: Map<string, SkillSummary>,
   ): ProjectDetailDTO {
     return {
       id: project.id.value,
@@ -96,7 +96,9 @@ export class GetProjectBySlug extends UseCase<
         alt: project.coverImage.alt.get(locale),
       },
       theme: project.theme?.get(locale),
-      skills: project.skills.map((id) => skillNames.get(id.value) ?? id.value),
+      skills: project.skills.map(
+        (id) => skillNames.get(id.value) ?? { name: id.value, icon: '' },
+      ),
       publishedAt: project.period.startAt.value,
       content: project.content.value,
       summary: project.summary?.get(locale),
@@ -113,7 +115,7 @@ export class GetProjectBySlug extends UseCase<
   private toSummaryDTO(
     project: Project,
     locale: Locale,
-    skillNames: Map<string, string>,
+    skillNames: Map<string, SkillSummary>,
   ): ProjectSummaryDTO {
     return {
       id: project.id.value,
@@ -125,7 +127,9 @@ export class GetProjectBySlug extends UseCase<
         alt: project.coverImage.alt.get(locale),
       },
       theme: project.theme?.get(locale),
-      skills: project.skills.map((id) => skillNames.get(id.value) ?? id.value),
+      skills: project.skills.map(
+        (id) => skillNames.get(id.value) ?? { name: id.value, icon: '' },
+      ),
       publishedAt: project.period.startAt.value,
     };
   }

--- a/packages/application/src/portfolio/use-cases/GetPublishedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetPublishedProjects.ts
@@ -6,7 +6,7 @@ import {
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
 import { UseCase } from '../../shared/UseCase';
-import { ProjectSummaryDTO } from '../dtos/ProjectSummaryDTO';
+import { ProjectSummaryDTO, SkillSummary } from '../dtos/ProjectSummaryDTO';
 
 export type GetPublishedProjectsInput = {
   locale: Locale;
@@ -51,7 +51,7 @@ export class GetPublishedProjects extends UseCase<
   private toDTO(
     project: Project,
     locale: Locale,
-    skillNames: Map<string, string>,
+    skillNames: Map<string, SkillSummary>,
   ): ProjectSummaryDTO {
     return {
       id: project.id.value,
@@ -63,7 +63,9 @@ export class GetPublishedProjects extends UseCase<
         alt: project.coverImage.alt.get(locale),
       },
       theme: project.theme?.get(locale),
-      skills: project.skills.map((id) => skillNames.get(id.value) ?? id.value),
+      skills: project.skills.map(
+        (id) => skillNames.get(id.value) ?? { name: id.value, icon: '' },
+      ),
       publishedAt: project.period.startAt.value,
     };
   }

--- a/packages/application/test/portfolio/GetExperiences.test.ts
+++ b/packages/application/test/portfolio/GetExperiences.test.ts
@@ -56,7 +56,7 @@ function makeRepository(
 }
 
 function makeSkillRepository(
-  map: Map<string, string> = new Map(),
+  map: Map<string, { name: string; icon: string }> = new Map(),
 ): ISkillRepository {
   return {
     findNamesByIds: vi.fn().mockResolvedValue(map),
@@ -206,7 +206,10 @@ describe('GetExperiences', () => {
         findAll: vi.fn().mockResolvedValue([experience]),
       });
       const skillRepo = makeSkillRepository(
-        new Map([[SKILL_ID_1, 'TypeScript'], [SKILL_ID_2, 'React']]),
+        new Map([
+          [SKILL_ID_1, { name: 'TypeScript', icon: '' }],
+          [SKILL_ID_2, { name: 'React', icon: '' }],
+        ]),
       );
       const useCase = new GetExperiences(repo, skillRepo);
 
@@ -216,8 +219,8 @@ describe('GetExperiences', () => {
       const dto = (result.value as ExperienceDTO[])[0]!;
 
       expect(dto.skills).toHaveLength(2);
-      expect(dto.skills[0]).toBe('TypeScript');
-      expect(dto.skills[1]).toBe('React');
+      expect(dto.skills[0]).toEqual({ name: 'TypeScript', icon: '' });
+      expect(dto.skills[1]).toEqual({ name: 'React', icon: '' });
     });
 
     it('should map skills as empty array when experience has no skills', async () => {

--- a/packages/application/test/portfolio/GetFeaturedProjects.test.ts
+++ b/packages/application/test/portfolio/GetFeaturedProjects.test.ts
@@ -33,11 +33,14 @@ const BASE_PROPS: IProjectProps = {
 
 function makeProject(overrides: Partial<IProjectProps> = {}): Project {
   const result = Project.create({ ...BASE_PROPS, ...overrides });
-  if (result.isLeft()) throw new Error(`makeProject failed: ${result.value.message}`);
+  if (result.isLeft())
+    throw new Error(`makeProject failed: ${result.value.message}`);
   return result.value;
 }
 
-function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRepository {
+function makeRepository(
+  overrides: Partial<IProjectRepository> = {},
+): IProjectRepository {
   return {
     findAll: vi.fn(),
     findPublished: vi.fn(),
@@ -52,7 +55,7 @@ function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRe
 }
 
 function makeSkillRepository(
-  map: Map<string, string> = new Map(),
+  map: Map<string, { name: string; icon: string }> = new Map(),
 ): ISkillRepository {
   return {
     findNamesByIds: vi.fn().mockResolvedValue(map),
@@ -66,7 +69,9 @@ function makeSkillRepository(
 describe('GetFeaturedProjects', () => {
   describe('execute()', () => {
     it('should return Right with empty array when repository returns no projects', async () => {
-      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([]) });
+      const repo = makeRepository({
+        findFeatured: vi.fn().mockResolvedValue([]),
+      });
       const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
@@ -77,7 +82,9 @@ describe('GetFeaturedProjects', () => {
 
     it('should return Right with mapped DTOs when repository returns projects', async () => {
       const project = makeProject();
-      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
+      const repo = makeRepository({
+        findFeatured: vi.fn().mockResolvedValue([project]),
+      });
       const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
@@ -88,7 +95,9 @@ describe('GetFeaturedProjects', () => {
 
     it('should map all DTO fields correctly for pt-BR locale', async () => {
       const project = makeProject();
-      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
+      const repo = makeRepository({
+        findFeatured: vi.fn().mockResolvedValue([project]),
+      });
       const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
@@ -111,7 +120,9 @@ describe('GetFeaturedProjects', () => {
       const project = makeProject({
         theme: { 'pt-BR': 'Tema PT', 'en-US': 'Theme EN' },
       });
-      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
+      const repo = makeRepository({
+        findFeatured: vi.fn().mockResolvedValue([project]),
+      });
       const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 
       const ptResult = await useCase.execute({ locale: 'pt-BR' });
@@ -133,9 +144,14 @@ describe('GetFeaturedProjects', () => {
       const skillId1 = 'a0000000-0000-4000-8000-000000000001';
       const skillId2 = 'a0000000-0000-4000-8000-000000000002';
       const project = makeProject({ skills: [skillId1, skillId2] });
-      const repo = makeRepository({ findFeatured: vi.fn().mockResolvedValue([project]) });
+      const repo = makeRepository({
+        findFeatured: vi.fn().mockResolvedValue([project]),
+      });
       const skillRepo = makeSkillRepository(
-        new Map([[skillId1, 'TypeScript'], [skillId2, 'React']]),
+        new Map([
+          [skillId1, { name: 'TypeScript', icon: '' }],
+          [skillId2, { name: 'React', icon: '' }],
+        ]),
       );
       const useCase = new GetFeaturedProjects(repo, skillRepo);
 
@@ -143,12 +159,17 @@ describe('GetFeaturedProjects', () => {
 
       expect(result.isRight()).toBe(true);
       const dto = (result.value as ProjectSummaryDTO[])[0]!;
-      expect(dto.skills).toEqual(['TypeScript', 'React']);
+      expect(dto.skills).toEqual([
+        { name: 'TypeScript', icon: '' },
+        { name: 'React', icon: '' },
+      ]);
     });
 
     it('should return Left with DomainError when repository throws', async () => {
       const repo = makeRepository({
-        findFeatured: vi.fn().mockRejectedValue(new Error('DB connection failed')),
+        findFeatured: vi
+          .fn()
+          .mockRejectedValue(new Error('DB connection failed')),
       });
       const useCase = new GetFeaturedProjects(repo, makeSkillRepository());
 

--- a/packages/application/test/portfolio/GetProjectBySlug.test.ts
+++ b/packages/application/test/portfolio/GetProjectBySlug.test.ts
@@ -52,7 +52,7 @@ function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRe
 }
 
 function makeSkillRepository(
-  map: Map<string, string> = new Map(),
+  map: Map<string, { name: string; icon: string }> = new Map(),
 ): ISkillRepository {
   return {
     findNamesByIds: vi.fn().mockResolvedValue(map),

--- a/packages/application/test/portfolio/GetPublishedProjects.test.ts
+++ b/packages/application/test/portfolio/GetPublishedProjects.test.ts
@@ -33,11 +33,14 @@ const BASE_PROPS: IProjectProps = {
 
 function makeProject(overrides: Partial<IProjectProps> = {}): Project {
   const result = Project.create({ ...BASE_PROPS, ...overrides });
-  if (result.isLeft()) throw new Error(`makeProject failed: ${result.value.message}`);
+  if (result.isLeft())
+    throw new Error(`makeProject failed: ${result.value.message}`);
   return result.value;
 }
 
-function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRepository {
+function makeRepository(
+  overrides: Partial<IProjectRepository> = {},
+): IProjectRepository {
   return {
     findAll: vi.fn(),
     findPublished: vi.fn(),
@@ -52,7 +55,7 @@ function makeRepository(overrides: Partial<IProjectRepository> = {}): IProjectRe
 }
 
 function makeSkillRepository(
-  map: Map<string, string> = new Map(),
+  map: Map<string, { name: string; icon: string }> = new Map(),
 ): ISkillRepository {
   return {
     findNamesByIds: vi.fn().mockResolvedValue(map),
@@ -66,7 +69,9 @@ function makeSkillRepository(
 describe('GetPublishedProjects', () => {
   describe('execute()', () => {
     it('should return Right with empty array when repository returns no projects', async () => {
-      const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([]) });
+      const repo = makeRepository({
+        findPublished: vi.fn().mockResolvedValue([]),
+      });
       const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
@@ -77,7 +82,9 @@ describe('GetPublishedProjects', () => {
 
     it('should return Right with mapped DTOs when repository returns projects', async () => {
       const project = makeProject();
-      const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([project]) });
+      const repo = makeRepository({
+        findPublished: vi.fn().mockResolvedValue([project]),
+      });
       const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
@@ -87,9 +94,18 @@ describe('GetPublishedProjects', () => {
     });
 
     it('should sort projects by publishedAt descending (newest first)', async () => {
-      const oldest = makeProject({ slug: 'oldest', period: { start: '2021-01-01T00:00:00.000Z' } });
-      const middle = makeProject({ slug: 'middle', period: { start: '2022-06-01T00:00:00.000Z' } });
-      const newest = makeProject({ slug: 'newest', period: { start: '2023-12-01T00:00:00.000Z' } });
+      const oldest = makeProject({
+        slug: 'oldest',
+        period: { start: '2021-01-01T00:00:00.000Z' },
+      });
+      const middle = makeProject({
+        slug: 'middle',
+        period: { start: '2022-06-01T00:00:00.000Z' },
+      });
+      const newest = makeProject({
+        slug: 'newest',
+        period: { start: '2023-12-01T00:00:00.000Z' },
+      });
 
       const repo = makeRepository({
         findPublished: vi.fn().mockResolvedValue([oldest, newest, middle]),
@@ -106,11 +122,19 @@ describe('GetPublishedProjects', () => {
     });
 
     it('should not mutate the original array from the repository', async () => {
-      const oldest = makeProject({ slug: 'oldest', period: { start: '2021-01-01T00:00:00.000Z' } });
-      const newest = makeProject({ slug: 'newest', period: { start: '2023-01-01T00:00:00.000Z' } });
+      const oldest = makeProject({
+        slug: 'oldest',
+        period: { start: '2021-01-01T00:00:00.000Z' },
+      });
+      const newest = makeProject({
+        slug: 'newest',
+        period: { start: '2023-01-01T00:00:00.000Z' },
+      });
       const original = [oldest, newest];
 
-      const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue(original) });
+      const repo = makeRepository({
+        findPublished: vi.fn().mockResolvedValue(original),
+      });
       const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       await useCase.execute({ locale: 'pt-BR' });
@@ -121,7 +145,9 @@ describe('GetPublishedProjects', () => {
 
     it('should map all DTO fields correctly for pt-BR locale', async () => {
       const project = makeProject();
-      const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([project]) });
+      const repo = makeRepository({
+        findPublished: vi.fn().mockResolvedValue([project]),
+      });
       const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const result = await useCase.execute({ locale: 'pt-BR' });
@@ -144,7 +170,9 @@ describe('GetPublishedProjects', () => {
       const project = makeProject({
         theme: { 'pt-BR': 'Tema PT', 'en-US': 'Theme EN' },
       });
-      const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([project]) });
+      const repo = makeRepository({
+        findPublished: vi.fn().mockResolvedValue([project]),
+      });
       const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 
       const ptResult = await useCase.execute({ locale: 'pt-BR' });
@@ -166,9 +194,14 @@ describe('GetPublishedProjects', () => {
       const skillId1 = 'a0000000-0000-4000-8000-000000000001';
       const skillId2 = 'a0000000-0000-4000-8000-000000000002';
       const project = makeProject({ skills: [skillId1, skillId2] });
-      const repo = makeRepository({ findPublished: vi.fn().mockResolvedValue([project]) });
+      const repo = makeRepository({
+        findPublished: vi.fn().mockResolvedValue([project]),
+      });
       const skillRepo = makeSkillRepository(
-        new Map([[skillId1, 'TypeScript'], [skillId2, 'React']]),
+        new Map([
+          [skillId1, { name: 'TypeScript', icon: '' }],
+          [skillId2, { name: 'React', icon: '' }],
+        ]),
       );
       const useCase = new GetPublishedProjects(repo, skillRepo);
 
@@ -176,12 +209,17 @@ describe('GetPublishedProjects', () => {
 
       expect(result.isRight()).toBe(true);
       const dto = (result.value as ProjectSummaryDTO[])[0]!;
-      expect(dto.skills).toEqual(['TypeScript', 'React']);
+      expect(dto.skills).toEqual([
+        { name: 'TypeScript', icon: '' },
+        { name: 'React', icon: '' },
+      ]);
     });
 
     it('should return Left with DomainError when repository throws', async () => {
       const repo = makeRepository({
-        findPublished: vi.fn().mockRejectedValue(new Error('DB connection failed')),
+        findPublished: vi
+          .fn()
+          .mockRejectedValue(new Error('DB connection failed')),
       });
       const useCase = new GetPublishedProjects(repo, makeSkillRepository());
 

--- a/packages/core/src/portfolio/entities/skill/repositories/ISkillRepository.ts
+++ b/packages/core/src/portfolio/entities/skill/repositories/ISkillRepository.ts
@@ -1,5 +1,10 @@
 import { Locale } from '../../../../shared';
 
+export type SkillInfo = { name: string; icon: string };
+
 export interface ISkillRepository {
-  findNamesByIds(ids: string[], locale: Locale): Promise<Map<string, string>>;
+  findNamesByIds(
+    ids: string[],
+    locale: Locale,
+  ): Promise<Map<string, SkillInfo>>;
 }

--- a/packages/infra/src/repositories/skill/PrismaSkillRepository.ts
+++ b/packages/infra/src/repositories/skill/PrismaSkillRepository.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import { ISkillRepository } from '@repo/core/portfolio';
+import { ISkillRepository, SkillInfo } from '@repo/core/portfolio';
 import { Locale } from '@repo/core/shared';
 
 export class PrismaSkillRepository implements ISkillRepository {
@@ -8,13 +8,14 @@ export class PrismaSkillRepository implements ISkillRepository {
   async findNamesByIds(
     ids: string[],
     locale: Locale,
-  ): Promise<Map<string, string>> {
+  ): Promise<Map<string, SkillInfo>> {
     if (ids.length === 0) return new Map();
     const rows = await this.db.skill.findMany({ where: { id: { in: ids } } });
     return new Map(
       rows.map((row) => {
         const desc = row.description as Record<string, string>;
-        return [row.id, desc[locale] ?? desc['en-US'] ?? row.id];
+        const name = desc[locale] ?? desc['en-US'] ?? row.id;
+        return [row.id, { name, icon: row.icon }];
       }),
     );
   }


### PR DESCRIPTION
## Summary

- **RSC streaming layout shift**: wraps each async Server Component section in its own `<Suspense>` boundary with an inline skeleton on home, about, and projects pages
- **Missing Tailwind classes**: adds `src/features/**` to `tailwind.config.ts` content scan — Épico 3 moved all product components from `src/components/View/` to `src/features/` but the content array was never updated, causing semantic token classes to go missing from the generated CSS
- **Skill icons in badges**: propagates `icon` field through the full stack (core `ISkillRepository`, `PrismaSkillRepository`, application DTOs and use cases, all web components) so each technology badge renders its icon before the name
- **Build error**: fixes `next/headers` imported into client bundle — `ProjectDetail` (`'use client'`) was importing from the `ProjectsSection` barrel which re-exports `HomeProjectsSection` (a server component that calls `next/headers`); now imports `ProjectList` directly from its source file

## Root Causes

**Streaming layout shift** — `ContactSection` is synchronous and resolved first, so Next.js immediately replaced the outer `B:0` boundary with the page shell. At that point `P:1` (HeroSection) and `P:2` (ProjectsSection) were empty `<template>` tags. ProjectsSection filled before HeroSection, making project images flash at the top of the page.

**Missing CSS classes** — Tailwind's `content` array controls which source files are scanned for utility class names. After Épico 3 moved components to `src/features/`, classes like `border-subtle`, `bg-surface/20`, `text-content-muted`, `line-clamp-*` were absent from the generated stylesheet.

**Client bundle contamination** — barrel `index.ts` re-exports both `ProjectList` (client-safe) and `HomeProjectsSection` (server-only). Any client component importing from the barrel pulled `next/headers` into the browser bundle.

## Test plan

- [ ] Hard refresh home, about, and projects pages — each section should show its skeleton independently before content fills in
- [ ] Verify semantic token classes (`border-subtle`, `text-content-muted`, etc.) are applied correctly across all pages
- [ ] Skill badges display icons before the technology name where an icon is configured
- [ ] Project detail page builds without the `next/headers` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)