### PR TITLE
fix(site): correct turbo filter syntax for Vercel build

### DIFF
--- a/apps/site/vercel.json
+++ b/apps/site/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "cd ../.. && turbo run build --filter=site",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary

- Adds `apps/site/vercel.json` with the correct Turbo filter syntax
- Turbo v2 removed support for `{/path}` anchored path syntax in `--filter`
- Replaces `--filter={/apps/site}` with `--filter=site` (package name)

## Root cause

Vercel auto-detects a monorepo and runs:
```
cd ../.. && turbo run build --filter={/apps/site}
```
This fails in Turbo v2+ because the `{/path}` directory-based filter was dropped.

## Fix

`apps/site/vercel.json` overrides the build command with the package-name filter:
```json
{
  "buildCommand": "cd ../.. && turbo run build --filter=site",
  "framework": "nextjs"
}
```

Refs #636