### PR TITLE
feat(site): add RSS feed and nav link

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -35,7 +35,8 @@
     "language": "Language",
     "theme": "Theme",
     "linkedin": "LinkedIn",
-    "github": "GitHub"
+    "github": "GitHub",
+    "rss": "RSS Feed"
   },
   "Theme": {
     "light": "Light",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -35,7 +35,8 @@
     "language": "Idioma",
     "theme": "Tema",
     "linkedin": "LinkedIn",
-    "github": "GitHub"
+    "github": "GitHub",
+    "rss": "RSS Feed"
   },
   "Theme": {
     "light": "Claro",

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -35,7 +35,8 @@
     "language": "Idioma",
     "theme": "Tema",
     "linkedin": "LinkedIn",
-    "github": "GitHub"
+    "github": "GitHub",
+    "rss": "RSS Feed"
   },
   "Theme": {
     "light": "Claro",

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -31,6 +31,13 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
   },
+  alternates: {
+    types: {
+      'application/rss+xml': [
+        { url: `${SITE_URL}/feed.xml`, title: 'Wallace Ferreira' },
+      ],
+    },
+  },
 };
 
 export default async function RootLayout({

--- a/apps/site/src/app/feed.xml/route.ts
+++ b/apps/site/src/app/feed.xml/route.ts
@@ -6,7 +6,6 @@ interface ProjectItem {
   slug: string;
   title: string;
   caption: string;
-  createdAt: string;
 }
 
 function escapeXml(value: string): string {
@@ -30,11 +29,6 @@ export async function GET(): Promise<Response> {
     if (!body.error) projects.push(...body.data);
   }
 
-  const lastBuildDate =
-    projects.length > 0 && projects[0]
-      ? new Date(projects[0].createdAt).toUTCString()
-      : new Date().toUTCString();
-
   const items = projects
     .map(
       (p) => `
@@ -43,7 +37,6 @@ export async function GET(): Promise<Response> {
       <link>${SITE_URL}/projects/${escapeXml(p.slug)}</link>
       <description>${escapeXml(p.caption)}</description>
       <guid isPermaLink="true">${SITE_URL}/projects/${escapeXml(p.slug)}</guid>
-      <pubDate>${new Date(p.createdAt).toUTCString()}</pubDate>
     </item>`,
     )
     .join('');
@@ -55,7 +48,7 @@ export async function GET(): Promise<Response> {
     <link>${SITE_URL}</link>
     <description>Frontend Software Engineer — scalable web applications built with React, Next.js, and TypeScript.</description>
     <language>en-US</language>
-    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
     <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
     ${items}
   </channel>

--- a/apps/site/src/app/feed.xml/route.ts
+++ b/apps/site/src/app/feed.xml/route.ts
@@ -1,0 +1,70 @@
+import { ApiResponse } from '~/lib/api/envelope';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
+interface ProjectItem {
+  slug: string;
+  title: string;
+  caption: string;
+  createdAt: string;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export async function GET(): Promise<Response> {
+  const res = await fetch(`${SITE_URL}/api/v1/projects`, {
+    cache: 'no-store',
+  }).catch(() => null);
+
+  const projects: ProjectItem[] = [];
+
+  if (res?.ok) {
+    const body: ApiResponse<ProjectItem[]> = await res.json();
+    if (!body.error) projects.push(...body.data);
+  }
+
+  const lastBuildDate =
+    projects.length > 0 && projects[0]
+      ? new Date(projects[0].createdAt).toUTCString()
+      : new Date().toUTCString();
+
+  const items = projects
+    .map(
+      (p) => `
+    <item>
+      <title>${escapeXml(p.title)}</title>
+      <link>${SITE_URL}/projects/${escapeXml(p.slug)}</link>
+      <description>${escapeXml(p.caption)}</description>
+      <guid isPermaLink="true">${SITE_URL}/projects/${escapeXml(p.slug)}</guid>
+      <pubDate>${new Date(p.createdAt).toUTCString()}</pubDate>
+    </item>`,
+    )
+    .join('');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Wallace Ferreira</title>
+    <link>${SITE_URL}</link>
+    <description>Frontend Software Engineer — scalable web applications built with React, Next.js, and TypeScript.</description>
+    <language>en-US</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
+    ${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -59,6 +59,9 @@ export const SideNavigation: FC = () => {
         >
           {t('github')}
         </MenuItem.Item2.Link>
+        <MenuItem.Item2.Link href="/feed.xml" icon="mdi:rss" newTab>
+          {t('rss')}
+        </MenuItem.Item2.Link>
         <ThemeToggle />
         <LanguageSelector />
       </ul>

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -59,7 +59,12 @@ export const SideNavigation: FC = () => {
         >
           {t('github')}
         </MenuItem.Item2.Link>
-        <MenuItem.Item2.Link href="/feed.xml" icon="mdi:rss" newTab>
+        <MenuItem.Item2.Link
+          href="/feed.xml"
+          icon="mdi:rss"
+          iconClassName="text-white"
+          newTab
+        >
           {t('rss')}
         </MenuItem.Item2.Link>
         <ThemeToggle />


### PR DESCRIPTION
## Summary

- Adds `/feed.xml` route returning a valid RSS 2.0 feed with all projects as items
- Registers `<link rel="alternate" type="application/rss+xml">` in `<head>` via `metadata.alternates`
- Adds an **RSS Feed** link to the `SideNavigation` bottom section, alongside LinkedIn and GitHub
- Adds `rss` translation key to all 3 locale files (en-US, pt-BR, es)

## Test plan

- [ ] Visit `/feed.xml` — valid RSS 2.0 XML is returned with all projects listed as `<item>` entries
- [ ] View page source on any page — `<link rel="alternate" type="application/rss+xml">` is present in `<head>`
- [ ] Open the side navigation — RSS Feed link appears below GitHub with an RSS icon
- [ ] Click the RSS Feed link — opens `/feed.xml` in a new tab
- [ ] Verify all 193 tests pass (`pnpm test`)
- [ ] Verify TypeScript is clean (`npx tsc --noEmit`)

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)