### PR TITLE
feat(site): add SEO metadata, Open Graph, sitemap and robots

### DIFF
--- a/apps/site/.env.example
+++ b/apps/site/.env.example
@@ -34,6 +34,7 @@ CONTACT_EMAIL_FROM="onboarding@resend.dev"
 # ── Public (exposed to the browser) ───────────────────────────────────────────
 NEXT_PUBLIC_CONTACT_EMAIL="your@email.com"
 NEXT_PUBLIC_CONTACT_NUMBER="5511999999999"
+NEXT_PUBLIC_SITE_URL="https://your-domain.com"
 NEXT_PUBLIC_GITHUB_URL="https://github.com/your-username"
 NEXT_PUBLIC_LINKEDIN_URL="https://www.linkedin.com/in/your-profile/"
 NEXT_PUBLIC_RESUME_URL="https://docs.google.com/..."

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -19,6 +19,8 @@ const nextConfig = {
     remotePatterns: [
       { protocol: 'https', hostname: 'cdn.pixabay.com' },
       { protocol: 'https', hostname: 'placehold.co' },
+      { protocol: 'https', hostname: 'github.com' },
+      { protocol: 'https', hostname: 'opengraph.githubassets.com' },
     ],
   },
 };

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
     NEXT_PUBLIC_LINKEDIN_URL: process.env.NEXT_PUBLIC_LINKEDIN_URL,
     NEXT_PUBLIC_RESUME_URL: process.env.NEXT_PUBLIC_RESUME_URL,
     NEXT_PUBLIC_WHATSAPP_URL: process.env.NEXT_PUBLIC_WHATSAPP_URL,
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
   },
   images: {
     qualities: [100, 75],

--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -1,6 +1,9 @@
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
 
 import { applyDevSimulations } from '~/dev/simulate';
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
 import {
   ExperiencesSection,
   ExperiencesSkeleton,
@@ -10,7 +13,48 @@ import { ValuesSection, ValuesSkeleton } from '~features/about/ValuesSection';
 import { HeroBannerSkeleton } from '~features/shared/HeroBanner/HeroBannerSkeleton';
 
 interface AboutPageProps {
+  params?: Promise<{ locale: string }>;
   searchParams?: Promise<{ loading?: string; error?: string }>;
+}
+
+interface ProfileMeta {
+  name: string;
+  bio: string;
+  photo: { url: string; alt: string };
+}
+
+export async function generateMetadata({
+  params,
+}: AboutPageProps): Promise<Metadata> {
+  const locale = (await params)?.locale ?? 'en-US';
+  const baseUrl = await getInternalBaseUrl();
+
+  const res = await fetch(`${baseUrl}/api/v1/profile?locale=${locale}`, {
+    cache: 'no-store',
+  }).catch(() => null);
+
+  const title = locale.startsWith('pt')
+    ? 'Sobre'
+    : locale.startsWith('es')
+      ? 'Sobre'
+      : 'About';
+
+  if (!res?.ok) return { title };
+
+  const body: ApiResponse<ProfileMeta> = await res.json();
+  if (body.error) return { title };
+
+  const { bio, photo } = body.data;
+
+  return {
+    title,
+    description: bio,
+    openGraph: {
+      title,
+      description: bio,
+      images: [{ url: photo.url, alt: photo.alt }],
+    },
+  };
 }
 
 export default async function About({ searchParams }: AboutPageProps) {

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import { Inter } from 'next/font/google';
+import type { Metadata } from 'next';
 
 import { AppLayout } from '~components';
 
@@ -9,6 +10,28 @@ import '@repo/tailwind-config/tailwind.css';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'], display: 'swap' });
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: 'Wallace Ferreira',
+    template: '%s | Wallace Ferreira',
+  },
+  description:
+    'Frontend Software Engineer with 6+ years of experience building scalable, performant, and accessible web products with React, Next.js, and TypeScript.',
+  openGraph: {
+    type: 'website',
+    siteName: 'Wallace Ferreira',
+    images: [
+      { url: 'https://github.com/wallace-sf.png', alt: 'Wallace Ferreira' },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+  },
+};
 
 export default async function RootLayout({
   children,

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -1,6 +1,9 @@
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
 
 import { applyDevSimulations } from '~/dev/simulate';
+import { ApiResponse } from '~/lib/api/envelope';
+import { getInternalBaseUrl } from '~/lib/api/internal';
 import { HeroSection } from '~features/home/HeroSection';
 import {
   ProjectsSection,
@@ -10,7 +13,43 @@ import { HeroBannerSkeleton } from '~features/shared/HeroBanner/HeroBannerSkelet
 import { ContactSection } from '~features/contact/ContactSection';
 
 interface HomePageProps {
+  params?: Promise<{ locale: string }>;
   searchParams?: Promise<{ loading?: string; error?: string }>;
+}
+
+interface ProfileMeta {
+  name: string;
+  headline: string;
+  bio: string;
+  photo: { url: string; alt: string };
+}
+
+export async function generateMetadata({
+  params,
+}: HomePageProps): Promise<Metadata> {
+  const locale = (await params)?.locale ?? 'en-US';
+  const baseUrl = await getInternalBaseUrl();
+
+  const res = await fetch(`${baseUrl}/api/v1/profile?locale=${locale}`, {
+    cache: 'no-store',
+  }).catch(() => null);
+
+  if (!res?.ok) return {};
+
+  const body: ApiResponse<ProfileMeta> = await res.json();
+  if (body.error) return {};
+
+  const { name, headline, photo } = body.data;
+
+  return {
+    title: name,
+    description: headline,
+    openGraph: {
+      title: name,
+      description: headline,
+      images: [{ url: photo.url, alt: photo.alt }],
+    },
+  };
 }
 
 export default async function Home({ searchParams }: HomePageProps) {

--- a/apps/site/src/app/[locale]/projects/[slug]/page.tsx
+++ b/apps/site/src/app/[locale]/projects/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
 
 import { ApiResponse } from '~/lib/api/envelope';
 import { getInternalBaseUrl } from '~/lib/api/internal';
@@ -11,7 +12,43 @@ import {
 type ProjectDetailData = IProjectDetailProps & { id: string };
 
 interface ProjectDetailPageProps {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ locale: string; slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: ProjectDetailPageProps): Promise<Metadata> {
+  const { locale, slug } = await params;
+  const baseUrl = await getInternalBaseUrl();
+
+  const res = await fetch(
+    `${baseUrl}/api/v1/projects/${slug}?locale=${locale}`,
+    {
+      cache: 'no-store',
+    },
+  ).catch(() => null);
+
+  if (!res?.ok) return {};
+
+  const body: ApiResponse<{
+    title: string;
+    caption: string;
+    coverImageUrl: string;
+    coverImageAlt: string;
+  }> = await res.json();
+  if (body.error) return {};
+
+  const { title, caption, coverImageUrl, coverImageAlt } = body.data;
+
+  return {
+    title,
+    description: caption,
+    openGraph: {
+      title,
+      description: caption,
+      images: [{ url: coverImageUrl, alt: coverImageAlt }],
+    },
+  };
 }
 
 export default async function ProjectDetailPage({

--- a/apps/site/src/app/[locale]/projects/page.tsx
+++ b/apps/site/src/app/[locale]/projects/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
 
 import { applyDevSimulations } from '~/dev/simulate';
 import { HeroSection } from '~features/projects/HeroSection';
@@ -7,7 +8,26 @@ import { ProjectsSkeleton } from '~features/home/ProjectsSection';
 import { HeroBannerSkeleton } from '~features/shared/HeroBanner/HeroBannerSkeleton';
 
 interface ProjectsPageProps {
+  params?: Promise<{ locale: string }>;
   searchParams?: Promise<{ loading?: string; error?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: ProjectsPageProps): Promise<Metadata> {
+  const locale = (await params)?.locale ?? 'en-US';
+  const title = locale.startsWith('pt')
+    ? 'Projetos'
+    : locale.startsWith('es')
+      ? 'Proyectos'
+      : 'Projects';
+  const description = locale.startsWith('pt')
+    ? 'Projetos de software desenvolvidos por Wallace Ferreira — aplicações web escaláveis com React, Next.js e TypeScript.'
+    : locale.startsWith('es')
+      ? 'Proyectos de software desarrollados por Wallace Ferreira — aplicaciones web escalables con React, Next.js y TypeScript.'
+      : 'Software projects developed by Wallace Ferreira — scalable web applications built with React, Next.js, and TypeScript.';
+
+  return { title, description, openGraph: { title, description } };
 }
 
 export default async function Projects({ searchParams }: ProjectsPageProps) {

--- a/apps/site/src/app/robots.ts
+++ b/apps/site/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from 'next';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/apps/site/src/app/sitemap.ts
+++ b/apps/site/src/app/sitemap.ts
@@ -1,0 +1,42 @@
+import type { MetadataRoute } from 'next';
+
+import { ApiResponse } from '~/lib/api/envelope';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+const LOCALES = ['en-US', 'pt-BR', 'es'] as const;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticRoutes = ['', '/about', '/projects'];
+
+  const staticEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) =>
+    staticRoutes.map((route) => ({
+      url: `${SITE_URL}/${locale}${route}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: route === '' ? 1.0 : 0.8,
+    })),
+  );
+
+  try {
+    const res = await fetch(`${SITE_URL}/api/v1/projects`, {
+      cache: 'no-store',
+    });
+    if (!res.ok) return staticEntries;
+
+    const body: ApiResponse<{ slug: string }[]> = await res.json();
+    if (body.error) return staticEntries;
+
+    const projectEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) =>
+      body.data.map((project) => ({
+        url: `${SITE_URL}/${locale}/projects/${project.slug}`,
+        lastModified: new Date(),
+        changeFrequency: 'monthly' as const,
+        priority: 0.6,
+      })),
+    );
+
+    return [...staticEntries, ...projectEntries];
+  } catch {
+    return staticEntries;
+  }
+}

--- a/apps/site/tests/app/[locale]/project-detail.test.tsx
+++ b/apps/site/tests/app/[locale]/project-detail.test.tsx
@@ -76,7 +76,7 @@ describe('ProjectDetailPage', () => {
     const { default: Page } = await import(
       '~/app/[locale]/projects/[slug]/page'
     );
-    render(await Page({ params: Promise.resolve({ slug: 'my-project' }) }));
+    render(await Page({ params: Promise.resolve({ locale: 'en-US', slug: 'my-project' }) }));
     expect(screen.getByTestId('project-detail')).toBeInTheDocument();
     expect(screen.getByText('My Project')).toBeInTheDocument();
   });
@@ -88,7 +88,7 @@ describe('ProjectDetailPage', () => {
       '~/app/[locale]/projects/[slug]/page'
     );
     await expect(
-      Page({ params: Promise.resolve({ slug: 'missing' }) }),
+      Page({ params: Promise.resolve({ locale: 'en-US', slug: 'missing' }) }),
     ).rejects.toThrow('NEXT_NOT_FOUND');
     expect(notFound).toHaveBeenCalled();
   });
@@ -100,7 +100,7 @@ describe('ProjectDetailPage', () => {
       '~/app/[locale]/projects/[slug]/page'
     );
     await expect(
-      Page({ params: Promise.resolve({ slug: 'my-project' }) }),
+      Page({ params: Promise.resolve({ locale: 'en-US', slug: 'my-project' }) }),
     ).rejects.toThrow('NEXT_NOT_FOUND');
     expect(notFound).toHaveBeenCalled();
   });
@@ -119,7 +119,7 @@ describe('ProjectDetailPage', () => {
       '~/app/[locale]/projects/[slug]/page'
     );
     await expect(
-      Page({ params: Promise.resolve({ slug: 'my-project' }) }),
+      Page({ params: Promise.resolve({ locale: 'en-US', slug: 'my-project' }) }),
     ).rejects.toThrow('NEXT_NOT_FOUND');
     expect(notFound).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- **Global metadata** (`layout.tsx`): title template (`%s | Wallace Ferreira`), `metadataBase` via `NEXT_PUBLIC_SITE_URL`, Open Graph base config, Twitter `summary_large_image` card
- **Home** `generateMetadata`: fetches profile API — uses real name as title, headline as description, photo as og:image
- **About** `generateMetadata`: locale-aware title (About / Sobre), bio as description
- **Projects** `generateMetadata`: locale-aware title + description in en/pt/es
- **Project detail** `generateMetadata`: project title, caption as description, `coverImageUrl` as og:image
- **`sitemap.ts`**: static routes (`/`, `/about`, `/projects`) + published project slugs for all 3 locales (en-US, pt-BR, es)
- **`robots.ts`**: allow all crawlers, sitemap pointer
- `NEXT_PUBLIC_SITE_URL` added to `next.config.mjs` env block and `.env.example`

## Test plan

- [ ] Set `NEXT_PUBLIC_SITE_URL` in `.env.local` and restart dev server
- [ ] Check `<title>` and `<meta name="description">` on each page via browser DevTools
- [ ] Visit `/sitemap.xml` — should list all routes for all 3 locales
- [ ] Visit `/robots.txt` — should allow `*` and point to sitemap
- [ ] Share a project URL on a social preview tool (e.g. opengraph.xyz) — should show project title, caption, and cover image

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)