### PR TITLE
chore: add MVP Round 2 PRD and Task Master planning

### DIFF
--- a/.taskmaster/docs/mvp-round-2.md
+++ b/.taskmaster/docs/mvp-round-2.md
@@ -1,0 +1,193 @@
+# PRD — MVP Round 2
+
+## Overview
+
+MVP Round 2 is the final set of work items required before launching the portfolio publicly. The goal is to close gaps in quality, data realism, architectural correctness, and i18n coverage. Reference design: [Paul Scanlon's portfolio](https://www.paulie.dev/).
+
+All items map to GitHub issues in the **MVP Round 2** milestone (issues #543, #588–#594).
+
+---
+
+## 1. Endpoint Testing
+
+**GitHub issue:** #588  
+**Priority:** High
+
+Manually validate every route handler under `/api/v1/` against the documented response envelope contract (`{ data, error }`). Cover happy path and key error cases (400, 401, 404, 500) for all public, auth, identity, and admin endpoints.
+
+### Scope
+
+- Public portfolio: `GET /api/v1/projects`, `/projects/featured`, `/projects/:slug`, `/experiences`, `/profile`
+- Contact: `POST /api/v1/contact` (including rate-limit check)
+- Auth: `POST /api/v1/auth/sign-in`, `sign-out`, `refresh`
+- Identity: `GET /api/v1/me`
+- Admin: all routes under `/api/v1/admin/*` (projects CRUD, publish/archive, profile, experiences CRUD)
+
+### Acceptance criteria
+
+- Every endpoint returns the correct envelope and HTTP status
+- Error cases (missing auth, not admin, not found, invalid input) return correct codes
+- Findings documented; broken endpoints tracked as follow-up issues
+
+---
+
+## 2. Realistic Seed Data
+
+**GitHub issue:** #590  
+**Priority:** Medium
+
+Replace placeholder seeds with content close to the real portfolio: real projects, real experiences, real skills, and a realistic profile. Seeds must run without errors via `pnpm prisma db seed`.
+
+### Scope
+
+- `packages/infra/prisma/seed.ts`
+- Entities: `Project`, `Experience`, `Skill`, `Profile`
+
+### Acceptance criteria
+
+- Seeds reflect real or near-real data for all entities
+- `pnpm prisma db seed` completes without errors
+- At least 2 published projects and 2 experiences in the seed
+
+---
+
+## 3. i18n in Core — LocalizedText and Domain Error Messages
+
+**GitHub issue:** #591  
+**Priority:** High
+
+Implement full i18n support in `@repo/core`: ensure `ERROR_MESSAGE` covers all existing error codes for `pt-BR` and `en-US`, and audit all domain entities and VOs to use stable codes rather than inline strings.
+
+### Scope
+
+- `packages/core/src/shared/i18n/` — `ERROR_MESSAGE`, `Locale`
+- All entities and VOs that produce `ValidationError`
+
+### Acceptance criteria
+
+- `ERROR_MESSAGE` has entries for all codes in `pt-BR` and `en-US`
+- Domain code never produces a human-readable string directly — only a code
+- Edge (`apps/site`) resolves messages from `ERROR_MESSAGE[locale][code]`
+- Unit tests verify code-to-message resolution
+
+---
+
+## 4. Remove Hardcoded Strings from @repo/core
+
+**GitHub issue:** #592  
+**Priority:** Medium  
+**Depends on:** #591 (i18n in core)
+
+Replace any remaining hardcoded human-readable strings in `@repo/core` with stable error codes that can be resolved to localized messages at the edge.
+
+### Scope
+
+- `packages/core/src/` — entities, VOs, error constructors
+
+### Acceptance criteria
+
+- No plain human-readable string literals in `ValidationError` or `DomainError` instantiations beyond the `code` field
+- All `ValidationError` instances use a static `ERROR_CODE` constant
+- ESLint passes; existing tests updated if needed
+
+---
+
+## 5. Application-Layer Orchestration Audit
+
+**GitHub issue:** #543  
+**Priority:** High
+
+Audit route handlers in `apps/site/app/api/` to ensure no application-layer orchestration logic (branching on domain results, multiple use-case calls in sequence, business decisions) leaks into the web adapter. Route handlers should: resolve the container, call one use case, map the result to HTTP.
+
+### Scope
+
+- `apps/site/app/api/` — all route handlers
+- `packages/application/` — use cases (may need extraction of orchestration logic)
+
+### Acceptance criteria
+
+- Each route handler calls exactly one use case (or delegates to a thin orchestrator use case)
+- No `if/else` on domain model internals inside route handlers
+- Architecture ESLint rules pass
+
+---
+
+## 6. Move Admin and Login to apps/admin
+
+**GitHub issue:** #593  
+**Priority:** Medium
+
+Extract `/{locale}/login` and `/{locale}/admin/*` from `apps/site` into a new dedicated `apps/admin` Next.js app. The public portfolio app should contain no admin or login routes.
+
+### Scope
+
+- Create `apps/admin` with Next.js App Router
+- Move login and admin pages
+- Scope auth middleware to `apps/admin`
+- Update `turbo.json`, root `package.json`, and workspace config
+
+### Acceptance criteria
+
+- `apps/site` has no login or admin routes
+- `apps/admin` runs independently (`pnpm --filter admin dev`)
+- Both apps build without errors
+- Auth middleware only active in `apps/admin`
+
+---
+
+## 7. Figma Styling Review
+
+**GitHub issue:** #589  
+**Priority:** Medium
+
+Conduct a Figma review round to identify components that are unfinished or need visual changes before launch. Implement all identified changes in `@repo/ui` and `apps/site`.
+
+### Scope
+
+- `packages/ui/src/` — design system components
+- `apps/site/src/` — page-level layout and feature components
+
+### Acceptance criteria
+
+- All components reviewed against the Figma design
+- List of required changes documented and implemented
+- No obvious visual regressions on Home, Projects, About pages
+
+---
+
+## 8. General Code Review
+
+**GitHub issue:** #594  
+**Priority:** High
+
+Quality pass across the full codebase before MVP launch. Enforce architectural rules, remove `any` types, verify the REST boundary is respected, and ensure all tests pass.
+
+### Scope
+
+- All packages and apps
+
+### Acceptance criteria
+
+- Zero `any` types across TypeScript codebase
+- No direct imports between bounded contexts
+- No use cases called from pages, layouts, or client components
+- No `@supabase/*` outside `@repo/infra`
+- All route handlers follow the response envelope
+- `pnpm lint` and `pnpm test` pass with zero errors
+
+---
+
+## Dependencies Between Tasks
+
+```
+#591 (i18n in core) → #592 (remove hardcoded strings)
+#588 (endpoint testing) → #594 (general code review) [inform findings]
+#543 (app layer audit) → #594 (general code review)
+```
+
+## Out of Scope (Post-MVP)
+
+- Blog (`apps/blog`)
+- `IAuthenticationGateway` full implementation
+- Playwright E2E tests
+- CI/CD re-enablement

--- a/.taskmaster/reports/task-complexity-report_mvp-round-2.json
+++ b/.taskmaster/reports/task-complexity-report_mvp-round-2.json
@@ -1,0 +1,93 @@
+{
+	"meta": {
+		"generatedAt": "2026-05-20T23:00:40.201Z",
+		"tasksAnalyzed": 10,
+		"totalTasks": 10,
+		"analysisCount": 10,
+		"thresholdScore": 5,
+		"projectName": "Task Master",
+		"usedResearch": false
+	},
+	"complexityAnalysis": [
+		{
+			"taskId": 1,
+			"taskTitle": "Implement ERROR_MESSAGE i18n Dictionary in @repo/core",
+			"complexityScore": 7,
+			"recommendedSubtasks": 5,
+			"expansionPrompt": "Break this task into: (1) audit all ERROR_CODE constants across 20 entities/VOs (Slug, Name, Text, Email, Url, Id, Image, DateTime, DateRange, LocalizedText, Project, Experience, Skill, Profile, User, etc.), (2) create ERROR_MESSAGE.ts file with Record<Locale, Record<string, { message: string }>> structure, (3) populate with pt-BR and en-US translations for each code, (4) create getErrorMessage helper with locale fallback logic, (5) update ValidationError/NotFoundError/UnauthorizedError constructors to accept only code, and (6) write comprehensive unit tests for dictionary completeness and fallback behavior.",
+			"reasoning": "MODERATE-HIGH complexity. I found 20 files with ERROR_CODE constants across packages/core/src. Each file has 1-4 error codes (totaling ~30-40 codes). The dictionary structure is straightforward, but requires meticulous auditing to ensure no codes are missed. Translation for pt-BR adds work. The helper function and error class updates are simple but critical. Test coverage requirements add complexity."
+		},
+		{
+			"taskId": 2,
+			"taskTitle": "Remove Hardcoded Error Messages from @repo/core Domain Code",
+			"complexityScore": 6,
+			"recommendedSubtasks": 4,
+			"expansionPrompt": "Break this task into: (1) audit and update all VOs (Slug, Name, Text, Email, Url, Id, Image, DateTime, DateRange, LocalizedText) to remove inline messages from ValidationError instantiations, (2) audit and update all entities (Project, Experience, Skill, Profile, User, Language, SocialNetwork, ProfessionalValue, ProfileStat) to use code-only ValidationError, (3) update ValidationError constructor to make message optional with default 'Validation failed', (4) run grep to verify zero string literals remain in error instantiations, and (5) add unit tests verifying all ValidationError instances use ERROR_CODE only.",
+			"reasoning": "MODERATE complexity. I found 24 files with ValidationError usage. Current pattern is: new ValidationError({ code: Foo.ERROR_CODE, message: 'text' }). Need to change to: new ValidationError({ code: Foo.ERROR_CODE }). This is a repetitive but straightforward refactor. The ValidationError constructor change is trivial. Risk is low since tests will catch any missed instances. Depends on task #1 being complete."
+		},
+		{
+			"taskId": 3,
+			"taskTitle": "Manual Endpoint Testing — Public Portfolio Routes",
+			"complexityScore": 5,
+			"recommendedSubtasks": 3,
+			"expansionPrompt": "Break this task into: (1) set up local environment (pnpm dev, pnpm seed), create manual test script/Postman collection, (2) test all public endpoints (GET /api/v1/projects, /projects/featured, /projects/:slug, /experiences, /profile, /professional-values) for happy path (200, correct envelope), not found (404), and invalid input (400), (3) document all findings in .taskmaster/docs/endpoint-testing-results.md with detailed results table, and (4) create follow-up GitHub issues for any broken endpoints.",
+			"reasoning": "MODERATE complexity. I found 18 route handlers in apps/site/src/app/api/v1/. Public routes are simpler (no auth). Most handlers follow clean pattern: resolve container → call use case → return handleRequest. Testing is manual but straightforward. Main complexity is methodical documentation and edge case discovery. Depends on tasks #1 and #2 for error message verification."
+		},
+		{
+			"taskId": 4,
+			"taskTitle": "Manual Endpoint Testing — Contact, Auth, Identity, and Admin Routes",
+			"complexityScore": 7,
+			"recommendedSubtasks": 5,
+			"expansionPrompt": "Break this task into: (1) test contact endpoint (POST /api/v1/contact) for valid/invalid payloads and rate-limiting, (2) test auth endpoints (sign-in, sign-out, refresh) for valid/invalid credentials and session management, (3) test identity endpoint (GET /api/v1/me) with and without session, (4) set up admin user via seed and test all admin CRUD endpoints (projects, experiences, profile) with authorization checks (401 without auth, 401 with non-admin), and (5) document findings and create follow-up issues.",
+			"reasoning": "MODERATE-HIGH complexity. Auth and admin routes require session management, authorization testing, and rate-limiting verification. More edge cases than public routes. I observed route handlers in apps/site/src/app/api/v1/admin/* with EnsureAdmin checks. Auth may be partially implemented per docs/11-IDENTITY.md. Requires careful documentation of current state vs. expected behavior. Depends on task #3."
+		},
+		{
+			"taskId": 5,
+			"taskTitle": "Create Realistic Seed Data",
+			"complexityScore": 4,
+			"recommendedSubtasks": 3,
+			"expansionPrompt": "Break this task into: (1) update Profile, Skills, and ProfessionalValues in packages/infra/prisma/seed.ts with realistic content (real name, bio 100-200 words, better photo text), (2) replace Projects array with 2-4 real projects (meaningful titles, captions, content 200+ words, correct skills, periods, ensure 2+ PUBLISHED featured), (3) replace Experiences array with 2-3 real experiences (accurate companies, positions, rich descriptions 150+ words, real dates), (4) run pnpm prisma db seed to verify zero errors, and (5) manually verify data appears correctly in UI.",
+			"reasoning": "LOW-MODERATE complexity. I reviewed packages/infra/prisma/seed.ts — it's well-structured with stable IDs and idempotent upserts. Current data is generic but structurally sound. Main work is content writing (bio, descriptions, etc.), not code changes. Seeders use good patterns (loc helper, img helper). Low technical risk. Main effort is content creation and verification."
+		},
+		{
+			"taskId": 6,
+			"taskTitle": "Audit Application-Layer Orchestration in Route Handlers",
+			"complexityScore": 6,
+			"recommendedSubtasks": 4,
+			"expansionPrompt": "Break this task into: (1) review all 18 route handlers in apps/site/src/app/api/v1/ and identify violations (if/else branching on domain internals, multiple use-case calls with business decisions, business logic in handlers), (2) for each violation, extract orchestration into new use case or enhance existing use case, (3) refactor route handlers to follow pattern: resolve container → call one use case → mapToHttpResponse, (4) document all findings in .taskmaster/docs/orchestration-audit.md with violation details and refactor recommendations, and (5) create follow-up GitHub issues for non-critical refactors.",
+			"reasoning": "MODERATE complexity. I reviewed route handlers — most follow clean pattern (e.g., GET /api/v1/projects calls one use case). However, admin routes like POST /api/v1/admin/projects have auth checks (resolveSessionUserId) before use case call, which is acceptable. Need to identify true violations (business logic in handlers). Manual code review is time-consuming. Refactors may touch multiple files. ESLint architecture rules help verify."
+		},
+		{
+			"taskId": 7,
+			"taskTitle": "Create apps/admin and Move Login/Admin Routes",
+			"complexityScore": 8,
+			"recommendedSubtasks": 6,
+			"expansionPrompt": "Break this task into: (1) create new Next.js app with pnpm create next-app apps/admin, (2) move /{locale}/login and /{locale}/admin/* pages from apps/site to apps/admin, (3) move middleware.ts from apps/site to apps/admin (scope to admin only), (4) copy necessary dependencies, components, and utilities to apps/admin or move to @repo/ui, (5) update turbo.json (add admin#build, admin#dev, admin#lint), root package.json (dev:admin, build:admin), and workspace config, (6) verify apps/site has zero login/admin routes remaining (grep for 'admin', 'login'), and (7) test both apps run independently (pnpm --filter site dev, pnpm --filter admin dev) and build successfully (pnpm build).",
+			"reasoning": "MODERATE-HIGH complexity. I found apps/site/src/app/[locale]/login/page.tsx and apps/site/src/app/[locale]/admin/* pages. This is a significant structural change affecting build config, middleware, routing, and shared dependencies. Need to ensure clean separation without breaking existing functionality. Monorepo tooling (Turbo, pnpm workspaces) adds complexity. Testing both apps independently is critical. Risk of missing shared components or utilities."
+		},
+		{
+			"taskId": 8,
+			"taskTitle": "Figma Styling Review and Component Updates",
+			"complexityScore": 7,
+			"recommendedSubtasks": 5,
+			"expansionPrompt": "Break this task into: (1) review Figma design against current implementation for all pages (Home, Projects, About, Contact, Admin) and document discrepancies (missing components, incorrect spacing/typography/colors, inconsistent variants, responsive issues), (2) create checklist in .taskmaster/docs/figma-review-checklist.md prioritizing by visual impact, (3) implement changes in @repo/ui components (Button, Card, Input, etc.) to match design tokens, (4) update page layouts in apps/site/src/app/[locale]/* and test responsive breakpoints (mobile 375px, tablet 768px, desktop 1440px), and (5) perform visual regression testing (before/after screenshots, verify typography hierarchy, color palette, interactive states).",
+			"reasoning": "MODERATE-HIGH complexity. I found 19 page/layout files in apps/site/src/app/[locale]/**/*.tsx. Design review is subjective and time-consuming. Requires access to Figma file. Component updates may cascade to multiple pages. Responsive testing across breakpoints adds effort. Visual regression requires careful comparison. Reference to Paul Scanlon's portfolio suggests high design standards. Risk of scope creep if many discrepancies found."
+		},
+		{
+			"taskId": 9,
+			"taskTitle": "General Code Quality Review and Cleanup",
+			"complexityScore": 8,
+			"recommendedSubtasks": 6,
+			"expansionPrompt": "Break this task into: (1) eliminate all 'any' types across packages/core, packages/application, apps/site/src/app/api (grep -r 'any', replace with explicit types or unknown), (2) verify architectural boundaries (no cross-context imports portfolio ↔ identity, no use cases in pages/layouts/client components, no @repo/application in apps/site pages except route handlers, no @supabase outside @repo/infra), (3) verify REST boundary (all route handlers follow envelope: { data, error }, correct HTTP status codes, no domain logic in handlers), (4) run all tests and fix failures (pnpm test:core, test:utils, test:site, test), (5) run linters and fix violations (pnpm lint, pnpm format, pnpm types), and (6) document remaining technical debt in GitHub issues.",
+			"reasoning": "HIGH complexity. This is a comprehensive quality pass touching many areas. I found 7 'any' usages in packages/core/src (low but non-zero). 288 test files exist — running all tests and fixing failures is time-consuming. Architectural boundary verification requires extensive grepping and manual review. I confirmed @repo/application is only imported in apps/site/src/app/api/* route handlers (correct). ESLint/Prettier/TypeScript checks may surface many issues. Depends on tasks #2 and #6."
+		},
+		{
+			"taskId": 10,
+			"taskTitle": "Document Findings and Create Follow-up Issues",
+			"complexityScore": 5,
+			"recommendedSubtasks": 4,
+			"expansionPrompt": "Break this task into: (1) review all documentation created during tasks #3, #4, #6, #8, #9 (.taskmaster/docs/endpoint-testing-results.md, orchestration-audit.md, figma-review-checklist.md, code quality notes), (2) for each finding, assess severity (blocker, critical, medium, low) and determine if launch-blocking or post-MVP, (3) create GitHub issues with gh issue create (proper labels: bug, refactor, enhancement, milestone: MVP Round 2, link to parent issues #588, #543, #589, #594), (4) create launch checklist in .taskmaster/docs/launch-checklist.md (tests passing, endpoints working, realistic seed data, Figma match, zero violations, docs updated, admin app separated if task #7 complete), (5) update project README with MVP Round 2 status, known post-MVP work, deployment instructions, and (6) perform final smoke test (view projects, submit contact form, admin login).",
+			"reasoning": "MODERATE complexity. Consolidation task depending on outputs from tasks #3, #4, #6, #8, #9. Main work is synthesis, prioritization, and issue creation. GitHub CLI (gh issue create) makes issue creation straightforward. Launch checklist creation is critical but manageable. Final smoke test is manual but scoped. Risk is missing findings if dependent tasks are incomplete. Depends on tasks #3, #4, #6, #8, #9."
+		}
+	]
+}

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -4973,7 +4973,72 @@
         "priority": "medium",
         "dependencies": [],
         "status": "pending",
-        "subtasks": []
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Create new Next.js admin app with pnpm",
+            "description": "Initialize a new Next.js application in apps/admin using pnpm create next-app with TypeScript, App Router, Tailwind, and no src directory",
+            "dependencies": [],
+            "details": "Run `pnpm create next-app apps/admin --typescript --app --tailwind --no-src-dir` to scaffold the new admin application. Verify the app structure matches monorepo conventions (no src/ directory, uses app/ router). Ensure package.json is created with correct name (@repo/admin or similar). Create basic app/layout.tsx and app/page.tsx if not auto-generated. This establishes the foundation for the admin app before moving routes.",
+            "status": "pending",
+            "testStrategy": "Verify apps/admin directory exists with correct structure (app/, package.json, tsconfig.json, tailwind.config.ts). Run `pnpm install` at root to ensure workspace recognizes new app. Test `pnpm --filter admin dev` starts successfully (even if showing default Next.js page)."
+          },
+          {
+            "id": 2,
+            "title": "Move login and admin routes from apps/site to apps/admin",
+            "description": "Migrate all /{locale}/login and /{locale}/admin/* pages from apps/site to apps/admin, preserving [locale] dynamic routing structure",
+            "dependencies": [
+              1
+            ],
+            "details": "Move apps/site/src/app/[locale]/login/page.tsx to apps/admin/app/[locale]/login/page.tsx. Move all pages under apps/site/src/app/[locale]/admin/* to apps/admin/app/[locale]/admin/*. Preserve directory structure and file names exactly. Update any relative imports in moved files to reflect new app location. Delete original files from apps/site after successful move. Ensure [locale] param handling remains consistent.",
+            "status": "pending",
+            "testStrategy": "Verify apps/site no longer contains login or admin directories under app/[locale]/. Verify apps/admin/app/[locale]/login/page.tsx and apps/admin/app/[locale]/admin/* exist. Grep apps/site for 'admin' and 'login' route references (should return zero results in app/ directory)."
+          },
+          {
+            "id": 3,
+            "title": "Move and scope middleware.ts to apps/admin",
+            "description": "Transfer authentication middleware from apps/site to apps/admin and configure it to only protect admin routes, removing it from public site",
+            "dependencies": [
+              2
+            ],
+            "details": "Move apps/site/middleware.ts to apps/admin/middleware.ts. Update middleware config.matcher to scope only to admin app routes (e.g., matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'] or more specific to /[locale]/admin/* and /[locale]/login). Remove any middleware configuration from apps/site. Verify middleware only runs for admin app pages. Update any auth redirect logic to point to admin app login route.",
+            "status": "pending",
+            "testStrategy": "Run `pnpm --filter admin dev` and verify middleware executes on /login and /admin/* routes. Run `pnpm --filter site dev` and verify NO middleware executes (check network tab for middleware headers/redirects). Test unauthenticated access to admin routes redirects to /login. Verify public site routes are not protected."
+          },
+          {
+            "id": 4,
+            "title": "Copy dependencies and shared components to apps/admin or @repo/ui",
+            "description": "Identify and migrate all dependencies, components, utilities, and types used by admin/login pages to apps/admin or promote to @repo/ui if shared",
+            "dependencies": [
+              3
+            ],
+            "details": "Analyze moved pages for imports (components, utilities, hooks, types). For admin-specific code, copy to apps/admin/components, apps/admin/lib, apps/admin/types. For potentially shared UI components, move to packages/ui/src and update imports in both apps. Update apps/admin/package.json with required dependencies (next-intl, auth libs, form libraries, etc.). Ensure no broken imports remain in apps/admin. Update tsconfig paths if needed for @repo/* imports.",
+            "status": "pending",
+            "testStrategy": "Run `pnpm --filter admin build` and verify zero module resolution errors. Check all imports resolve correctly. Run `pnpm --filter site build` to ensure no regressions. Test that shared components in @repo/ui work in both apps if moved. Verify apps/admin/package.json has all necessary dependencies."
+          },
+          {
+            "id": 5,
+            "title": "Update turbo.json, root package.json, and workspace config",
+            "description": "Configure Turborepo, root scripts, and pnpm workspace to recognize and build apps/admin alongside apps/site",
+            "dependencies": [
+              4
+            ],
+            "details": "In turbo.json, add pipeline entries: `admin#build`, `admin#dev`, `admin#lint`, `admin#type-check` mirroring site app config. Set correct `dependsOn` and `outputs` for admin tasks. Add environment variables for admin app if needed. In root package.json, add scripts: `dev:admin` → `pnpm --filter admin dev`, `build:admin` → `pnpm --filter admin build`. Verify pnpm-workspace.yaml includes `apps/*` (should already exist). Test workspace recognizes admin app.",
+            "status": "pending",
+            "testStrategy": "Run `pnpm run dev:admin` from root and verify admin app starts. Run `pnpm run build:admin` from root and verify successful build. Run `turbo run build --filter=admin` and verify Turborepo caching works. Check `pnpm list --filter admin` shows correct dependencies. Verify no turbo.json syntax errors."
+          },
+          {
+            "id": 6,
+            "title": "Verify separation and test both apps independently",
+            "description": "Confirm apps/site has zero admin/login routes, then test both apps run and build independently without errors or cross-contamination",
+            "dependencies": [
+              5
+            ],
+            "details": "Run `grep -r 'admin\\|login' apps/site/app` to verify no admin/login routes remain (ignore mentions in comments/docs). Run `pnpm --filter site dev` and manually test public portfolio pages load correctly without auth middleware. Run `pnpm --filter admin dev` and test login page and admin CRUD pages load with auth middleware active. Run `pnpm build` at root to verify both apps build successfully in monorepo. Check build outputs in apps/site/.next and apps/admin/.next. Document any issues found.",
+            "status": "pending",
+            "testStrategy": "Execute `grep -r 'admin\\|login' apps/site/app` → expect zero route files. Test `pnpm --filter site dev` → public pages accessible without auth. Test `pnpm --filter admin dev` → /login and /admin/* require auth. Run `pnpm build` → both apps build without errors. Verify apps/site and apps/admin are fully independent (no shared state or middleware leakage)."
+          }
+        ]
       },
       {
         "id": 8,
@@ -4998,7 +5063,72 @@
           6
         ],
         "status": "pending",
-        "subtasks": []
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Eliminate all 'any' types across packages/core, packages/application, and apps/site/src/app/api",
+            "description": "Find and replace all 'any' type annotations with explicit types or 'unknown' across core domain packages and API routes",
+            "dependencies": [],
+            "details": "1. Run `grep -r 'any' packages/core/src packages/application/src apps/site/src/app/api` to identify all occurrences (exclude node_modules, .next)\n2. For each occurrence, analyze the context and determine the appropriate explicit type\n3. Replace 'any' with explicit types (union types, branded types, generics) or 'unknown' where type is truly dynamic\n4. Focus on packages/core (7 known instances), packages/application, and apps/site/src/app/api\n5. Verify TypeScript compilation succeeds after each change\n6. Ensure no 'any' remains except in type definition files or unavoidable third-party integrations",
+            "status": "pending",
+            "testStrategy": "1. Run `grep -r 'any' packages/core/src packages/application/src apps/site/src/app/api` and verify zero results\n2. Run `pnpm types` and verify zero type errors\n3. Verify TypeScript strict mode is enabled in all tsconfig.json files\n4. Run unit tests for modified files to ensure type changes don't break behavior"
+          },
+          {
+            "id": 2,
+            "title": "Verify architectural boundaries and enforce layer dependencies",
+            "description": "Audit and enforce architectural rules: no cross-context imports, no use cases in UI layer, no @repo/application in pages, no @supabase outside infra",
+            "dependencies": [
+              1
+            ],
+            "details": "1. Verify no direct imports between bounded contexts (portfolio ↔ identity):\n   - Grep for '@repo/core/portfolio' in packages/core/src/identity and vice versa\n   - Only shared kernel imports allowed between contexts\n2. Verify no use cases called from pages, layouts, or client components:\n   - Grep for '@repo/application' in apps/site/src/app excluding api/ directory\n   - Ensure all use case calls are in route handlers only\n3. Verify no @repo/application imports in apps/site pages (only in route handlers):\n   - Confirmed correct pattern in initial analysis\n4. Verify no @supabase/* imports outside @repo/infra:\n   - Run `grep -r '@supabase' packages/core packages/application apps/site`\n   - All auth gateway implementations must be behind IAuthenticationGateway interface\n5. Document any violations and create refactoring tasks if needed",
+            "status": "pending",
+            "testStrategy": "1. Run grep commands for each boundary rule and verify zero violations\n2. Review ESLint configuration to ensure boundary rules are enforced\n3. Test that architecture documentation (docs/02-ARCHITECTURE.md) accurately reflects implementation\n4. Verify dependency graph using package.json imports matches intended architecture"
+          },
+          {
+            "id": 3,
+            "title": "Verify REST boundary: envelope structure, HTTP status codes, and handler responsibilities",
+            "description": "Ensure all route handlers follow REST contract: response envelope { data, error }, correct status codes, no domain logic in handlers",
+            "dependencies": [
+              2
+            ],
+            "details": "1. Audit all route handlers in apps/site/src/app/api/v1/:\n   - Verify each returns `{ data: T | null, error: Error | null }` envelope\n   - Verify correct HTTP status codes: 200 (success), 400 (validation), 401 (unauthorized), 404 (not found), 500 (server error)\n2. Verify no domain logic in route handlers:\n   - Handlers should only: parse request, call use case, map Either to envelope, return response\n   - All business rules must be in entities, VOs, or use cases\n3. Verify error mapping:\n   - ValidationError → 400\n   - NotFoundError → 404\n   - UnauthorizedError → 401\n   - All other errors → 500\n4. Check consistency with docs/05-API-CONTRACTS.md\n5. Review contact, auth, identity, projects, experiences, profile, admin endpoints",
+            "status": "pending",
+            "testStrategy": "1. Manual inspection of all route handler files\n2. Verify response types match ApiResponse<T> from docs/05-API-CONTRACTS.md\n3. Test error scenarios return correct status codes (covered in tasks #3 and #4)\n4. Grep for business logic keywords (e.g., 'validate', 'calculate', 'transform') in route handlers\n5. Ensure all handlers follow the pattern: request → use case → Either → envelope → response"
+          },
+          {
+            "id": 4,
+            "title": "Run all test suites and fix failures",
+            "description": "Execute all test commands (test:core, test:utils, test:site, test) and resolve any failing tests across the monorepo",
+            "dependencies": [
+              3
+            ],
+            "details": "1. Run `pnpm test:core` — core domain tests (entities, VOs, shared kernel)\n   - Fix any failing tests in packages/core\n2. Run `pnpm test:utils` — utility tests (Validator, formatters, etc.)\n   - Fix any failing tests in packages/utils\n3. Run `pnpm test:site` — site-specific tests (route handlers, components)\n   - Fix any failing tests in apps/site\n4. Run `pnpm test` — full test suite across all packages\n   - Verify all 288+ test files pass\n5. For each failure:\n   - Analyze root cause (implementation bug vs. test bug)\n   - Fix implementation or update test to match correct behavior\n   - Ensure fixes align with DDD/Clean Architecture principles\n6. Verify test coverage remains high (target >80% for core and application layers)",
+            "status": "pending",
+            "testStrategy": "1. Run `pnpm test` and verify zero failures\n2. Run `pnpm test:coverage` and verify coverage thresholds are met\n3. Verify test naming follows convention: 'should <expected behavior> when <context>'\n4. Ensure tests focus on behavior, not implementation details\n5. Verify integration tests cover happy path and error scenarios"
+          },
+          {
+            "id": 5,
+            "title": "Run linters and fix all violations",
+            "description": "Execute ESLint, Prettier, and TypeScript type checking across all packages and resolve all violations",
+            "dependencies": [
+              4
+            ],
+            "details": "1. Run `pnpm lint` — ESLint across all packages\n   - Fix all linting errors and warnings\n   - Focus on architectural rule violations flagged by custom ESLint rules\n2. Run `pnpm format` — Prettier formatting\n   - Auto-fix formatting issues\n   - Verify consistent code style across monorepo\n3. Run `pnpm types` — TypeScript type checking\n   - Fix all type errors (should be zero after subtask #1)\n   - Verify strict mode is enabled in all tsconfig.json files\n4. Review ESLint configuration:\n   - Ensure rules enforce architectural boundaries (e.g., no-restricted-imports)\n   - Verify rules align with docs/02-ARCHITECTURE.md\n5. Set up pre-commit hooks if not already configured:\n   - Run lint-staged on staged files\n   - Block commits with linting errors",
+            "status": "pending",
+            "testStrategy": "1. Run `pnpm lint` and verify zero errors and warnings\n2. Run `pnpm format` and verify no files are modified (already formatted)\n3. Run `pnpm types` and verify zero type errors\n4. Verify ESLint rules are enforced in CI pipeline\n5. Test pre-commit hooks by staging files with intentional violations"
+          },
+          {
+            "id": 6,
+            "title": "Document remaining technical debt in GitHub issues",
+            "description": "Identify, document, and create GitHub issues for any remaining technical debt, architectural improvements, or deferred work discovered during quality review",
+            "dependencies": [
+              5
+            ],
+            "details": "1. Review findings from subtasks #1-5 and identify remaining technical debt:\n   - Unavoidable 'any' types (e.g., third-party library integrations)\n   - Architectural improvements that require larger refactors\n   - Test coverage gaps\n   - Performance optimizations\n   - Missing features or incomplete implementations\n2. For each item, create a GitHub issue:\n   - Clear title and description\n   - Label appropriately (tech-debt, enhancement, refactor)\n   - Link to relevant code locations\n   - Estimate complexity (low/medium/high)\n   - Assign to appropriate milestone (if applicable)\n3. Prioritize issues:\n   - Critical: blocks MVP or violates core principles\n   - High: impacts maintainability or scalability\n   - Medium: nice-to-have improvements\n   - Low: cosmetic or minor optimizations\n4. Update project documentation (docs/INDEX.md or TECHNICAL_DEBT.md) with summary of known issues",
+            "status": "pending",
+            "testStrategy": "1. Verify all identified technical debt items have corresponding GitHub issues\n2. Review issues for clarity and completeness\n3. Ensure issues are linked to relevant code locations or documentation\n4. Verify issues are labeled and prioritized correctly\n5. Confirm no critical technical debt is left undocumented"
+          }
+        ]
       },
       {
         "id": 10,

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -4889,5 +4889,139 @@
         "sprint-6"
       ]
     }
+  },
+  "mvp-round-2": {
+    "tasks": [
+      {
+        "id": 1,
+        "title": "Implement ERROR_MESSAGE i18n Dictionary in @repo/core",
+        "description": "Create comprehensive ERROR_MESSAGE dictionary with pt-BR and en-US translations for all domain error codes across core entities and value objects",
+        "details": "1. Create `packages/core/src/shared/i18n/ERROR_MESSAGE.ts` with structure: `ERROR_MESSAGE: Record<Locale, Record<string, { message: string }>>`\n2. Audit all ERROR_CODE constants across VOs (Slug, Name, Text, Email, Url, Id, Image, DateTime, DateRange, LocalizedText) and entities (Project, Experience, Skill, Profile, User, etc.)\n3. For each code, add entries in both `pt-BR` and `en-US` with human-readable messages\n4. Export ERROR_MESSAGE from `@repo/core/shared/i18n/index.ts`\n5. Create helper function `getErrorMessage(locale: Locale, code: string): string | undefined`\n6. Update `ValidationError`, `NotFoundError`, `UnauthorizedError` to accept only `code` (no inline messages)\n7. Ensure all codes match pattern: INVALID_*, NOT_FOUND, UNAUTHORIZED, AUTH_*, ERROR_*\n\nExample structure:\n```typescript\nexport const ERROR_MESSAGE: Record<Locale, Record<string, { message: string }>> = {\n  'en-US': {\n    'INVALID_SLUG': { message: 'Slug must be kebab-case (a-z, 0-9, hyphens only)' },\n    'INVALID_EMAIL': { message: 'Invalid email format' },\n    'NOT_FOUND': { message: 'Resource not found' },\n    // ... all codes\n  },\n  'pt-BR': {\n    'INVALID_SLUG': { message: 'Slug deve estar em kebab-case (a-z, 0-9, hífens apenas)' },\n    'INVALID_EMAIL': { message: 'Formato de e-mail inválido' },\n    'NOT_FOUND': { message: 'Recurso não encontrado' },\n    // ... all codes\n  }\n};\n```",
+        "testStrategy": "1. Unit tests verifying ERROR_MESSAGE has entries for all ERROR_CODE constants\n2. Test `getErrorMessage` returns correct message for each locale\n3. Test fallback behavior: en-US → pt-BR → undefined\n4. Verify no hardcoded messages remain in ValidationError instantiations\n5. Test that all domain code paths returning ValidationError use stable codes",
+        "priority": "high",
+        "dependencies": [],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 2,
+        "title": "Remove Hardcoded Error Messages from @repo/core Domain Code",
+        "description": "Replace all inline human-readable error messages in entities and VOs with stable ERROR_CODE constants, ensuring ValidationError only receives codes",
+        "details": "1. Audit all entities (Project, Experience, Skill, Profile, User, Language, SocialNetwork, ProfessionalValue, ProfileStat) for ValidationError instantiations\n2. Audit all VOs (Slug, Name, Text, Email, Url, Id, Image, DateTime, DateRange, LocalizedText) for ValidationError instantiations\n3. Replace pattern:\n   BEFORE: `return left(new ValidationError({ code: Foo.ERROR_CODE, message: 'Human readable text' }))`\n   AFTER: `return left(new ValidationError({ code: Foo.ERROR_CODE }))`\n4. Ensure each class has a static `ERROR_CODE` constant\n5. Update Validator chain messages to be generic/internal (not user-facing) since edge will resolve from ERROR_MESSAGE\n6. Verify no plain string literals appear in error instantiations\n7. Update ValidationError constructor to make message optional, defaulting to 'Validation failed'\n8. Run ESLint and fix any violations\n\nFocus files:\n- packages/core/src/shared/vo/*.ts (Slug, Name, Text, Url, Email, Id, Image, DateTime, DateRange)\n- packages/core/src/portfolio/entities/**/*.ts\n- packages/core/src/identity/entities/**/*.ts\n- packages/core/src/shared/errors/ValidationError.ts",
+        "testStrategy": "1. Unit tests verify all ValidationError instances use ERROR_CODE only\n2. Test that domain validation still returns left() with correct codes\n3. Grep for string literals in ValidationError constructors (should be zero)\n4. Test entity.create() methods return ValidationError with code-only\n5. Integration test: ensure edge can resolve messages via ERROR_MESSAGE[locale][code]",
+        "priority": "high",
+        "dependencies": [
+          1
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 3,
+        "title": "Manual Endpoint Testing — Public Portfolio Routes",
+        "description": "Manually test all public portfolio API endpoints (GET /api/v1/projects, /projects/featured, /projects/:slug, /experiences, /profile) for correct envelope and HTTP status codes",
+        "details": "1. Set up local development environment: `pnpm dev`, seed database: `pnpm seed`\n2. Create manual test script or use Postman/Insomnia/curl\n3. Test each endpoint for:\n   - Happy path: returns `{ data: <T>, error: null }` with 200\n   - Not found cases: returns `{ data: null, error: { code, message } }` with 404\n   - Invalid input (if applicable): returns 400 with error envelope\n4. Endpoints to test:\n   - GET /api/v1/projects — list all published projects\n   - GET /api/v1/projects/featured — list featured projects\n   - GET /api/v1/projects/:slug — project by slug (test valid slug and 404 case)\n   - GET /api/v1/experiences — list all experiences\n   - GET /api/v1/profile — get profile\n   - GET /api/v1/professional-values — list professional values\n5. Document findings in `.taskmaster/docs/endpoint-testing-results.md`\n6. Create follow-up GitHub issues for any broken endpoints\n7. Verify error messages resolve from ERROR_MESSAGE (requires task #1, #2)\n\nValidation checklist:\n- Response always has `data` and `error` keys\n- Success: `data` is non-null, `error` is null, status 200\n- Failure: `data` is null, `error` has `code` and `message`, correct status\n- No 500 errors for expected failures",
+        "testStrategy": "Manual testing protocol:\n1. Execute each endpoint with valid and invalid inputs\n2. Verify response envelope structure matches API contract (docs/05-API-CONTRACTS.md)\n3. Confirm HTTP status codes: 200 (success), 400 (validation), 404 (not found)\n4. Document all edge cases and unexpected behaviors\n5. Cross-reference with ERROR_MESSAGE to ensure message localization works",
+        "priority": "high",
+        "dependencies": [
+          2
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 4,
+        "title": "Manual Endpoint Testing — Contact, Auth, Identity, and Admin Routes",
+        "description": "Manually test contact form, authentication, identity, and admin CRUD endpoints for correct envelope, status codes, and authorization",
+        "details": "1. Test Contact endpoint:\n   - POST /api/v1/contact with valid payload → 200\n   - POST /api/v1/contact with invalid payload → 400\n   - POST /api/v1/contact rate-limit behavior (requires multiple requests)\n2. Test Auth endpoints (pending full implementation per docs/11-IDENTITY.md):\n   - POST /api/v1/auth/sign-in with valid credentials → 200 with session\n   - POST /api/v1/auth/sign-in with invalid credentials → 401\n   - POST /api/v1/auth/sign-out → 200\n   - POST /api/v1/auth/refresh → 200 or 401\n3. Test Identity endpoint:\n   - GET /api/v1/me without session → 401 with AUTH_REQUIRED\n   - GET /api/v1/me with session → 200 with user data\n4. Test Admin endpoints (requires auth as admin):\n   - Projects: POST, PUT, DELETE, GET /api/v1/admin/projects/* (CRUD)\n   - Publish/Archive: POST /api/v1/admin/projects/:slug/publish, /archive\n   - Profile: PUT /api/v1/admin/profile\n   - Experiences: POST, PUT, DELETE, GET /api/v1/admin/experiences/* (CRUD)\n   - Test 401 UNAUTHORIZED when not admin\n5. Document findings in `.taskmaster/docs/endpoint-testing-results.md`\n6. Create follow-up issues for broken endpoints\n\nNote: Auth endpoints may be partially implemented; document current state",
+        "testStrategy": "Manual testing protocol:\n1. Set up test admin user via seed (ADMIN_EMAIL env var)\n2. Test auth flow: sign-in → get session → call protected endpoints\n3. Test authorization: call admin endpoints without auth → 401, with non-admin → 401\n4. Verify rate limiting on contact endpoint (multiple rapid requests)\n5. Confirm all responses follow envelope contract\n6. Document any missing implementations for post-MVP work",
+        "priority": "high",
+        "dependencies": [
+          3
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 5,
+        "title": "Create Realistic Seed Data",
+        "description": "Replace placeholder seed data with content close to real portfolio: real projects, experiences, skills, and profile with meaningful descriptions",
+        "details": "1. Update `packages/infra/prisma/seed.ts` with realistic data:\n   - Profile: Real name, headline, bio (100-200 words), real photo URL or placeholder with better text\n   - Skills: Keep existing tech stack (TypeScript, React, Next.js, etc.), add more relevant skills\n   - Projects: Replace with 2-4 real or near-real projects with:\n     * Meaningful titles, captions, and content (200+ words each)\n     * Correct skill associations\n     * Real period dates\n     * At least 2 PUBLISHED featured projects\n   - Experiences: Replace with 2-3 real experiences with:\n     * Accurate company names, positions, locations\n     * Rich descriptions (150+ words per experience)\n     * Correct employment type and location type\n     * Real date ranges\n   - Professional values: Keep or enhance with more authentic content\n2. Ensure seeds remain idempotent (use upsert with stable IDs)\n3. Update image placeholders to use better text or real URLs\n4. Verify `pnpm prisma db seed` runs without errors\n5. Manually verify seeded data appears correctly in UI\n\nGoal: Seeds should represent the actual portfolio content or be very close, not generic placeholders",
+        "testStrategy": "1. Run `pnpm prisma db seed` and verify zero errors\n2. Query database to confirm all entities created\n3. Verify at least 2 published projects exist\n4. Verify at least 2 experiences exist\n5. Load frontend and confirm realistic data appears on Home, Projects, About pages\n6. Test that related projects, skills, and experiences link correctly",
+        "priority": "medium",
+        "dependencies": [],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 6,
+        "title": "Audit Application-Layer Orchestration in Route Handlers",
+        "description": "Audit all route handlers in apps/site/src/app/api/ to ensure no orchestration logic (branching on domain results, multiple use-case calls) leaks into the web adapter",
+        "details": "1. Review all 18 route handlers under `apps/site/src/app/api/v1/`:\n   - Public: projects, projects/featured, projects/[slug], experiences, profile, professional-values\n   - Contact: contact\n   - Auth: auth/sign-in, auth/sign-out, auth/refresh\n   - Identity: me\n   - Admin: admin/projects/*, admin/profile, admin/experiences/*\n2. Identify violations:\n   - Route handlers with if/else branching on domain model internals\n   - Multiple use-case calls in sequence with business decisions between them\n   - Business logic that should be in a use case\n3. For each violation:\n   - Extract orchestration into a new use case or enhance existing use case\n   - Simplify route handler to: resolve container → call one use case → map result to HTTP\n4. Document findings in `.taskmaster/docs/orchestration-audit.md`\n5. Create follow-up GitHub issues for refactors\n6. Ensure architecture ESLint rules pass\n\nPattern to enforce:\n```typescript\nexport async function GET(req: Request) {\n  const container = resolveContainer();\n  const result = await container.useCase.execute(params);\n  return mapToHttpResponse(result);\n}\n```",
+        "testStrategy": "1. Manual code review of all route handlers\n2. Identify handlers with >20 lines or multiple use-case calls\n3. Verify each handler calls exactly one use case (or thin orchestrator)\n4. Check no domain model interrogation (e.g., `if (project.status === ...)`) in handlers\n5. Run `pnpm lint` and ensure architecture rules pass\n6. Document violations and create issues for post-MVP if not critical",
+        "priority": "high",
+        "dependencies": [],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 7,
+        "title": "Create apps/admin and Move Login/Admin Routes",
+        "description": "Extract /{locale}/login and /{locale}/admin/* routes from apps/site into new dedicated apps/admin Next.js app, scoping auth middleware to admin only",
+        "details": "1. Create new Next.js app: `pnpm create next-app apps/admin --typescript --app --tailwind --no-src-dir`\n2. Set up admin app structure:\n   - `apps/admin/app/[locale]/login/page.tsx` — move from apps/site\n   - `apps/admin/app/[locale]/admin/*` — move all admin pages\n   - `apps/admin/middleware.ts` — auth middleware (move from apps/site, scope to admin)\n   - Copy necessary dependencies, components, and utilities\n3. Update `turbo.json`:\n   - Add `admin#build`, `admin#dev`, `admin#lint`, etc.\n   - Set correct env vars for admin app\n4. Update root `package.json`:\n   - Add scripts for admin: `dev:admin`, `build:admin`\n5. Update workspace config (pnpm-workspace.yaml if needed)\n6. Move shared components to `@repo/ui` if needed\n7. Ensure apps/site has ZERO login/admin routes remaining\n8. Test both apps run independently:\n   - `pnpm --filter site dev` — public portfolio only\n   - `pnpm --filter admin dev` — admin panel and login\n9. Update documentation (README, docs/) to reflect new structure\n10. Verify both apps build: `pnpm build`\n\nGoal: Complete separation of public site and admin app",
+        "testStrategy": "1. Verify apps/site has no login or admin routes (grep for 'admin', 'login')\n2. Verify apps/admin runs independently: `pnpm --filter admin dev`\n3. Test login flow in apps/admin\n4. Test admin CRUD operations in apps/admin\n5. Verify auth middleware only active in apps/admin (no impact on apps/site)\n6. Run `pnpm build` and ensure both apps build successfully\n7. Verify no shared state or dependencies between apps beyond packages/*",
+        "priority": "medium",
+        "dependencies": [],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 8,
+        "title": "Figma Styling Review and Component Updates",
+        "description": "Conduct Figma design review to identify unfinished or inconsistent components, then implement all required visual changes in @repo/ui and apps/site",
+        "details": "1. Review Figma design against current implementation:\n   - Home page: Hero, Stats, Featured Projects, About preview\n   - Projects page: Project grid, filters, Project detail\n   - About page: Bio, Experiences timeline, Skills grid, Professional Values\n   - Contact form\n   - Admin pages (if designed)\n2. Document discrepancies:\n   - Missing components\n   - Incorrect spacing, typography, colors\n   - Inconsistent component variants\n   - Responsive behavior issues\n3. Create a checklist in `.taskmaster/docs/figma-review-checklist.md`:\n   - List all components requiring changes\n   - Prioritize by visual impact\n4. Implement changes:\n   - Update `@repo/ui` components (Button, Card, Input, etc.)\n   - Update page layouts in `apps/site/src/app/[locale]/*`\n   - Ensure Tailwind classes match design tokens\n   - Test responsive breakpoints (mobile, tablet, desktop)\n5. Visual regression testing:\n   - Compare before/after screenshots\n   - Verify on multiple screen sizes\n6. Update Storybook stories if needed\n\nReference: [Paul Scanlon's portfolio](https://www.paulie.dev/) for inspiration",
+        "testStrategy": "1. Side-by-side comparison: Figma vs. running app\n2. Test all pages on mobile (375px), tablet (768px), desktop (1440px)\n3. Verify typography hierarchy matches design\n4. Verify color palette matches (check contrast ratios)\n5. Test interactive states (hover, focus, active) on all components\n6. Review Storybook to ensure component variants are complete\n7. User acceptance: have stakeholder review visuals",
+        "priority": "medium",
+        "dependencies": [],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 9,
+        "title": "General Code Quality Review and Cleanup",
+        "description": "Comprehensive quality pass: eliminate 'any' types, enforce architectural boundaries, verify REST contract, ensure all tests pass, and enforce ESLint rules",
+        "details": "1. Eliminate all `any` types:\n   - Run `grep -r 'any' packages/*/src apps/*/src` (exclude node_modules, .next)\n   - Replace with explicit types or `unknown`\n   - Focus on `packages/core`, `packages/application`, `apps/site/src/app/api`\n2. Verify architectural boundaries:\n   - No direct imports between bounded contexts (portfolio ↔ identity)\n   - No use cases called from pages, layouts, or client components in apps/site\n   - No `@repo/application` imports in apps/site pages (only in route handlers)\n   - No `@supabase/*` outside `@repo/infra` (grep for '@supabase')\n3. Verify REST boundary:\n   - All route handlers follow response envelope: `{ data, error }`\n   - No domain logic in route handlers (see task #6)\n   - All errors map to correct HTTP status codes\n4. Run all tests and fix failures:\n   - `pnpm test:core` — core domain tests\n   - `pnpm test:utils` — utils tests\n   - `pnpm test:site` — site tests\n   - `pnpm test` — full test suite\n5. Run linters and fix violations:\n   - `pnpm lint` — ESLint across all packages\n   - `pnpm format` — Prettier formatting\n   - `pnpm types` — TypeScript type checking\n6. Document any remaining technical debt in GitHub issues\n\nGoal: Zero linting errors, zero `any` types, all tests green, architecture rules enforced",
+        "testStrategy": "1. Run `pnpm lint` and verify zero errors\n2. Run `pnpm types` and verify zero type errors\n3. Run `pnpm test` and verify all tests pass\n4. Grep for 'any' in src directories — zero results (excluding type definitions)\n5. Grep for '@repo/application' in apps/site/src/app — only in api/ route handlers\n6. Grep for '@supabase' in apps/site — zero results\n7. Verify no cross-context imports (portfolio importing identity entities)\n8. Run `pnpm build` and verify successful build",
+        "priority": "high",
+        "dependencies": [
+          2,
+          6
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 10,
+        "title": "Document Findings and Create Follow-up Issues",
+        "description": "Consolidate all audit findings from tasks #3, #4, #6, #8, #9 into GitHub issues in MVP Round 2 milestone, prioritize, and prepare launch checklist",
+        "details": "1. Review documentation created during previous tasks:\n   - `.taskmaster/docs/endpoint-testing-results.md` (tasks #3, #4)\n   - `.taskmaster/docs/orchestration-audit.md` (task #6)\n   - `.taskmaster/docs/figma-review-checklist.md` (task #8)\n   - Any code quality notes from task #9\n2. For each finding:\n   - Assess severity: blocker, critical, medium, low\n   - Determine if it must be fixed before launch or post-MVP\n3. Create GitHub issues:\n   - Use `gh issue create` with proper labels (bug, refactor, enhancement)\n   - Assign to MVP Round 2 milestone if launch-blocking\n   - Link to parent issue (e.g., #588, #543, #589, #594)\n4. Create launch checklist in `.taskmaster/docs/launch-checklist.md`:\n   - All tests passing\n   - All endpoints working\n   - Realistic seed data\n   - Figma design matches\n   - Zero architectural violations\n   - Documentation updated\n   - Admin app separated (if task #7 complete)\n5. Update project README with:\n   - MVP Round 2 completion status\n   - Known post-MVP work items\n   - Deployment instructions\n6. Prepare for launch: final smoke test\n\nGoal: Clear view of launch readiness and post-MVP backlog",
+        "testStrategy": "1. Verify all findings documented in `.taskmaster/docs/`\n2. Verify GitHub issues created for each finding\n3. Verify issues tagged with correct milestone and labels\n4. Review launch checklist completeness\n5. Stakeholder review: confirm all launch-blocking items addressed\n6. Final manual smoke test of critical flows (view projects, submit contact form, admin login)",
+        "priority": "high",
+        "dependencies": [
+          3,
+          4,
+          6,
+          8,
+          9
+        ],
+        "status": "pending",
+        "subtasks": []
+      }
+    ],
+    "metadata": {
+      "created": "2026-05-20T22:57:44.775Z",
+      "updated": "2026-05-20T22:57:44.775Z",
+      "description": "Tasks for mvp-round-2 context"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `.taskmaster/docs/mvp-round-2.md` — PRD covering all 8 MVP Round 2 items (GitHub issues #543, #588–#594)
- Parses PRD into 10 Task Master tasks tagged `mvp-round-2`
- Includes complexity analysis report

## Tasks generated (tag: mvp-round-2)

| ID | Title | Complexity |
|----|-------|-----------|
| 1 | Implement ERROR_MESSAGE i18n dictionary in @repo/core | 7 (medium) |
| 2 | Remove hardcoded error messages from entities/VOs | 6 (medium) |
| 3 | Manual endpoint testing — public endpoints | 5 (medium) |
| 4 | Manual endpoint testing — auth, identity, admin | 7 (medium) |
| 5 | Create realistic seed data | 4 (low) |
| 6 | Audit application-layer orchestration in route handlers | 6 (medium) |
| 7 | Create apps/admin and move login/admin pages | 8 (high) |
| 8 | Figma styling review and implementation | 7 (medium) |
| 9 | General code quality review | 8 (high) |
| 10 | Document findings and create launch checklist | 5 (medium) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)