### PR TITLE
chore: mark task #18 as done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -5300,8 +5300,9 @@
           "11",
           "12"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-05-21T22:13:10.555Z"
       },
       {
         "id": "19",
@@ -5339,9 +5340,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-05-21T21:38:03.909Z",
+      "lastModified": "2026-05-21T22:13:10.555Z",
       "taskCount": 20,
-      "completedCount": 13,
+      "completedCount": 14,
       "tags": [
         "mvp-round-2"
       ]


### PR DESCRIPTION
Atualiza `tasks.json` com o status done da task #18 após abertura do PR #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)