### PR TITLE
fix(infra): return 409 Conflict when project slug is already taken

### DIFF
--- a/apps/site/src/lib/api/error-mapper.ts
+++ b/apps/site/src/lib/api/error-mapper.ts
@@ -1,5 +1,10 @@
 import { UnauthorizedError } from '@repo/core/identity';
-import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+import {
+  ConflictError,
+  DomainError,
+  NotFoundError,
+  ValidationError,
+} from '@repo/core/shared';
 
 import { HttpErrorCodes } from './error-codes';
 
@@ -16,6 +21,7 @@ const HTTP_STATUS_REGISTRY: ReadonlyArray<
 > = [
   [NotFoundError, 404],
   [ValidationError, 400],
+  [ConflictError, 409],
   [UnauthorizedError, 401],
 ];
 

--- a/packages/application/src/portfolio/use-cases/SaveProject.ts
+++ b/packages/application/src/portfolio/use-cases/SaveProject.ts
@@ -5,6 +5,7 @@ import {
   Project,
 } from '@repo/core/portfolio';
 import {
+  ConflictError,
   DomainError,
   Either,
   NotFoundError,
@@ -24,7 +25,11 @@ export type SaveProjectInput = {
 export class SaveProject extends UseCase<
   SaveProjectInput,
   void,
-  ValidationError | UnauthorizedError | NotFoundError | DomainError
+  | ValidationError
+  | ConflictError
+  | UnauthorizedError
+  | NotFoundError
+  | DomainError
 > {
   constructor(
     private readonly projectRepository: IProjectRepository,
@@ -37,7 +42,11 @@ export class SaveProject extends UseCase<
     input: SaveProjectInput,
   ): Promise<
     Either<
-      ValidationError | UnauthorizedError | NotFoundError | DomainError,
+      | ValidationError
+      | ConflictError
+      | UnauthorizedError
+      | NotFoundError
+      | DomainError,
       void
     >
   > {
@@ -50,7 +59,8 @@ export class SaveProject extends UseCase<
     try {
       await this.projectRepository.save(projectResult.value);
       return right(undefined);
-    } catch {
+    } catch (err) {
+      if (err instanceof ConflictError) return left(err);
       return left(
         new DomainError('SAVE_FAILED', { message: 'Failed to save project' }),
       );

--- a/packages/application/test/portfolio/use-cases/SaveProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/SaveProject.test.ts
@@ -6,7 +6,12 @@ import {
   IProjectRepository,
   ProjectStatus,
 } from '@repo/core/portfolio';
-import { DomainError, NotFoundError, ValidationError } from '@repo/core/shared';
+import {
+  ConflictError,
+  DomainError,
+  NotFoundError,
+  ValidationError,
+} from '@repo/core/shared';
 
 import { EnsureAdmin } from '~/identity/use-cases/EnsureAdmin';
 import { SaveProject } from '~/portfolio/use-cases/SaveProject';
@@ -104,7 +109,7 @@ describe('SaveProject', () => {
       expect(result.value).toBeInstanceOf(ValidationError);
     });
 
-    it('should return Left(DomainError) when repository throws', async () => {
+    it('should return Left(DomainError) when repository throws a generic error', async () => {
       const admin = makeUser(Role.ADMIN);
       const { useCase } = makeUseCase(admin, {
         save: vi.fn().mockRejectedValue(new Error('DB error')),
@@ -117,6 +122,21 @@ describe('SaveProject', () => {
 
       expect(result.isLeft()).toBe(true);
       expect(result.value).toBeInstanceOf(DomainError);
+    });
+
+    it('should return Left(ConflictError) when repository throws a ConflictError (e.g. duplicate slug)', async () => {
+      const admin = makeUser(Role.ADMIN);
+      const { useCase } = makeUseCase(admin, {
+        save: vi.fn().mockRejectedValue(new ConflictError()),
+      });
+
+      const result = await useCase.execute({
+        userId: ADMIN_UUID,
+        projectProps: VALID_PROJECT_PROPS,
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(ConflictError);
     });
   });
 

--- a/packages/core/src/shared/errors/ConflictError.ts
+++ b/packages/core/src/shared/errors/ConflictError.ts
@@ -1,0 +1,14 @@
+import { DomainError } from './DomainError';
+
+export class ConflictError extends DomainError {
+  static readonly CODE = 'CONFLICT';
+
+  constructor(details?: Record<string, unknown>) {
+    super(ConflictError.CODE, {
+      message: 'Resource already exists',
+      details,
+    });
+    this.name = 'ConflictError';
+    Object.setPrototypeOf(this, ConflictError.prototype);
+  }
+}

--- a/packages/core/src/shared/errors/index.ts
+++ b/packages/core/src/shared/errors/index.ts
@@ -1,3 +1,4 @@
+export * from './ConflictError';
 export * from './DomainError';
 export * from './NotFoundError';
 export * from './ValidationError';

--- a/packages/infra/src/repositories/project/PrismaProjectRepository.ts
+++ b/packages/infra/src/repositories/project/PrismaProjectRepository.ts
@@ -1,10 +1,10 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import {
   IProjectRepository,
   Project,
   ProjectStatus,
 } from '@repo/core/portfolio';
-import { Id, Slug } from '@repo/core/shared';
+import { ConflictError, Id, Slug } from '@repo/core/shared';
 
 import { InfrastructureError } from '../../errors/InfrastructureError';
 import { ProjectMapper } from './ProjectMapper';
@@ -78,11 +78,21 @@ export class PrismaProjectRepository implements IProjectRepository {
   async save(project: Project): Promise<void> {
     const data = ProjectMapper.toPrisma(project);
 
-    await this.db.project.upsert({
-      where: { id: data.id as string },
-      create: data,
-      update: data,
-    });
+    try {
+      await this.db.project.upsert({
+        where: { id: data.id as string },
+        create: data,
+        update: data,
+      });
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2002'
+      ) {
+        throw new ConflictError();
+      }
+      throw err;
+    }
   }
 
   async delete(id: Id): Promise<void> {

--- a/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
+++ b/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
@@ -4,6 +4,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { ProjectStatus } from '@repo/core/portfolio';
 import { Id, Slug } from '@repo/core/shared';
 
+import { ConflictError } from '@repo/core/shared';
+
 import { InfrastructureError } from '../../../src/errors/InfrastructureError';
 import { ProjectMapper } from '../../../src/repositories/project/ProjectMapper';
 import { PrismaProjectRepository } from '../../../src/repositories/project/PrismaProjectRepository';
@@ -206,6 +208,18 @@ describe('PrismaProjectRepository', () => {
       expect(found).not.toBeNull();
       expect(found!.slug.value).toBe(raw.slug);
       expect(found!.skills).toHaveLength(2);
+    });
+
+    it('should throw ValidationError when slug is already taken by another project', async () => {
+      const seeded = await seedProject();
+
+      const duplicateRaw = buildPrismaProject({
+        slug: seeded.slug,
+        id: crypto.randomUUID(),
+      });
+      const duplicateProject = ProjectMapper.toDomain(duplicateRaw);
+
+      await expect(repo.save(duplicateProject)).rejects.toThrow(ConflictError);
     });
 
     it('should update an existing project on upsert', async () => {

--- a/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
+++ b/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
@@ -210,7 +210,7 @@ describe('PrismaProjectRepository', () => {
       expect(found!.skills).toHaveLength(2);
     });
 
-    it('should throw ValidationError when slug is already taken by another project', async () => {
+    it('should throw ConflictError when slug is already taken by another project', async () => {
       const seeded = await seedProject();
 
       const duplicateRaw = buildPrismaProject({


### PR DESCRIPTION
## Summary

- Adds `ConflictError` to `@repo/core/shared` — analogous to `NotFoundError`, maps to HTTP 409
- `PrismaProjectRepository.save()` now catches Prisma `P2002` (unique constraint) and throws `ConflictError` instead of letting it bubble as 500
- `SaveProject` use case catches `ConflictError` in the try/catch and returns `left(err)` directly
- Error mapper registers `ConflictError → 409`

## Why 409 and not 400?

The slug format is valid — it passes all domain validation. The problem is that a resource with this slug already exists. That is a state conflict, not a malformed request, so 409 Conflict is the semantically correct HTTP status.

## Test plan

- [x] `pnpm --filter @repo/application test` — `SaveProject` with repo throwing `ConflictError` → returns `Left(ConflictError)` ✅ (158/158 passing)
- [x] `pnpm --filter @repo/infra test` — `PrismaProjectRepository.save()` with duplicate slug → throws `ConflictError` ✅ (113/113 passing)
- [x] Manual: `POST /api/v1/admin/projects` with duplicate slug → **409 Conflict** `{ data: null, error: { code: "CONFLICT", message: "Resource already exists" } }` ✅

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)