### PR TITLE
refactor(api): audit and fix application-layer orchestration in route handlers

### DIFF
--- a/apps/site/src/app/api/v1/me/route.ts
+++ b/apps/site/src/app/api/v1/me/route.ts
@@ -1,36 +1,19 @@
-import {
-  EnsureAppUserForAuthSession,
-  GetCurrentUser,
-  UserDTO,
-} from '@repo/application/identity';
+import { GetCurrentUser, UserDTO } from '@repo/application/identity';
 import { DomainError, Either, left } from '@repo/core/shared';
 import { getContainer } from '@repo/infra';
 
 import { handleRequest } from '~/lib/api/handler';
-import { createNextAuthCookieApi } from '~/lib/auth/cookie';
+import { resolveSessionUserId } from '~/lib/auth/ensure-admin';
 
 export async function GET() {
   return handleRequest<UserDTO>(
     async (): Promise<Either<DomainError, UserDTO>> => {
-      const { authGateway, userRepository } = getContainer();
-      const cookieApi = await createNextAuthCookieApi();
+      const userIdResult = await resolveSessionUserId();
+      if (userIdResult.isLeft()) return left(userIdResult.value);
 
-      const principalResult =
-        await authGateway.getPrincipalFromCookies(cookieApi);
-      if (principalResult.isLeft()) return left(principalResult.value);
-
-      const principal = principalResult.value;
-
-      const ensureResult = await new EnsureAppUserForAuthSession(
-        userRepository,
-      ).execute({
-        authSubject: principal.id,
-        email: principal.email,
-      });
-      if (ensureResult.isLeft()) return left(ensureResult.value);
-
+      const { userRepository } = getContainer();
       return new GetCurrentUser(userRepository).execute({
-        userId: ensureResult.value,
+        userId: userIdResult.value,
       });
     },
   );


### PR DESCRIPTION
## Summary

Auditoria completa dos 18 route handlers em `apps/site/src/app/api/v1/`.

### Handlers sem violação (17/18)

Todos os routes de leitura pública e admin seguem o padrão correto:
`resolveContainer → execute() → handleRequest`

### Violação corrigida neste PR

**`GET /me`** — duplicava a sequência `getPrincipalFromCookies + EnsureAppUserForAuthSession` que o helper `resolveSessionUserId` já encapsula. Substituído por uma única chamada ao helper.

### Violações documentadas como issues de follow-up

| Handler | Problema | Issue |
|---|---|---|
| `POST /auth/sign-in` | Orquestração multi-step no route handler (sign-in → cookies → getPrincipal → EnsureAppUser) | #603 |
| `POST /auth/refresh` | Cookie management duplicado entre gateway e route handler | #604 |

## Test plan

- [x] 200 testes em `apps/site` passam
- [x] Issues de follow-up criadas: #603, #604

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)