### PR TITLE
refactor(auth): move cookie management out of gateway into route handlers

### DIFF
--- a/apps/site/src/app/api/v1/auth/refresh/route.ts
+++ b/apps/site/src/app/api/v1/auth/refresh/route.ts
@@ -1,39 +1,19 @@
 import { right } from '@repo/core/shared';
-import {
-  SUPABASE_ACCESS_TOKEN_COOKIE,
-  SUPABASE_REFRESH_TOKEN_COOKIE,
-  getContainer,
-} from '@repo/infra';
+import { SUPABASE_REFRESH_TOKEN_COOKIE, getContainer } from '@repo/infra';
 
 import { handleRequest } from '~/lib/api/handler';
-import { createNextAuthCookieApi } from '~/lib/auth/cookie';
+import { createNextAuthCookieApi, setSessionCookies } from '~/lib/auth/cookie';
 
 export async function POST() {
   return handleRequest(async () => {
     const { authGateway } = getContainer();
     const cookieApi = await createNextAuthCookieApi();
+    const refreshToken = cookieApi.get(SUPABASE_REFRESH_TOKEN_COOKIE) ?? '';
 
-    const sessionResult = await authGateway.refreshSession(cookieApi);
+    const sessionResult = await authGateway.refreshSession(refreshToken);
     if (sessionResult.isLeft()) return sessionResult;
 
-    const session = sessionResult.value;
-    const expiresIn = session.expiresAt - Math.floor(Date.now() / 1000);
-
-    cookieApi.set(SUPABASE_ACCESS_TOKEN_COOKIE, session.accessToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: expiresIn,
-      path: '/',
-    });
-    cookieApi.set(SUPABASE_REFRESH_TOKEN_COOKIE, session.refreshToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 30,
-      path: '/',
-    });
-
+    setSessionCookies(cookieApi, sessionResult.value);
     return right(null as unknown);
   });
 }

--- a/apps/site/src/app/api/v1/auth/sign-in/route.ts
+++ b/apps/site/src/app/api/v1/auth/sign-in/route.ts
@@ -1,17 +1,13 @@
 import { SignIn } from '@repo/application/identity';
 import { ValidationError, left } from '@repo/core/shared';
-import {
-  SUPABASE_ACCESS_TOKEN_COOKIE,
-  SUPABASE_REFRESH_TOKEN_COOKIE,
-  getContainer,
-} from '@repo/infra';
+import { getContainer } from '@repo/infra';
 import { Validator } from '@repo/utils/validator';
 import { NextRequest } from 'next/server';
 
 import { HttpErrorCodes } from '~/lib/api/error-codes';
 import { handleRequest } from '~/lib/api/handler';
 import { resolveLocale } from '~/lib/api/locale';
-import { createNextAuthCookieApi } from '~/lib/auth/cookie';
+import { createNextAuthCookieApi, setSessionCookies } from '~/lib/auth/cookie';
 
 export async function POST(request: NextRequest) {
   const locale = resolveLocale(request);
@@ -41,22 +37,8 @@ export async function POST(request: NextRequest) {
 
       const session = result.value;
       const cookieApi = await createNextAuthCookieApi();
-      const expiresIn = session.expiresAt - Math.floor(Date.now() / 1000);
 
-      cookieApi.set(SUPABASE_ACCESS_TOKEN_COOKIE, session.accessToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        maxAge: expiresIn,
-        path: '/',
-      });
-      cookieApi.set(SUPABASE_REFRESH_TOKEN_COOKIE, session.refreshToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        maxAge: 60 * 60 * 24 * 30,
-        path: '/',
-      });
+      setSessionCookies(cookieApi, session);
 
       return result;
     },

--- a/apps/site/src/app/api/v1/auth/sign-out/route.ts
+++ b/apps/site/src/app/api/v1/auth/sign-out/route.ts
@@ -1,17 +1,27 @@
 import { right } from '@repo/core/shared';
-import { getContainer } from '@repo/infra';
+import {
+  SUPABASE_ACCESS_TOKEN_COOKIE,
+  SUPABASE_REFRESH_TOKEN_COOKIE,
+  getContainer,
+} from '@repo/infra';
 
 import { handleRequest } from '~/lib/api/handler';
-import { createNextAuthCookieApi } from '~/lib/auth/cookie';
+import {
+  clearSessionCookies,
+  createNextAuthCookieApi,
+} from '~/lib/auth/cookie';
 
 export async function POST() {
   return handleRequest(async () => {
     const { authGateway } = getContainer();
     const cookieApi = await createNextAuthCookieApi();
+    const accessToken = cookieApi.get(SUPABASE_ACCESS_TOKEN_COOKIE) ?? '';
+    const refreshToken = cookieApi.get(SUPABASE_REFRESH_TOKEN_COOKIE) ?? '';
 
-    const result = await authGateway.signOut(cookieApi);
+    const result = await authGateway.signOut(accessToken, refreshToken);
     if (result.isLeft()) return result;
 
+    clearSessionCookies(cookieApi);
     return right(null as unknown);
   });
 }

--- a/apps/site/src/lib/auth/cookie.ts
+++ b/apps/site/src/lib/auth/cookie.ts
@@ -1,7 +1,12 @@
 import type {
   AuthCookieApi,
+  AuthSession,
   CookieSetOptions,
 } from '@repo/application/identity';
+import {
+  SUPABASE_ACCESS_TOKEN_COOKIE,
+  SUPABASE_REFRESH_TOKEN_COOKIE,
+} from '@repo/infra';
 import { cookies } from 'next/headers';
 
 export async function createNextAuthCookieApi(): Promise<AuthCookieApi> {
@@ -17,4 +22,30 @@ export async function createNextAuthCookieApi(): Promise<AuthCookieApi> {
       jar.delete(name);
     },
   };
+}
+
+export function setSessionCookies(
+  cookieApi: AuthCookieApi,
+  session: AuthSession,
+): void {
+  const expiresIn = session.expiresAt - Math.floor(Date.now() / 1000);
+  cookieApi.set(SUPABASE_ACCESS_TOKEN_COOKIE, session.accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: expiresIn,
+    path: '/',
+  });
+  cookieApi.set(SUPABASE_REFRESH_TOKEN_COOKIE, session.refreshToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 30,
+    path: '/',
+  });
+}
+
+export function clearSessionCookies(cookieApi: AuthCookieApi): void {
+  cookieApi.delete(SUPABASE_ACCESS_TOKEN_COOKIE);
+  cookieApi.delete(SUPABASE_REFRESH_TOKEN_COOKIE);
 }

--- a/apps/site/tests/app/api/v1/auth/refresh/route.test.ts
+++ b/apps/site/tests/app/api/v1/auth/refresh/route.test.ts
@@ -25,7 +25,7 @@ vi.mock('next/headers', () => ({
 const mockRefresh = vi.fn();
 
 beforeEach(() => {
-  mockCookieStore.store = {};
+  mockCookieStore.store = { 'sb-refresh-token': 'refresh-token-456' };
   vi.clearAllMocks();
 
   mockCookieStore.get.mockImplementation((name: string) => {
@@ -69,11 +69,40 @@ describe('POST /api/v1/auth/refresh', () => {
     );
   });
 
-  it('should return 401 when no refresh token is present', async () => {
+  it('should pass the refresh token string directly to the gateway', async () => {
+    const { right } = await import('@repo/core/shared');
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+    mockRefresh.mockResolvedValue(
+      right({ accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt }),
+    );
+
+    await POST();
+
+    expect(mockRefresh).toHaveBeenCalledOnce();
+    expect(mockRefresh).toHaveBeenCalledWith('refresh-token-456');
+  });
+
+  it('should pass empty string when no refresh token cookie is present', async () => {
+    const { left } = await import('@repo/core/shared');
+    const { DomainError } = await import('@repo/core/shared');
+    mockCookieStore.store = {};
+    mockRefresh.mockResolvedValue(
+      left(new DomainError('NO_REFRESH_TOKEN', { message: 'No refresh token.' })),
+    );
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(mockRefresh).toHaveBeenCalledWith('');
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe('AUTH_REQUIRED');
+  });
+
+  it('should return 401 when refresh token is invalid', async () => {
     const { left } = await import('@repo/core/shared');
     const { DomainError } = await import('@repo/core/shared');
     mockRefresh.mockResolvedValue(
-      left(new DomainError('NO_REFRESH_TOKEN', { message: 'No refresh token.' })),
+      left(new DomainError('INVALID_REFRESH_TOKEN', { message: 'Token expired.' })),
     );
 
     const response = await POST();

--- a/apps/site/tests/app/api/v1/auth/sign-out/route.test.ts
+++ b/apps/site/tests/app/api/v1/auth/sign-out/route.test.ts
@@ -7,9 +7,12 @@ import { POST } from '~/app/api/v1/auth/sign-out/route';
 
 vi.mock('@repo/infra', () => ({
   getContainer: vi.fn(),
+  SUPABASE_ACCESS_TOKEN_COOKIE: 'sb-access-token',
+  SUPABASE_REFRESH_TOKEN_COOKIE: 'sb-refresh-token',
 }));
 
 const mockCookieStore = {
+  store: {} as Record<string, string>,
   get: vi.fn(),
   set: vi.fn(),
   delete: vi.fn(),
@@ -22,7 +25,19 @@ vi.mock('next/headers', () => ({
 const mockSignOut = vi.fn();
 
 beforeEach(() => {
+  mockCookieStore.store = {
+    'sb-access-token': 'access-token-123',
+    'sb-refresh-token': 'refresh-token-456',
+  };
   vi.clearAllMocks();
+
+  mockCookieStore.get.mockImplementation((name: string) => {
+    const value = mockCookieStore.store[name];
+    return value !== undefined ? { name, value } : undefined;
+  });
+  mockCookieStore.delete.mockImplementation((name: string) => {
+    delete mockCookieStore.store[name];
+  });
 
   vi.mocked(getContainer).mockReturnValue({
     authGateway: {
@@ -44,17 +59,46 @@ describe('POST /api/v1/auth/sign-out', () => {
     expect(response.status).toBe(200);
   });
 
-  it('should pass cookie api to gateway signOut', async () => {
+  it('should pass access and refresh tokens directly to gateway signOut', async () => {
     const { right } = await import('@repo/core/shared');
     mockSignOut.mockResolvedValue(right(undefined));
 
     await POST();
 
     expect(mockSignOut).toHaveBeenCalledOnce();
-    const cookieArg = mockSignOut.mock.calls[0]![0];
-    expect(typeof cookieArg.get).toBe('function');
-    expect(typeof cookieArg.set).toBe('function');
-    expect(typeof cookieArg.delete).toBe('function');
+    expect(mockSignOut).toHaveBeenCalledWith('access-token-123', 'refresh-token-456');
+  });
+
+  it('should clear session cookies after successful sign-out', async () => {
+    const { right } = await import('@repo/core/shared');
+    mockSignOut.mockResolvedValue(right(undefined));
+
+    await POST();
+
+    expect(mockCookieStore.delete).toHaveBeenCalledWith('sb-access-token');
+    expect(mockCookieStore.delete).toHaveBeenCalledWith('sb-refresh-token');
+  });
+
+  it('should not clear cookies when gateway returns an error', async () => {
+    const { left } = await import('@repo/core/shared');
+    const { DomainError } = await import('@repo/core/shared');
+    mockSignOut.mockResolvedValue(
+      left(new DomainError('AUTH_UNEXPECTED_ERROR', { message: 'IdP error.' })),
+    );
+
+    await POST();
+
+    expect(mockCookieStore.delete).not.toHaveBeenCalled();
+  });
+
+  it('should pass empty strings when cookies are absent', async () => {
+    const { right } = await import('@repo/core/shared');
+    mockCookieStore.store = {};
+    mockSignOut.mockResolvedValue(right(undefined));
+
+    await POST();
+
+    expect(mockSignOut).toHaveBeenCalledWith('', '');
   });
 
   it('should return 500 when sign-out gateway throws', async () => {

--- a/packages/application/src/identity/ports/IAuthenticationGateway.ts
+++ b/packages/application/src/identity/ports/IAuthenticationGateway.ts
@@ -26,17 +26,20 @@ export interface IAuthenticationGateway {
   ): Promise<Either<DomainError, AuthSession>>;
 
   /**
-   * Invalidate the current session.
-   * Reads the access token from cookies to identify the session at the IdP.
+   * Invalidate the current session at the IdP.
+   * The caller is responsible for clearing cookies after this returns.
    */
-  signOut(cookies: AuthCookieApi): Promise<Either<DomainError, void>>;
+  signOut(
+    accessToken: string,
+    refreshToken: string,
+  ): Promise<Either<DomainError, void>>;
 
   /**
-   * Obtain a fresh session using the refresh token stored in cookies.
-   * Returns a new `AuthSession`; the caller updates the cookies.
+   * Exchange a refresh token for a new session.
+   * Returns a new `AuthSession`; the caller is responsible for updating cookies.
    */
   refreshSession(
-    cookies: AuthCookieApi,
+    refreshToken: string,
   ): Promise<Either<DomainError, AuthSession>>;
 
   /**

--- a/packages/application/test/identity/FakeAuthenticationGateway.ts
+++ b/packages/application/test/identity/FakeAuthenticationGateway.ts
@@ -6,7 +6,6 @@ import { AuthPrincipal } from '~/identity/dtos/AuthPrincipal';
 import { AuthSession } from '~/identity/dtos/AuthSession';
 
 const ACCESS_TOKEN_COOKIE = 'sb-access-token';
-const REFRESH_TOKEN_COOKIE = 'sb-refresh-token';
 
 type StoredUser = { password: string; principal: AuthPrincipal };
 
@@ -48,20 +47,21 @@ export class FakeAuthenticationGateway implements IAuthenticationGateway {
     return right(this._makeSession(credentials.email));
   }
 
-  async signOut(cookies: AuthCookieApi): Promise<Either<DomainError, void>> {
+  async signOut(
+    _accessToken: string,
+    _refreshToken: string,
+  ): Promise<Either<DomainError, void>> {
     if (this.forcedError) return left(this.forcedError);
-
-    cookies.delete(ACCESS_TOKEN_COOKIE);
-    cookies.delete(REFRESH_TOKEN_COOKIE);
     return right(undefined);
   }
 
-  async refreshSession(cookies: AuthCookieApi): Promise<Either<DomainError, AuthSession>> {
+  async refreshSession(
+    refreshToken: string,
+  ): Promise<Either<DomainError, AuthSession>> {
     if (this.forcedError) return left(this.forcedError);
 
-    const refreshToken = cookies.get(REFRESH_TOKEN_COOKIE);
     if (!refreshToken) {
-      return left(new DomainError('NO_REFRESH_TOKEN', { message: 'No refresh token in cookies.' }));
+      return left(new DomainError('NO_REFRESH_TOKEN', { message: 'No refresh token.' }));
     }
 
     const email = this._emailFromToken(refreshToken);

--- a/packages/application/test/identity/IAuthenticationGateway.test.ts
+++ b/packages/application/test/identity/IAuthenticationGateway.test.ts
@@ -102,23 +102,17 @@ describe('IAuthenticationGateway — signOut', () => {
     gateway = new FakeAuthenticationGateway(SEED_USERS);
   });
 
-  it('should return Right(void) and remove tokens from cookies', async () => {
-    const cookies = makeCookieApi({
-      'sb-access-token': 'access:admin@example.com:abc',
-      'sb-refresh-token': 'refresh:admin@example.com:abc',
-    });
-
-    const result = await gateway.signOut(cookies);
+  it('should return Right(void) when called with valid tokens', async () => {
+    const result = await gateway.signOut(
+      'access:admin@example.com:abc',
+      'refresh:admin@example.com:abc',
+    );
 
     expect(result.isRight()).toBe(true);
-    expect(cookies.store['sb-access-token']).toBeUndefined();
-    expect(cookies.store['sb-refresh-token']).toBeUndefined();
   });
 
-  it('should return Right(void) even when cookies are already empty', async () => {
-    const cookies = makeCookieApi();
-
-    const result = await gateway.signOut(cookies);
+  it('should return Right(void) when called with empty tokens', async () => {
+    const result = await gateway.signOut('', '');
 
     expect(result.isRight()).toBe(true);
   });
@@ -127,7 +121,7 @@ describe('IAuthenticationGateway — signOut', () => {
     const error = new DomainError('IDP_UNAVAILABLE', { message: 'Service is down.' });
     gateway.simulateError(error);
 
-    const result = await gateway.signOut(makeCookieApi());
+    const result = await gateway.signOut('access-token', 'refresh-token');
 
     expect(result.isLeft()).toBe(true);
     expect(result.value).toBe(error);
@@ -146,11 +140,7 @@ describe('IAuthenticationGateway — refreshSession', () => {
   });
 
   it('should return Right(AuthSession) with a new session when refresh token is valid', async () => {
-    const cookies = makeCookieApi({
-      'sb-refresh-token': 'refresh:admin@example.com:abc',
-    });
-
-    const result = await gateway.refreshSession(cookies);
+    const result = await gateway.refreshSession('refresh:admin@example.com:abc');
 
     expect(result.isRight()).toBe(true);
     expect(result.value).toMatchObject({
@@ -160,28 +150,22 @@ describe('IAuthenticationGateway — refreshSession', () => {
     });
   });
 
-  it('should return Left(DomainError) when no refresh token cookie is present', async () => {
-    const cookies = makeCookieApi();
-
-    const result = await gateway.refreshSession(cookies);
+  it('should return Left(DomainError) when refresh token is empty', async () => {
+    const result = await gateway.refreshSession('');
 
     expect(result.isLeft()).toBe(true);
     expect((result.value as DomainError).code).toBe('NO_REFRESH_TOKEN');
   });
 
   it('should return Left(DomainError) when refresh token is malformed', async () => {
-    const cookies = makeCookieApi({ 'sb-refresh-token': 'malformed-token' });
-
-    const result = await gateway.refreshSession(cookies);
+    const result = await gateway.refreshSession('malformed-token');
 
     expect(result.isLeft()).toBe(true);
     expect((result.value as DomainError).code).toBe('INVALID_REFRESH_TOKEN');
   });
 
   it('should return Left(DomainError) when refresh token references unknown user', async () => {
-    const cookies = makeCookieApi({ 'sb-refresh-token': 'refresh:ghost@example.com:abc' });
-
-    const result = await gateway.refreshSession(cookies);
+    const result = await gateway.refreshSession('refresh:ghost@example.com:abc');
 
     expect(result.isLeft()).toBe(true);
     expect((result.value as DomainError).code).toBe('INVALID_REFRESH_TOKEN');
@@ -191,7 +175,7 @@ describe('IAuthenticationGateway — refreshSession', () => {
     const error = new DomainError('IDP_UNAVAILABLE', { message: 'Service is down.' });
     gateway.simulateError(error);
 
-    const result = await gateway.refreshSession(makeCookieApi());
+    const result = await gateway.refreshSession('refresh:admin@example.com:abc');
 
     expect(result.isLeft()).toBe(true);
     expect(result.value).toBe(error);

--- a/packages/infra/src/identity/SupabaseAuthenticationGateway.ts
+++ b/packages/infra/src/identity/SupabaseAuthenticationGateway.ts
@@ -57,11 +57,11 @@ export class SupabaseAuthenticationGateway implements IAuthenticationGateway {
     }
   }
 
-  async signOut(cookies: AuthCookieApi): Promise<Either<DomainError, void>> {
+  async signOut(
+    accessToken: string,
+    refreshToken: string,
+  ): Promise<Either<DomainError, void>> {
     try {
-      const accessToken = cookies.get(SUPABASE_ACCESS_TOKEN_COOKIE);
-      const refreshToken = cookies.get(SUPABASE_REFRESH_TOKEN_COOKIE);
-
       if (accessToken && refreshToken) {
         const supabase = createClient(this.supabaseUrl, this.supabaseAnonKey, {
           auth: { persistSession: false },
@@ -73,9 +73,6 @@ export class SupabaseAuthenticationGateway implements IAuthenticationGateway {
         await supabase.auth.signOut();
       }
 
-      cookies.delete(SUPABASE_ACCESS_TOKEN_COOKIE);
-      cookies.delete(SUPABASE_REFRESH_TOKEN_COOKIE);
-
       return right(undefined);
     } catch (err) {
       return left(this._unexpectedError(err));
@@ -83,11 +80,9 @@ export class SupabaseAuthenticationGateway implements IAuthenticationGateway {
   }
 
   async refreshSession(
-    cookies: AuthCookieApi,
+    refreshToken: string,
   ): Promise<Either<DomainError, AuthSession>> {
     try {
-      const refreshToken = cookies.get(SUPABASE_REFRESH_TOKEN_COOKIE);
-
       if (!refreshToken) {
         return left(
           new DomainError('NO_REFRESH_TOKEN', {


### PR DESCRIPTION
## Summary

- `IAuthenticationGateway.signOut` now receives `(accessToken: string, refreshToken: string)` — the gateway only invalidates the IdP session and returns; the route handler reads the tokens from cookies and clears them after
- `IAuthenticationGateway.refreshSession` now receives `(refreshToken: string)` — the gateway exchanges the token and returns a new `AuthSession`; the route handler updates the cookies
- `cookie.ts` gains two new helpers: `setSessionCookies(cookieApi, session)` and `clearSessionCookies(cookieApi)` — eliminating the duplicated cookie-option block that existed in both sign-in and refresh routes

## Test plan

- [x] `sign-out/route.test.ts` — 6 tests: verifies gateway receives token strings directly, cookies are cleared after success, cookies are not cleared on gateway error, empty tokens on missing cookies
- [x] `refresh/route.test.ts` — 5 tests: verifies gateway receives refresh token string, cookie update via `setSessionCookies`, 401 on empty token, 401 on invalid token, 500 on throw
- [x] `IAuthenticationGateway.test.ts` — `signOut` and `refreshSession` contract tests updated to match new signatures
- [x] `FakeAuthenticationGateway` updated accordingly
- [x] All 193 site tests and 158 application tests pass; TypeScript clean across `@repo/infra` and `apps/site`

Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)