### PR TITLE
refactor(utils,core,application): fix Validator chain-loop bug and make message params optional

### DIFF
--- a/packages/application/src/contact/use-cases/SendContactMessage.ts
+++ b/packages/application/src/contact/use-cases/SendContactMessage.ts
@@ -23,19 +23,19 @@ export class SendContactMessage {
     input: SendContactMessageInput,
   ): Promise<Either<ValidationError | DomainError, void>> {
     const { isValid: nameValid } = Validator.of(input.name?.trim() ?? '')
-      .notEmpty('invalid-name')
+      .notEmpty()
       .validate();
     if (!nameValid) return left(new ValidationError({ code: 'INVALID_NAME' }));
 
     const { isValid: emailValid } = Validator.of(input.email?.trim() ?? '')
-      .notEmpty('invalid-email')
-      .email('invalid-email')
+      .notEmpty()
+      .email()
       .validate();
     if (!emailValid)
       return left(new ValidationError({ code: 'INVALID_EMAIL' }));
 
     const { isValid: messageValid } = Validator.of(input.message?.trim() ?? '')
-      .notEmpty('invalid-message')
+      .notEmpty()
       .validate();
     if (!messageValid)
       return left(new ValidationError({ code: 'INVALID_MESSAGE' }));

--- a/packages/core/src/portfolio/entities/language/model/Language.ts
+++ b/packages/core/src/portfolio/entities/language/model/Language.ts
@@ -55,7 +55,7 @@ export class Language extends Entity<Language, ILanguageProps> {
 
   private static _createLocale(value: string): Either<ValidationError, Locale> {
     const { isValid } = Validator.of(value)
-      .refine((v) => isLocale(v), '')
+      .refine((v) => isLocale(v))
       .validate();
     if (!isValid)
       return left(new ValidationError({ code: Language.LOCALE_ERROR_CODE }));

--- a/packages/core/src/portfolio/entities/profile/model/Profile.ts
+++ b/packages/core/src/portfolio/entities/profile/model/Profile.ts
@@ -58,10 +58,7 @@ export class Profile extends AggregateRoot<Profile, IProfileProps> {
 
   static create(props: IProfileProps): Either<ValidationError, Profile> {
     const { isValid } = Validator.of(props.featuredProjectSlugs)
-      .refine(
-        (slugs) => slugs.length <= Profile.MAX_FEATURED_PROJECTS,
-        'max-featured-projects',
-      )
+      .refine((slugs) => slugs.length <= Profile.MAX_FEATURED_PROJECTS)
       .validate();
 
     if (!isValid)

--- a/packages/core/src/portfolio/entities/project/model/Project.ts
+++ b/packages/core/src/portfolio/entities/project/model/Project.ts
@@ -100,7 +100,7 @@ export class Project extends AggregateRoot<Project, IProjectProps> {
   static create(props: IProjectProps): Either<ValidationError, Project> {
     {
       const { isValid } = Validator.of(props.status)
-        .in(Object.values(ProjectStatus), '')
+        .in(Object.values(ProjectStatus))
         .validate();
       if (!isValid)
         return left(new ValidationError({ code: Project.ERROR_CODE }));
@@ -164,14 +164,11 @@ export class Project extends AggregateRoot<Project, IProjectProps> {
 
     {
       const { isValid } = Validator.of(relatedSlugs)
-        .refine(
-          (slugs) => !slugs.some((s) => s.value === ownSlugValue),
-          'self-reference',
-        )
+        .refine((slugs) => !slugs.some((s) => s.value === ownSlugValue))
         .refine((slugs) => {
           const values = slugs.map((s) => s.value);
           return new Set(values).size === values.length;
-        }, 'duplicate-slugs')
+        })
         .validate();
       if (!isValid)
         return left(new ValidationError({ code: Project.ERROR_CODE }));
@@ -199,7 +196,7 @@ export class Project extends AggregateRoot<Project, IProjectProps> {
 
   publish(): Either<ValidationError, void> {
     const { isValid } = Validator.of(this.status)
-      .refine((s) => s !== ProjectStatus.PUBLISHED, '')
+      .refine((s) => s !== ProjectStatus.PUBLISHED)
       .validate();
     if (!isValid)
       return left(new ValidationError({ code: Project.ERROR_CODE }));
@@ -209,7 +206,7 @@ export class Project extends AggregateRoot<Project, IProjectProps> {
 
   archive(): Either<ValidationError, void> {
     const { isValid } = Validator.of(this.status)
-      .refine((s) => s !== ProjectStatus.ARCHIVED, '')
+      .refine((s) => s !== ProjectStatus.ARCHIVED)
       .validate();
     if (!isValid)
       return left(new ValidationError({ code: Project.ERROR_CODE }));

--- a/packages/core/src/portfolio/entities/skill/factory/SkillFactory.ts
+++ b/packages/core/src/portfolio/entities/skill/factory/SkillFactory.ts
@@ -7,9 +7,7 @@ export class SkillFactory {
   static readonly ERROR_CODE = 'ERROR_INVALID_SKILL_LIST';
 
   static bulk(props: ISkillProps[]): Either<ValidationError, Skill[]> {
-    const { isValid } = Validator.of(props)
-      .refine(Array.isArray, 'invalid-skill-list')
-      .validate();
+    const { isValid } = Validator.of(props).refine(Array.isArray).validate();
 
     if (!isValid)
       return left(new ValidationError({ code: SkillFactory.ERROR_CODE }));

--- a/packages/core/src/shared/i18n/LocalizedText.ts
+++ b/packages/core/src/shared/i18n/LocalizedText.ts
@@ -46,7 +46,7 @@ export class LocalizedText extends ValueObject<LocalizedTextValue> {
     input: ILocalizedTextInput,
   ): Either<ValidationError, LocalizedText> {
     const { isValid } = Validator.of(input?.['en-US']?.trim() ?? '')
-      .notEmpty('en-US is required and must be non-empty after trim.')
+      .notEmpty()
       .validate();
 
     if (!isValid)

--- a/packages/core/src/shared/vo/DateRange.ts
+++ b/packages/core/src/shared/vo/DateRange.ts
@@ -29,10 +29,7 @@ export class DateRange extends ValueObject<IDateRangeValue> {
       if (endResult.isLeft()) return left(endResult.value);
 
       const { isValid } = Validator.of(startResult.value.ms)
-        .refine(
-          (startMs) => startMs <= endResult.value.ms,
-          'Start date must be before or equal to end date.',
-        )
+        .refine((startMs) => startMs <= endResult.value.ms)
         .validate();
 
       if (!isValid)

--- a/packages/core/src/shared/vo/DateTime.ts
+++ b/packages/core/src/shared/vo/DateTime.ts
@@ -16,9 +16,7 @@ export class DateTime extends ValueObject<string> {
   }
 
   static create(value: string): Either<ValidationError, DateTime> {
-    const { isValid } = Validator.of(value)
-      .datetime('The value must be a valid date and time.')
-      .validate();
+    const { isValid } = Validator.of(value).datetime().validate();
 
     if (!isValid)
       return left(new ValidationError({ code: DateTime.ERROR_CODE }));

--- a/packages/core/src/shared/vo/Email.ts
+++ b/packages/core/src/shared/vo/Email.ts
@@ -14,8 +14,8 @@ export class Email extends ValueObject<string> {
   static create(value?: string): Either<ValidationError, Email> {
     const normalized = value?.trim().toLowerCase() ?? '';
     const { isValid } = Validator.of(normalized)
-      .length(3, 254, 'invalid-email')
-      .email('invalid-email')
+      .length(3, 254)
+      .email()
       .validate();
 
     if (!isValid) return left(new ValidationError({ code: Email.ERROR_CODE }));

--- a/packages/core/src/shared/vo/Id.ts
+++ b/packages/core/src/shared/vo/Id.ts
@@ -17,9 +17,7 @@ export class Id extends ValueObject<string> {
   }
 
   static create(value: string): Either<ValidationError, Id> {
-    const { isValid } = Validator.of(value)
-      .uuid('The value must be a valid UUID.')
-      .validate();
+    const { isValid } = Validator.of(value).uuid().validate();
 
     if (!isValid) return left(new ValidationError({ code: Id.ERROR_CODE }));
     return right(new Id(value));

--- a/packages/core/src/shared/vo/Name.ts
+++ b/packages/core/src/shared/vo/Name.ts
@@ -12,14 +12,7 @@ export class Name extends ValueObject<string> {
   }
 
   static create(value?: string): Either<ValidationError, Name> {
-    const { isValid } = Validator.of(value)
-      .alpha('The name must contain only letters.')
-      .length(
-        3,
-        100,
-        'The name must be between {{min}} and {{max}} characters.',
-      )
-      .validate();
+    const { isValid } = Validator.of(value).alpha().length(3, 100).validate();
 
     if (!isValid) return left(new ValidationError({ code: Name.ERROR_CODE }));
 

--- a/packages/core/src/shared/vo/Slug.ts
+++ b/packages/core/src/shared/vo/Slug.ts
@@ -17,8 +17,8 @@ export class Slug extends ValueObject<string> {
     const normalized = raw?.trim().toLowerCase() ?? '';
 
     const { isValid } = Validator.of(normalized)
-      .length(3, Slug.MAX_LENGTH, 'invalid-slug')
-      .regex(Slug.SLUG_REGEX, 'invalid-slug')
+      .length(3, Slug.MAX_LENGTH)
+      .regex(Slug.SLUG_REGEX)
       .validate();
 
     if (!isValid) return left(new ValidationError({ code: Slug.ERROR_CODE }));

--- a/packages/core/src/shared/vo/Text.ts
+++ b/packages/core/src/shared/vo/Text.ts
@@ -22,13 +22,7 @@ export class Text extends ValueObject<string, ITextConfig> {
   ): Either<ValidationError, Text> {
     const { min = 3, max = 50 } = config ?? {};
 
-    const { isValid } = Validator.of(value)
-      .length(
-        min,
-        max,
-        'The value must be between {{min}} and {{max}} characters.',
-      )
-      .validate();
+    const { isValid } = Validator.of(value).length(min, max).validate();
 
     if (!isValid) return left(new ValidationError({ code: Text.ERROR_CODE }));
     return right(new Text(value!, config));

--- a/packages/core/src/shared/vo/Url.ts
+++ b/packages/core/src/shared/vo/Url.ts
@@ -12,9 +12,7 @@ export class Url extends ValueObject<string> {
   }
 
   static create(value?: string): Either<ValidationError, Url> {
-    const { isValid } = Validator.of(value)
-      .url('The value must be a valid URL.')
-      .validate();
+    const { isValid } = Validator.of(value).url().validate();
 
     if (!isValid) return left(new ValidationError({ code: Url.ERROR_CODE }));
     return right(new Url(value!));

--- a/packages/utils/src/validator/Validator.ts
+++ b/packages/utils/src/validator/Validator.ts
@@ -22,7 +22,7 @@ export class Validator<TValue> {
     return new Validator<TValue>(value);
   }
 
-  private append(validation: Validation, error: string) {
+  private append(validation: Validation, error = 'validation-error') {
     this._validations.push([validation, error]);
 
     return this;
@@ -49,18 +49,18 @@ export class Validator<TValue> {
     return !this._failed;
   }
 
-  public length(min: number, max: number, error: string): Validator<TValue> {
+  public length(min: number, max: number, error?: string): Validator<TValue> {
     const config = { min, max };
 
     this.append(
       (value) => z.string().min(min).max(max).safeParse(value).success,
-      Mustache.render(error, config),
+      error ? Mustache.render(error, config) : undefined,
     );
 
     return this;
   }
 
-  public alpha(error: string): Validator<TValue> {
+  public alpha(error?: string): Validator<TValue> {
     this.append(
       (value) => z.string().regex(ALPHA_REGEX).safeParse(value).success,
       error,
@@ -69,55 +69,55 @@ export class Validator<TValue> {
     return this;
   }
 
-  public empty(error: string): Validator<TValue> {
+  public empty(error?: string): Validator<TValue> {
     this.append((value) => z.string().max(0).safeParse(value).success, error);
 
     return this;
   }
 
-  public notEmpty(error: string): Validator<TValue> {
+  public notEmpty(error?: string): Validator<TValue> {
     this.append((value) => z.string().min(1).safeParse(value).success, error);
 
     return this;
   }
 
-  public nil(error: string): Validator<TValue> {
+  public nil(error?: string): Validator<TValue> {
     this.append((value) => value == null, error);
 
     return this;
   }
 
-  public notNil(error: string): Validator<TValue> {
+  public notNil(error?: string): Validator<TValue> {
     this.append((value) => value != null, error);
 
     return this;
   }
 
-  public string(error: string): Validator<TValue> {
+  public string(error?: string): Validator<TValue> {
     this.append((value) => z.string().safeParse(value).success, error);
 
     return this;
   }
 
-  public uuid(error: string): Validator<TValue> {
+  public uuid(error?: string): Validator<TValue> {
     this.append((value) => z.string().uuid().safeParse(value).success, error);
 
     return this;
   }
 
-  public email(error: string): Validator<TValue> {
+  public email(error?: string): Validator<TValue> {
     this.append((value) => z.string().email().safeParse(value).success, error);
 
     return this;
   }
 
-  public url(error: string): Validator<TValue> {
+  public url(error?: string): Validator<TValue> {
     this.append((value) => z.string().url().safeParse(value).success, error);
 
     return this;
   }
 
-  public datetime(error: string): Validator<TValue> {
+  public datetime(error?: string): Validator<TValue> {
     this.append(
       (value) =>
         z.string().safeParse(value).success &&
@@ -128,7 +128,7 @@ export class Validator<TValue> {
     return this;
   }
 
-  public in(values: string[], error: string): Validator<TValue> {
+  public in(values: string[], error?: string): Validator<TValue> {
     this.append(
       (value) =>
         z.string().safeParse(value).success && values.includes(value as string),
@@ -138,7 +138,7 @@ export class Validator<TValue> {
     return this;
   }
 
-  public gt(valueB: number, error: string): Validator<TValue> {
+  public gt(valueB: number, error?: string): Validator<TValue> {
     this.append(
       (value) => z.number().gt(valueB).safeParse(value).success,
       error,
@@ -147,7 +147,7 @@ export class Validator<TValue> {
     return this;
   }
 
-  public gte(valueB: number, error: string): Validator<TValue> {
+  public gte(valueB: number, error?: string): Validator<TValue> {
     this.append(
       (value) => z.number().gte(valueB).safeParse(value).success,
       error,
@@ -156,7 +156,7 @@ export class Validator<TValue> {
     return this;
   }
 
-  public lt(valueB: number, error: string): Validator<TValue> {
+  public lt(valueB: number, error?: string): Validator<TValue> {
     this.append(
       (value) => z.number().lt(valueB).safeParse(value).success,
       error,
@@ -165,7 +165,7 @@ export class Validator<TValue> {
     return this;
   }
 
-  public lte(valueB: number, error: string): Validator<TValue> {
+  public lte(valueB: number, error?: string): Validator<TValue> {
     this.append(
       (value) => z.number().lte(valueB).safeParse(value).success,
       error,
@@ -174,7 +174,7 @@ export class Validator<TValue> {
     return this;
   }
 
-  public regex(pattern: RegExp, error: string): Validator<TValue> {
+  public regex(pattern: RegExp, error?: string): Validator<TValue> {
     this.append(
       (value) => z.string().regex(pattern).safeParse(value).success,
       error,
@@ -185,7 +185,7 @@ export class Validator<TValue> {
 
   public refine(
     predicate: (value: TValue) => boolean,
-    error: string,
+    error?: string,
   ): Validator<TValue> {
     this.append((value) => predicate(value as unknown as TValue), error);
 

--- a/packages/utils/src/validator/Validator.ts
+++ b/packages/utils/src/validator/Validator.ts
@@ -9,6 +9,7 @@ export type Validation = <TValue>(value: TValue) => boolean;
 export class Validator<TValue> {
   private readonly _validations: Array<[Validation, string]>;
   private _error: string | null = null;
+  private _failed: boolean = false;
   private _value: TValue;
 
   private constructor(value: TValue) {
@@ -31,9 +32,10 @@ export class Validator<TValue> {
     for (const [validation, error] of this._validations) {
       const isValid = validation(this._value);
 
+      this._failed = !isValid;
       this._error = isValid ? null : error;
 
-      if (this._error) break;
+      if (this._failed) break;
     }
 
     return { isValid: this.isValid, error: this.error };
@@ -44,7 +46,7 @@ export class Validator<TValue> {
   }
 
   get isValid(): boolean {
-    return this._error == null;
+    return !this._failed;
   }
 
   public length(min: number, max: number, error: string): Validator<TValue> {

--- a/packages/utils/test/node/Validator.test.ts
+++ b/packages/utils/test/node/Validator.test.ts
@@ -349,4 +349,49 @@ describe('Validator', () => {
       expect(validator.isValid).toBe(false);
     });
   });
+
+  describe('chain-loop bug fix', () => {
+    it('should stop chain on first failure even when message is empty string', () => {
+      const secondRuleCalled = { value: false };
+      const result = Validator.of('x')
+        .refine(() => false, '')
+        .refine(() => {
+          secondRuleCalled.value = true;
+          return true;
+        }, 'second-rule')
+        .validate();
+
+      expect(result.isValid).toBe(false);
+      expect(secondRuleCalled.value).toBe(false);
+    });
+
+    it('should stop chain on first failure and not let passing rule overwrite failure', () => {
+      const result = Validator.of('x')
+        .refine(() => false, '')
+        .refine(() => true, 'second-rule')
+        .validate();
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should continue chain when first rule passes', () => {
+      const result = Validator.of('x')
+        .refine(() => true, '')
+        .refine(() => false, 'second-fails')
+        .validate();
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('second-fails');
+    });
+
+    it('should return isValid true when all rules pass with empty messages', () => {
+      const result = Validator.of('x')
+        .refine(() => true, '')
+        .refine(() => true, '')
+        .validate();
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Fix chain-loop bug** — adicionado flag \`_failed: boolean\` ao \`Validator\` para que a chain pare na primeira falha mesmo quando a mensagem de erro é uma string vazia (o guard anterior \`if (this._error) break\` era falsy para \`''\`)
- **Parâmetro de mensagem opcional** — todos os métodos de regra (\`refine\`, \`length\`, \`regex\`, \`email\`, \`notEmpty\`, \`notNil\`, \`in\`, \`alpha\`, \`uuid\`, \`url\`, \`datetime\`, etc.) agora aceitam \`error?: string\`; \`append()\` faz default para \`'validation-error'\` quando não fornecido
- **Remoção de strings hardcoded** — eliminados todos os placeholders de mensagem dos call sites do \`Validator\` em:
  - \`packages/utils\` — \`Validator.ts\`, \`validateEnum.ts\`
  - \`packages/core\` — VOs compartilhados (\`Slug\`, \`Email\`, \`LocalizedText\`, \`DateRange\`, \`DateTime\`, \`Id\`, \`Name\`, \`Text\`, \`Url\`) e entidades (\`Language\`, \`Project\`, \`Profile\`, \`SkillFactory\`)
  - \`packages/application\` — \`SendContactMessage\`

## Test plan

- [x] \`@repo/utils\` — 85 testes passam (inclui 4 novos testes de regressão do chain-loop)
- [x] \`@repo/core\` — 248 testes passam
- [x] \`@repo/application\` — 157 testes passam
- [x] \`apps/site\` — todos os testes passam
- [x] TypeScript sem erros em \`@repo/core\` e \`@repo/application\` (após rebuild de \`@repo/utils\` types)

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)