### PR TITLE
chore: fix Task Master state after sprint-6 finalization

### DIFF
--- a/.taskmaster/state.json
+++ b/.taskmaster/state.json
@@ -1,5 +1,5 @@
 {
-  "currentTag": "sprint-6",
+  "currentTag": "mvp-round-2",
   "lastSwitched": "2026-05-16T04:38:43.744Z",
   "branchTagMapping": {},
   "migrationNoticeShown": true


### PR DESCRIPTION
## Summary

- Marks sprint-6 tasks #1, #5, #6 as `done` (sprint was finalized)
- Moves Validator refactor tasks from `sprint-6` to `mvp-round-2` (IDs 11–20)
- Marks `mvp-round-2` tasks #1 and #2 as `done` (PRs #596 and #597 merged)
- Switches active Task Master tag from `sprint-6` to `mvp-round-2`

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)