### PR TITLE
feat(site): enrich About page with career narrative sections

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -74,7 +74,13 @@
     "hero_caption": "Frontend Engineer · React · Next.js · TypeScript",
     "hero_content": "Frontend engineer with over 6 years of experience building scalable web applications. Passionate about clean architecture, performance, and accessibility.",
     "hero_image_alt": "Wallace Ferreira — Frontend Engineer",
-    "values_title": "My professional values"
+    "values_title": "My professional values",
+    "story_title": "My story",
+    "story_content": "Placeholder — to be filled with a career arc narrative: how you got into frontend engineering, key turning points, the experiences that shaped your technical approach, and what defines your trajectory today.",
+    "exploring_title": "What I'm exploring",
+    "exploring_content": "Placeholder — to be filled with your current learning focus: technologies, methodologies, or domains you're actively studying or experimenting with right now.",
+    "passions_title": "What drives me",
+    "passions_content": "Placeholder — to be filled with what you care most about in software engineering: principles, practices, or aspects of the craft that consistently motivate you."
   },
   "ExperienceCard": {
     "skills_label": "Skills"

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -74,7 +74,13 @@
     "hero_caption": "Ingeniero Front-end · React · Next.js · TypeScript",
     "hero_content": "Ingeniero front-end con más de 6 años de experiencia construyendo aplicaciones web escalables. Apasionado por la arquitectura limpia, el rendimiento y la accesibilidad.",
     "hero_image_alt": "Wallace Ferreira — Ingeniero Front-end",
-    "values_title": "Mis valores profesionales"
+    "values_title": "Mis valores profesionales",
+    "story_title": "Mi historia",
+    "story_content": "Placeholder — a completar con la narrativa de tu trayectoria: cómo llegaste al desarrollo frontend, los hitos clave, las experiencias que formaron tu enfoque técnico y lo que define tu camino hoy.",
+    "exploring_title": "Qué estoy explorando",
+    "exploring_content": "Placeholder — a completar con tu foco de aprendizaje actual: tecnologías, metodologías o áreas que estás estudiando o experimentando activamente ahora.",
+    "passions_title": "Qué me impulsa",
+    "passions_content": "Placeholder — a completar con lo que más valoras en la ingeniería de software: principios, prácticas o aspectos del trabajo que te motivan de forma consistente."
   },
   "ExperienceCard": {
     "skills_label": "Habilidades"

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -74,7 +74,13 @@
     "hero_caption": "Engenheiro Front-end · React · Next.js · TypeScript",
     "hero_content": "Engenheiro front-end com mais de 6 anos de experiência construindo aplicações web escaláveis. Apaixonado por arquitetura limpa, performance e acessibilidade.",
     "hero_image_alt": "Wallace Ferreira — Engenheiro Front-end",
-    "values_title": "Meus valores profissionais"
+    "values_title": "Meus valores profissionais",
+    "story_title": "Minha história",
+    "story_content": "Placeholder — a ser preenchido com a narrativa da sua trajetória: como você entrou no desenvolvimento frontend, os marcos importantes, as experiências que moldaram sua abordagem técnica e o que define seu caminho hoje.",
+    "exploring_title": "O que estou explorando",
+    "exploring_content": "Placeholder — a ser preenchido com seu foco de aprendizado atual: tecnologias, metodologias ou domínios que você está estudando ou experimentando ativamente agora.",
+    "passions_title": "O que me move",
+    "passions_content": "Placeholder — a ser preenchido com o que você mais valoriza na engenharia de software: princípios, práticas ou aspectos do trabalho que consistentemente te motivam."
   },
   "ExperienceCard": {
     "skills_label": "Habilidades"

--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -9,6 +9,7 @@ import {
   ExperiencesSkeleton,
 } from '~features/about/ExperiencesSection';
 import { HeroSection } from '~features/about/HeroSection';
+import { NarrativeSection } from '~features/about/NarrativeSection';
 import { ValuesSection, ValuesSkeleton } from '~features/about/ValuesSection';
 import { HeroBannerSkeleton } from '~features/shared/HeroBanner/HeroBannerSkeleton';
 
@@ -65,6 +66,7 @@ export default async function About({ searchParams }: AboutPageProps) {
       <Suspense fallback={<HeroBannerSkeleton />}>
         <HeroSection />
       </Suspense>
+      <NarrativeSection />
       <Suspense fallback={<ValuesSkeleton />}>
         <ValuesSection />
       </Suspense>

--- a/apps/site/src/features/about/NarrativeSection/index.tsx
+++ b/apps/site/src/features/about/NarrativeSection/index.tsx
@@ -1,0 +1,36 @@
+import { getTranslations } from 'next-intl/server';
+
+interface NarrativeCardProps {
+  title: string;
+  content: string;
+}
+
+function NarrativeCard({ title, content }: NarrativeCardProps) {
+  return (
+    <article className="flex flex-col gap-y-3 border border-subtle rounded-xl px-6 py-6 bg-surface/20">
+      <h3 className="text-white font-semibold text-lg">{title}</h3>
+      <p className="text-content-primary leading-relaxed">{content}</p>
+    </article>
+  );
+}
+
+export async function NarrativeSection() {
+  const t = await getTranslations('About');
+
+  return (
+    <section
+      data-testid="narrative-section"
+      className="mx-4 my-6 flex flex-col gap-y-4 xl:mx-auto xl:my-8 xl:w-full xl:max-w-237.5"
+    >
+      <NarrativeCard title={t('story_title')} content={t('story_content')} />
+      <NarrativeCard
+        title={t('exploring_title')}
+        content={t('exploring_content')}
+      />
+      <NarrativeCard
+        title={t('passions_title')}
+        content={t('passions_content')}
+      />
+    </section>
+  );
+}

--- a/apps/site/tests/app/[locale]/about.test.tsx
+++ b/apps/site/tests/app/[locale]/about.test.tsx
@@ -23,6 +23,10 @@ vi.mock('~features/about/ExperiencesSection', () => ({
   ExperiencesSkeleton: () => null,
 }));
 
+vi.mock('~features/about/NarrativeSection', () => ({
+  NarrativeSection: () => <div data-testid="narrative-section" />,
+}));
+
 vi.mock('~features/shared/HeroBanner/HeroBannerSkeleton', () => ({
   HeroBannerSkeleton: () => null,
 }));
@@ -33,6 +37,7 @@ describe('About page', () => {
     render(await About({ searchParams: Promise.resolve({}) }));
 
     expect(screen.getByTestId('hero-section')).toBeInTheDocument();
+    expect(screen.getByTestId('narrative-section')).toBeInTheDocument();
     expect(screen.getByTestId('values-section')).toBeInTheDocument();
     expect(screen.getByTestId('experiences-section')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- Adds `NarrativeSection` between the hero banner and professional values on the About page
- Three cards: **My Story**, **What I'm Exploring**, **What Drives Me**
- Content is i18n-driven (en-US, pt-BR, es) with placeholder text ready to be replaced with real copy in production
- No DB or API changes — content lives in message files for easy editing

## Test plan

- [ ] Visit `/about` — three new cards appear between the hero and "My professional values"
- [ ] Switch locale to pt-BR — cards show Portuguese placeholder text
- [ ] Switch locale to es — cards show Spanish placeholder text
- [ ] 193 tests pass (`pnpm test`)
- [ ] TypeScript is clean (`npx tsc --noEmit`)

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)