### PR TITLE
fix(turbo): explicit dependsOn in site#build and admin#build tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -19,9 +19,11 @@
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "site#build": {
+      "dependsOn": ["^build"],
       "env": ["NEXT_PUBLIC_*"]
     },
     "admin#build": {
+      "dependsOn": ["^build"],
       "env": ["NEXT_PUBLIC_*", "SITE_API_URL"]
     },
     "lint": {


### PR DESCRIPTION
## Summary

- Adds `dependsOn: ["^build"]` explicitly to `site#build` and `admin#build` in `turbo.json`

## Root cause

Turbo v2 should merge package-level task configs with the root task (inheriting `dependsOn`), but in practice this inheritance is not reliable. On Vercel, `@repo/ui build` (tsup → generates `dist/`) was not running before `site build`, causing Turbopack to fail with:

```
Module not found: Can't resolve '@repo/ui/Control'
Module not found: Can't resolve '@repo/ui/Imagery'
Module not found: Can't resolve '@repo/ui/View'
```

## Fix

Making `dependsOn: ["^build"]` explicit in both package-level tasks guarantees the upstream build order regardless of Turbo's merge behavior.

Refs #636