### PR TITLE
refactor(auth): extract sign-in orchestration into SignIn use case

### DIFF
--- a/apps/site/src/app/api/v1/auth/sign-in/route.ts
+++ b/apps/site/src/app/api/v1/auth/sign-in/route.ts
@@ -1,5 +1,5 @@
-import { EnsureAppUserForAuthSession } from '@repo/application/identity';
-import { ValidationError, left, right } from '@repo/core/shared';
+import { SignIn } from '@repo/application/identity';
+import { ValidationError, left } from '@repo/core/shared';
 import {
   SUPABASE_ACCESS_TOKEN_COOKIE,
   SUPABASE_REFRESH_TOKEN_COOKIE,
@@ -32,14 +32,14 @@ export async function POST(request: NextRequest) {
 
       const { authGateway, userRepository } = getContainer();
 
-      const sessionResult = await authGateway.signInWithPassword({
+      const result = await new SignIn(authGateway, userRepository).execute({
         email: body.email ?? '',
         password: body.password ?? '',
       });
 
-      if (sessionResult.isLeft()) return sessionResult;
+      if (result.isLeft()) return result;
 
-      const session = sessionResult.value;
+      const session = result.value;
       const cookieApi = await createNextAuthCookieApi();
       const expiresIn = session.expiresAt - Math.floor(Date.now() / 1000);
 
@@ -58,27 +58,7 @@ export async function POST(request: NextRequest) {
         path: '/',
       });
 
-      const principalResult = await authGateway.getPrincipalFromCookies({
-        get: (name) =>
-          name === SUPABASE_ACCESS_TOKEN_COOKIE
-            ? session.accessToken
-            : undefined,
-        set: () => {},
-        delete: () => {},
-      });
-
-      if (principalResult.isLeft()) return principalResult;
-
-      const ensureResult = await new EnsureAppUserForAuthSession(
-        userRepository,
-      ).execute({
-        authSubject: principalResult.value.id,
-        email: principalResult.value.email,
-      });
-
-      if (ensureResult.isLeft()) return ensureResult;
-
-      return right(null as unknown);
+      return result;
     },
     200,
     locale,

--- a/apps/site/tests/app/api/v1/auth/sign-in/route.test.ts
+++ b/apps/site/tests/app/api/v1/auth/sign-in/route.test.ts
@@ -24,8 +24,7 @@ vi.mock('next/headers', () => ({
 }));
 
 const mockSignIn = vi.fn();
-const mockGetPrincipal = vi.fn();
-const mockEnsureUser = vi.fn();
+const mockGetPrincipalFromSession = vi.fn();
 
 beforeEach(() => {
   mockCookieStore.store = {};
@@ -42,7 +41,8 @@ beforeEach(() => {
   vi.mocked(getContainer).mockReturnValue({
     authGateway: {
       signInWithPassword: mockSignIn,
-      getPrincipalFromCookies: mockGetPrincipal,
+      getPrincipalFromCookies: vi.fn(),
+      getPrincipalFromSession: mockGetPrincipalFromSession,
       signOut: vi.fn(),
       refreshSession: vi.fn(),
     },
@@ -111,7 +111,7 @@ describe('POST /api/v1/auth/sign-in', () => {
     mockSignIn.mockResolvedValue(
       right({ accessToken: 'access-123', refreshToken: 'refresh-456', expiresAt }),
     );
-    mockGetPrincipal.mockResolvedValue(
+    mockGetPrincipalFromSession.mockResolvedValue(
       right({ id: VALID_UUID, email: 'user@example.com', role: 'VISITOR' }),
     );
 

--- a/packages/application/src/identity/ports/IAuthenticationGateway.ts
+++ b/packages/application/src/identity/ports/IAuthenticationGateway.ts
@@ -47,4 +47,13 @@ export interface IAuthenticationGateway {
   getPrincipalFromCookies(
     cookies: AuthCookieApi,
   ): Promise<Either<DomainError, AuthPrincipal>>;
+
+  /**
+   * Decode and validate the access token from an in-memory `AuthSession`.
+   * Use this immediately after `signInWithPassword` to avoid constructing
+   * a fake cookie reader.
+   */
+  getPrincipalFromSession(
+    session: AuthSession,
+  ): Promise<Either<DomainError, AuthPrincipal>>;
 }

--- a/packages/application/src/identity/use-cases/SignIn.ts
+++ b/packages/application/src/identity/use-cases/SignIn.ts
@@ -1,0 +1,50 @@
+import { IUserRepository } from '@repo/core/identity';
+import { DomainError, Either, left, right } from '@repo/core/shared';
+
+import { UseCase } from '../../shared/UseCase';
+import { AuthSession } from '../dtos/AuthSession';
+import { IAuthenticationGateway } from '../ports/IAuthenticationGateway';
+import { EnsureAppUserForAuthSession } from './EnsureAppUserForAuthSession';
+
+export type SignInInput = {
+  email: string;
+  password: string;
+};
+
+export class SignIn extends UseCase<SignInInput, AuthSession, DomainError> {
+  constructor(
+    private readonly authGateway: IAuthenticationGateway,
+    private readonly userRepository: IUserRepository,
+  ) {
+    super();
+  }
+
+  async execute(input: SignInInput): Promise<Either<DomainError, AuthSession>> {
+    const sessionResult = await this.authGateway.signInWithPassword({
+      email: input.email,
+      password: input.password,
+    });
+
+    if (sessionResult.isLeft()) return sessionResult;
+
+    const session = sessionResult.value;
+
+    const principalResult =
+      await this.authGateway.getPrincipalFromSession(session);
+
+    if (principalResult.isLeft()) return left(principalResult.value);
+
+    const principal = principalResult.value;
+
+    const ensureResult = await new EnsureAppUserForAuthSession(
+      this.userRepository,
+    ).execute({
+      authSubject: principal.id,
+      email: principal.email,
+    });
+
+    if (ensureResult.isLeft()) return left(ensureResult.value);
+
+    return right(session);
+  }
+}

--- a/packages/application/src/identity/use-cases/index.ts
+++ b/packages/application/src/identity/use-cases/index.ts
@@ -4,3 +4,4 @@ export {
   type EnsureAppUserForAuthSessionInput,
 } from './EnsureAppUserForAuthSession';
 export { GetCurrentUser, type GetCurrentUserInput } from './GetCurrentUser';
+export { SignIn, type SignInInput } from './SignIn';

--- a/packages/application/test/identity/FakeAuthenticationGateway.ts
+++ b/packages/application/test/identity/FakeAuthenticationGateway.ts
@@ -91,6 +91,20 @@ export class FakeAuthenticationGateway implements IAuthenticationGateway {
     return right(stored.principal);
   }
 
+  async getPrincipalFromSession(
+    session: AuthSession,
+  ): Promise<Either<DomainError, AuthPrincipal>> {
+    if (this.forcedError) return left(this.forcedError);
+
+    const email = this._emailFromToken(session.accessToken);
+    const stored = email ? this.users.get(email) : undefined;
+    if (!stored) {
+      return left(new DomainError('INVALID_ACCESS_TOKEN', { message: 'Access token is invalid or expired.' }));
+    }
+
+    return right(stored.principal);
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/packages/application/test/identity/IAuthenticationGateway.test.ts
+++ b/packages/application/test/identity/IAuthenticationGateway.test.ts
@@ -268,3 +268,83 @@ describe('IAuthenticationGateway — getPrincipalFromCookies', () => {
     expect(result.value).toBe(error);
   });
 });
+
+// ---------------------------------------------------------------------------
+// getPrincipalFromSession
+// ---------------------------------------------------------------------------
+
+describe('IAuthenticationGateway — getPrincipalFromSession', () => {
+  let gateway: FakeAuthenticationGateway;
+
+  beforeEach(() => {
+    gateway = new FakeAuthenticationGateway(SEED_USERS);
+  });
+
+  it('should return Right(AuthPrincipal) when session access token is valid', async () => {
+    const session = {
+      accessToken: 'access:admin@example.com:xyz',
+      refreshToken: 'refresh:admin@example.com:xyz',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const result = await gateway.getPrincipalFromSession(session);
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toEqual(ADMIN_PRINCIPAL);
+  });
+
+  it('should return the correct principal for each user', async () => {
+    const session = {
+      accessToken: 'access:visitor@example.com:xyz',
+      refreshToken: 'refresh:visitor@example.com:xyz',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const result = await gateway.getPrincipalFromSession(session);
+
+    expect(result.isRight()).toBe(true);
+    expect(result.value).toEqual(VISITOR_PRINCIPAL);
+  });
+
+  it('should return Left(DomainError) when access token is malformed', async () => {
+    const session = {
+      accessToken: 'malformed-token',
+      refreshToken: 'refresh:admin@example.com:xyz',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const result = await gateway.getPrincipalFromSession(session);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_ACCESS_TOKEN');
+  });
+
+  it('should return Left(DomainError) when access token references unknown user', async () => {
+    const session = {
+      accessToken: 'access:ghost@example.com:xyz',
+      refreshToken: 'refresh:ghost@example.com:xyz',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const result = await gateway.getPrincipalFromSession(session);
+
+    expect(result.isLeft()).toBe(true);
+    expect((result.value as DomainError).code).toBe('INVALID_ACCESS_TOKEN');
+  });
+
+  it('should return Left(DomainError) when a forced error is set', async () => {
+    const error = new DomainError('IDP_UNAVAILABLE', { message: 'Service is down.' });
+    gateway.simulateError(error);
+
+    const session = {
+      accessToken: 'access:admin@example.com:xyz',
+      refreshToken: 'refresh:admin@example.com:xyz',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const result = await gateway.getPrincipalFromSession(session);
+
+    expect(result.isLeft()).toBe(true);
+    expect(result.value).toBe(error);
+  });
+});

--- a/packages/application/test/identity/SignIn.test.ts
+++ b/packages/application/test/identity/SignIn.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { IUserProps, IUserRepository, Role, User } from '@repo/core/identity';
+import { DomainError } from '@repo/core/shared';
+
+import { AuthPrincipal } from '../../src/identity/dtos/AuthPrincipal';
+import { SignIn } from '../../src/identity/use-cases/SignIn';
+import { FakeAuthenticationGateway } from './FakeAuthenticationGateway';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_UUID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VALID_EMAIL = 'admin@example.com';
+const VALID_PASSWORD = 'secret123';
+
+const PRINCIPAL: AuthPrincipal = {
+  id: VALID_UUID,
+  email: VALID_EMAIL,
+  role: 'ADMIN',
+};
+
+const BASE_USER_PROPS: IUserProps = {
+  name: 'Admin User',
+  email: VALID_EMAIL,
+  role: Role.ADMIN,
+  authSubject: VALID_UUID,
+};
+
+function makeUser(overrides: Partial<IUserProps> = {}): User {
+  const result = User.create({ ...BASE_USER_PROPS, ...overrides });
+  if (result.isLeft()) throw new Error(`makeUser failed: ${result.value.message}`);
+  return result.value;
+}
+
+function makeRepository(overrides: Partial<IUserRepository> = {}): IUserRepository {
+  return {
+    findById: vi.fn(),
+    findByEmail: vi.fn().mockResolvedValue(null),
+    findByAuthSubject: vi.fn().mockResolvedValue(null),
+    linkAuthSubject: vi.fn(),
+    save: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeGateway(): FakeAuthenticationGateway {
+  return new FakeAuthenticationGateway({
+    [VALID_EMAIL]: { password: VALID_PASSWORD, principal: PRINCIPAL },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SignIn', () => {
+  describe('execute()', () => {
+    it('should return Right(AuthSession) on valid credentials', async () => {
+      const gateway = makeGateway();
+      const repo = makeRepository();
+      const useCase = new SignIn(gateway, repo);
+
+      const result = await useCase.execute({ email: VALID_EMAIL, password: VALID_PASSWORD });
+
+      expect(result.isRight()).toBe(true);
+      expect(result.value).toMatchObject({
+        accessToken: expect.stringContaining('access:'),
+        refreshToken: expect.stringContaining('refresh:'),
+      });
+    });
+
+    it('should return Left with DomainError when credentials are invalid', async () => {
+      const gateway = makeGateway();
+      const repo = makeRepository();
+      const useCase = new SignIn(gateway, repo);
+
+      const result = await useCase.execute({ email: VALID_EMAIL, password: 'wrong' });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+      expect((result.value as DomainError).code).toBe('INVALID_CREDENTIALS');
+    });
+
+    it('should return Left when getPrincipalFromSession fails', async () => {
+      const gateway = makeGateway();
+      gateway.simulateError(
+        new DomainError('INVALID_ACCESS_TOKEN', { message: 'Token validation failed.' }),
+      );
+      const repo = makeRepository();
+      const useCase = new SignIn(gateway, repo);
+
+      const result = await useCase.execute({ email: VALID_EMAIL, password: VALID_PASSWORD });
+
+      expect(result.isLeft()).toBe(true);
+      expect((result.value as DomainError).code).toBe('INVALID_ACCESS_TOKEN');
+    });
+
+    it('should return Left when EnsureAppUserForAuthSession fails', async () => {
+      const gateway = makeGateway();
+      const repo = makeRepository({
+        findByAuthSubject: vi.fn().mockResolvedValue(null),
+        findByEmail: vi.fn().mockRejectedValue(new Error('DB error')),
+      });
+      const useCase = new SignIn(gateway, repo);
+
+      const result = await useCase.execute({ email: VALID_EMAIL, password: VALID_PASSWORD });
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.value).toBeInstanceOf(DomainError);
+    });
+
+    it('should upsert the app user after successful sign-in', async () => {
+      const gateway = makeGateway();
+      const save = vi.fn().mockResolvedValue(undefined);
+      const repo = makeRepository({ save });
+      const useCase = new SignIn(gateway, repo);
+
+      await useCase.execute({ email: VALID_EMAIL, password: VALID_PASSWORD });
+
+      expect(save).toHaveBeenCalledOnce();
+    });
+
+    it('should not call save when user already exists', async () => {
+      const gateway = makeGateway();
+      const existingUser = makeUser();
+      const save = vi.fn();
+      const repo = makeRepository({
+        findByAuthSubject: vi.fn().mockResolvedValue(existingUser),
+        save,
+      });
+      const useCase = new SignIn(gateway, repo);
+
+      const result = await useCase.execute({ email: VALID_EMAIL, password: VALID_PASSWORD });
+
+      expect(result.isRight()).toBe(true);
+      expect(save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/infra/src/identity/SupabaseAuthenticationGateway.ts
+++ b/packages/infra/src/identity/SupabaseAuthenticationGateway.ts
@@ -162,6 +162,35 @@ export class SupabaseAuthenticationGateway implements IAuthenticationGateway {
     }
   }
 
+  async getPrincipalFromSession(
+    session: AuthSession,
+  ): Promise<Either<DomainError, AuthPrincipal>> {
+    try {
+      const supabase = createClient(this.supabaseUrl, this.supabaseAnonKey, {
+        auth: { persistSession: false },
+      });
+
+      const { data, error } = await supabase.auth.getUser(session.accessToken);
+
+      if (error || !data.user) {
+        return left(
+          new DomainError('INVALID_ACCESS_TOKEN', {
+            message: error?.message ?? 'Access token is invalid or expired.',
+          }),
+        );
+      }
+
+      return right({
+        id: data.user.id,
+        email: data.user.email ?? '',
+        role:
+          (data.user.app_metadata?.['role'] as string | undefined) ?? 'VISITOR',
+      });
+    } catch (err) {
+      return left(this._unexpectedError(err));
+    }
+  }
+
   private _unexpectedError(err: unknown): DomainError {
     const message =
       err instanceof Error ? err.message : 'Unexpected authentication error.';


### PR DESCRIPTION
## Summary

- Adds `getPrincipalFromSession(session: AuthSession)` to `IAuthenticationGateway` — removes the fake-cookie hack where the route handler built a manual cookie reader just to validate the access token after sign-in
- Creates `SignIn` use case in `@repo/application/identity` that orchestrates `signInWithPassword → getPrincipalFromSession → EnsureAppUserForAuthSession`
- Simplifies `POST /api/v1/auth/sign-in` route handler to ~15 lines: validate input, call `SignIn.execute()`, set cookies, return 200

## Test plan

- [x] `SignIn.test.ts` — 6 tests covering success, invalid credentials, gateway failure, DB failure, user upsert, and existing user short-circuit
- [x] `IAuthenticationGateway.test.ts` — 5 new contract tests for `getPrincipalFromSession` on `FakeAuthenticationGateway`
- [x] `FakeAuthenticationGateway` updated to implement the new port method
- [x] `SupabaseAuthenticationGateway` implements `getPrincipalFromSession` (reuses `getUser(accessToken)` logic)
- [x] `apps/site` route test updated to mock `getPrincipalFromSession` instead of `getPrincipalFromCookies`
- [x] All 188 site tests, 169 application tests pass; TypeScript clean across `@repo/infra` and `apps/site`

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)