### PR TITLE
refactor(web): move inline skeletons out of pages into feature directories

### DIFF
--- a/apps/web/src/app/[locale]/about/page.tsx
+++ b/apps/web/src/app/[locale]/about/page.tsx
@@ -1,71 +1,16 @@
 import { Suspense } from 'react';
 
 import { applyDevSimulations } from '~/dev/simulate';
-import { ExperiencesSection } from '~features/about/ExperiencesSection';
+import {
+  ExperiencesSection,
+  ExperiencesSkeleton,
+} from '~features/about/ExperiencesSection';
 import { HeroSection } from '~features/about/HeroSection';
-import { ValuesSection } from '~features/about/ValuesSection';
+import { ValuesSection, ValuesSkeleton } from '~features/about/ValuesSection';
+import { HeroBannerSkeleton } from '~features/shared/HeroBanner/HeroBannerSkeleton';
 
 interface AboutPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
-}
-
-function HeroSkeleton() {
-  return (
-    <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
-      <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
-        <div className="h-8 w-48 bg-gray-700 rounded" />
-        <div className="h-8 w-64 bg-gray-700 rounded" />
-        <div className="flex flex-col gap-y-2 pt-4">
-          <div className="h-4 bg-gray-700 rounded w-full" />
-          <div className="h-4 bg-gray-700 rounded w-5/6" />
-          <div className="h-4 bg-gray-700 rounded w-4/6" />
-        </div>
-      </section>
-      <section className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
-    </section>
-  );
-}
-
-function ValuesSkeleton() {
-  return (
-    <div className="animate-pulse">
-      <div className="h-8 w-64 bg-gray-700 rounded mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
-      <ul className="flex flex-row gap-x-4 mx-4 xl:mx-auto xl:max-w-237.5">
-        {(['val-1', 'val-2', 'val-3', 'val-4'] as const).map((key) => (
-          <li
-            key={key}
-            className="w-full max-w-56 border border-dark-300 px-4 py-6 rounded-xl bg-dark-300/20 flex flex-col gap-y-3"
-          >
-            <div className="h-12 w-12 bg-gray-700 rounded" />
-            <div className="h-4 bg-gray-700 rounded w-full" />
-            <div className="h-4 bg-gray-700 rounded w-4/5" />
-            <div className="h-4 bg-gray-700 rounded w-3/5" />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function ExperiencesSkeleton() {
-  return (
-    <div className="animate-pulse">
-      <div className="h-px bg-gray-700 mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
-      <ul className="flex flex-col mx-4 gap-y-3 xl:mx-auto xl:max-w-237.5">
-        {(['exp-1', 'exp-2', 'exp-3'] as const).map((key) => (
-          <li
-            key={key}
-            className="flex flex-col py-6 px-3 bg-dark-200 rounded-xl gap-y-3"
-          >
-            <div className="h-5 w-3/5 bg-gray-700 rounded" />
-            <div className="h-4 w-2/5 bg-gray-700 rounded" />
-            <div className="h-4 bg-gray-700 rounded w-full" />
-            <div className="h-4 bg-gray-700 rounded w-5/6" />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
 }
 
 export default async function About({ searchParams }: AboutPageProps) {
@@ -73,7 +18,7 @@ export default async function About({ searchParams }: AboutPageProps) {
 
   return (
     <>
-      <Suspense fallback={<HeroSkeleton />}>
+      <Suspense fallback={<HeroBannerSkeleton />}>
         <HeroSection />
       </Suspense>
       <Suspense fallback={<ValuesSkeleton />}>

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,50 +1,16 @@
 import { Suspense } from 'react';
 
 import { applyDevSimulations } from '~/dev/simulate';
-import { ContactSection } from '~features/contact/ContactSection';
 import { HeroSection } from '~features/home/HeroSection';
-import { ProjectsSection } from '~features/home/ProjectsSection';
+import {
+  ProjectsSection,
+  ProjectsSkeleton,
+} from '~features/home/ProjectsSection';
+import { HeroBannerSkeleton } from '~features/shared/HeroBanner/HeroBannerSkeleton';
+import { ContactSection } from '~features/contact/ContactSection';
 
 interface HomePageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
-}
-
-function HeroSkeleton() {
-  return (
-    <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
-      <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
-        <div className="h-8 w-48 bg-gray-700 rounded" />
-        <div className="h-8 w-64 bg-gray-700 rounded" />
-        <div className="flex flex-col gap-y-2 pt-4">
-          <div className="h-4 bg-gray-700 rounded w-full" />
-          <div className="h-4 bg-gray-700 rounded w-5/6" />
-          <div className="h-4 bg-gray-700 rounded w-4/6" />
-        </div>
-      </section>
-      <section className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
-    </section>
-  );
-}
-
-function ProjectsSkeleton() {
-  return (
-    <div className="animate-pulse">
-      <div className="w-full flex justify-start mx-4 my-6 xl:mx-auto xl:max-w-237.5">
-        <div className="h-8 w-32 bg-gray-700 rounded" />
-      </div>
-      <ul className="mx-auto grid max-w-237.5 gap-4 md:grid-cols-2 xl:gap-6 pb-8 xl:pb-20">
-        {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
-          <li key={key} className="bg-surface p-3 rounded-5">
-            <div className="h-45 xl:h-61 bg-gray-700 rounded-lg mb-4" />
-            <div className="h-5 w-3/4 bg-gray-700 rounded mb-2" />
-            <div className="h-4 bg-gray-700 rounded mb-1" />
-            <div className="h-4 w-5/6 bg-gray-700 rounded mb-5" />
-            <div className="h-10 bg-gray-700 rounded" />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
 }
 
 export default async function Home({ searchParams }: HomePageProps) {
@@ -52,7 +18,7 @@ export default async function Home({ searchParams }: HomePageProps) {
 
   return (
     <>
-      <Suspense fallback={<HeroSkeleton />}>
+      <Suspense fallback={<HeroBannerSkeleton />}>
         <HeroSection />
       </Suspense>
       <Suspense fallback={<ProjectsSkeleton />}>

--- a/apps/web/src/app/[locale]/projects/page.tsx
+++ b/apps/web/src/app/[locale]/projects/page.tsx
@@ -3,47 +3,11 @@ import { Suspense } from 'react';
 import { applyDevSimulations } from '~/dev/simulate';
 import { HeroSection } from '~features/projects/HeroSection';
 import { ProjectsSection } from '~features/projects/ProjectsSection';
+import { ProjectsSkeleton } from '~features/home/ProjectsSection';
+import { HeroBannerSkeleton } from '~features/shared/HeroBanner/HeroBannerSkeleton';
 
 interface ProjectsPageProps {
   searchParams?: Promise<{ loading?: string; error?: string }>;
-}
-
-function HeroSkeleton() {
-  return (
-    <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
-      <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
-        <div className="h-8 w-36 bg-gray-700 rounded" />
-        <div className="h-8 w-56 bg-gray-700 rounded" />
-        <div className="flex flex-col gap-y-2 pt-4">
-          <div className="h-4 bg-gray-700 rounded w-full" />
-          <div className="h-4 bg-gray-700 rounded w-5/6" />
-          <div className="h-4 bg-gray-700 rounded w-4/6" />
-        </div>
-      </section>
-      <section className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
-    </section>
-  );
-}
-
-function ProjectsSkeleton() {
-  return (
-    <div className="animate-pulse">
-      <div className="w-full flex justify-start mx-4 my-6 xl:mx-auto xl:max-w-237.5">
-        <div className="h-8 w-32 bg-gray-700 rounded" />
-      </div>
-      <ul className="mx-auto grid max-w-237.5 gap-4 md:grid-cols-2 xl:gap-6 pb-8 xl:pb-20">
-        {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
-          <li key={key} className="bg-surface p-3 rounded-5">
-            <div className="h-45 xl:h-61 bg-gray-700 rounded-lg mb-4" />
-            <div className="h-5 w-3/4 bg-gray-700 rounded mb-2" />
-            <div className="h-4 bg-gray-700 rounded mb-1" />
-            <div className="h-4 w-5/6 bg-gray-700 rounded mb-5" />
-            <div className="h-10 bg-gray-700 rounded" />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
 }
 
 export default async function Projects({ searchParams }: ProjectsPageProps) {
@@ -51,7 +15,7 @@ export default async function Projects({ searchParams }: ProjectsPageProps) {
 
   return (
     <>
-      <Suspense fallback={<HeroSkeleton />}>
+      <Suspense fallback={<HeroBannerSkeleton />}>
         <HeroSection />
       </Suspense>
       <Suspense fallback={<ProjectsSkeleton />}>

--- a/apps/web/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx
+++ b/apps/web/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx
@@ -1,0 +1,20 @@
+export function ExperiencesSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="h-px bg-gray-700 mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
+      <ul className="flex flex-col mx-4 gap-y-3 xl:mx-auto xl:max-w-237.5">
+        {(['exp-1', 'exp-2', 'exp-3'] as const).map((key) => (
+          <li
+            key={key}
+            className="flex flex-col py-6 px-3 bg-dark-200 rounded-xl gap-y-3"
+          >
+            <div className="h-5 w-3/5 bg-gray-700 rounded" />
+            <div className="h-4 w-2/5 bg-gray-700 rounded" />
+            <div className="h-4 bg-gray-700 rounded w-full" />
+            <div className="h-4 bg-gray-700 rounded w-5/6" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/features/about/ExperiencesSection/index.ts
+++ b/apps/web/src/features/about/ExperiencesSection/index.ts
@@ -1,2 +1,3 @@
 export * from './ExperienceCard';
 export { ExperiencesSection } from './ExperiencesSection';
+export { ExperiencesSkeleton } from './ExperiencesSkeleton';

--- a/apps/web/src/features/about/ValuesSection/ValuesSkeleton.tsx
+++ b/apps/web/src/features/about/ValuesSection/ValuesSkeleton.tsx
@@ -1,0 +1,20 @@
+export function ValuesSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="h-8 w-64 bg-gray-700 rounded mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
+      <ul className="flex flex-row gap-x-4 mx-4 xl:mx-auto xl:max-w-237.5">
+        {(['val-1', 'val-2', 'val-3', 'val-4'] as const).map((key) => (
+          <li
+            key={key}
+            className="w-full max-w-56 border border-dark-300 px-4 py-6 rounded-xl bg-dark-300/20 flex flex-col gap-y-3"
+          >
+            <div className="h-12 w-12 bg-gray-700 rounded" />
+            <div className="h-4 bg-gray-700 rounded w-full" />
+            <div className="h-4 bg-gray-700 rounded w-4/5" />
+            <div className="h-4 bg-gray-700 rounded w-3/5" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/features/about/ValuesSection/index.ts
+++ b/apps/web/src/features/about/ValuesSection/index.ts
@@ -1,2 +1,3 @@
 export * from './ProfessionalValue';
 export { ValuesSection } from './ValuesSection';
+export { ValuesSkeleton } from './ValuesSkeleton';

--- a/apps/web/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
+++ b/apps/web/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
@@ -1,0 +1,20 @@
+export function ProjectsSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="w-full flex justify-start mx-4 my-6 xl:mx-auto xl:max-w-237.5">
+        <div className="h-8 w-32 bg-gray-700 rounded" />
+      </div>
+      <ul className="mx-auto grid max-w-237.5 gap-4 md:grid-cols-2 xl:gap-6 pb-8 xl:pb-20">
+        {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
+          <li key={key} className="bg-surface p-3 rounded-5">
+            <div className="h-45 xl:h-61 bg-gray-700 rounded-lg mb-4" />
+            <div className="h-5 w-3/4 bg-gray-700 rounded mb-2" />
+            <div className="h-4 bg-gray-700 rounded mb-1" />
+            <div className="h-4 w-5/6 bg-gray-700 rounded mb-5" />
+            <div className="h-10 bg-gray-700 rounded" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/features/home/ProjectsSection/index.ts
+++ b/apps/web/src/features/home/ProjectsSection/index.ts
@@ -1,3 +1,4 @@
 export * from './ProjectCard';
 export * from './ProjectList';
 export { ProjectsSection } from './HomeProjectsSection';
+export { ProjectsSkeleton } from './ProjectsSkeleton';

--- a/apps/web/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
+++ b/apps/web/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
@@ -1,0 +1,16 @@
+export function HeroBannerSkeleton() {
+  return (
+    <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
+      <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
+        <div className="h-8 w-48 bg-gray-700 rounded" />
+        <div className="h-8 w-64 bg-gray-700 rounded" />
+        <div className="flex flex-col gap-y-2 pt-4">
+          <div className="h-4 bg-gray-700 rounded w-full" />
+          <div className="h-4 bg-gray-700 rounded w-5/6" />
+          <div className="h-4 bg-gray-700 rounded w-4/6" />
+        </div>
+      </section>
+      <section className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
+    </section>
+  );
+}

--- a/apps/web/tests/app/[locale]/about.test.tsx
+++ b/apps/web/tests/app/[locale]/about.test.tsx
@@ -15,10 +15,16 @@ vi.mock('~features/about/HeroSection', () => ({
 
 vi.mock('~features/about/ValuesSection', () => ({
   ValuesSection: () => <div data-testid="values-section" />,
+  ValuesSkeleton: () => null,
 }));
 
 vi.mock('~features/about/ExperiencesSection', () => ({
   ExperiencesSection: () => <div data-testid="experiences-section" />,
+  ExperiencesSkeleton: () => null,
+}));
+
+vi.mock('~features/shared/HeroBanner/HeroBannerSkeleton', () => ({
+  HeroBannerSkeleton: () => null,
 }));
 
 describe('About page', () => {

--- a/apps/web/tests/app/[locale]/home.test.tsx
+++ b/apps/web/tests/app/[locale]/home.test.tsx
@@ -15,6 +15,11 @@ vi.mock('~features/home/HeroSection', () => ({
 
 vi.mock('~features/home/ProjectsSection', () => ({
   ProjectsSection: () => <div data-testid="projects-section" />,
+  ProjectsSkeleton: () => null,
+}));
+
+vi.mock('~features/shared/HeroBanner/HeroBannerSkeleton', () => ({
+  HeroBannerSkeleton: () => null,
 }));
 
 vi.mock('~features/contact/ContactSection', () => ({

--- a/apps/web/tests/app/[locale]/projects.test.tsx
+++ b/apps/web/tests/app/[locale]/projects.test.tsx
@@ -17,6 +17,14 @@ vi.mock('~features/projects/ProjectsSection', () => ({
   ProjectsSection: () => <div data-testid="projects-section" />,
 }));
 
+vi.mock('~features/home/ProjectsSection', () => ({
+  ProjectsSkeleton: () => null,
+}));
+
+vi.mock('~features/shared/HeroBanner/HeroBannerSkeleton', () => ({
+  HeroBannerSkeleton: () => null,
+}));
+
 describe('Projects page', () => {
   it('should render all feature sections', async () => {
     const { default: Projects } = await import(


### PR DESCRIPTION
## Summary

- Skeleton components previously defined inline inside the page files are now co-located with the feature section they represent
- Each section exports its own skeleton from its barrel; pages import them instead of declaring them locally
- Page-level test mocks updated to include the new skeleton exports

## Skeleton placement

| Skeleton | Location |
|---|---|
| `HeroBannerSkeleton` | `features/shared/HeroBanner/HeroBannerSkeleton.tsx` |
| `ProjectsSkeleton` | `features/home/ProjectsSection/ProjectsSkeleton.tsx` |
| `ValuesSkeleton` | `features/about/ValuesSection/ValuesSkeleton.tsx` |
| `ExperiencesSkeleton` | `features/about/ExperiencesSection/ExperiencesSkeleton.tsx` |

## Test plan

- [ ] All 178 unit tests pass (`pnpm --filter web run test`)
- [ ] Pages render with skeleton fallbacks during section loading (Suspense boundaries unchanged)

Refs #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)