### PR TITLE
fix: styling corrections and project detail runtime fix

### DIFF
--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { Inter } from 'next/font/google';
 import { AppLayout } from '~components';
 
 import '@repo/tailwind-config/tailwind.css';
+import '@repo/ui/globals.css';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'], display: 'swap' });

--- a/apps/site/src/app/[locale]/projects/[slug]/page.tsx
+++ b/apps/site/src/app/[locale]/projects/[slug]/page.tsx
@@ -9,6 +9,8 @@ import {
   IProjectDetailProps,
 } from '~features/projects/ProjectDetail';
 
+export const dynamic = 'force-dynamic';
+
 type ProjectDetailData = IProjectDetailProps & { id: string };
 
 interface ProjectDetailPageProps {
@@ -33,12 +35,11 @@ export async function generateMetadata({
   const body: ApiResponse<{
     title: string;
     caption: string;
-    coverImageUrl: string;
-    coverImageAlt: string;
+    coverImage: { url: string; alt: string };
   }> = await res.json();
   if (body.error) return {};
 
-  const { title, caption, coverImageUrl, coverImageAlt } = body.data;
+  const { title, caption, coverImage } = body.data;
 
   return {
     title,
@@ -46,7 +47,7 @@ export async function generateMetadata({
     openGraph: {
       title,
       description: caption,
-      images: [{ url: coverImageUrl, alt: coverImageAlt }],
+      images: [{ url: coverImage.url, alt: coverImage.alt }],
     },
   };
 }
@@ -73,24 +74,4 @@ export default async function ProjectDetailPage({
   const project = body.data;
 
   return <ProjectDetail {...project} />;
-}
-
-export async function generateStaticParams() {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_API_URL ??
-    (process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : 'http://localhost:3000');
-
-  try {
-    const res = await fetch(`${baseUrl}/api/v1/projects`, {
-      cache: 'force-cache',
-    });
-    if (!res.ok) return [];
-    const body: ApiResponse<{ slug: string }[]> = await res.json();
-    if (body.error) return [];
-    return body.data.map((p) => ({ slug: p.slug }));
-  } catch {
-    return [];
-  }
 }

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -116,12 +116,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
           labels={metaLabels}
         />
 
-        {content && (
-          <TextRich
-            content={content}
-            className="text-content-primary prose prose-invert max-w-none"
-          />
-        )}
+        {content && <TextRich content={content} />}
 
         {relatedProjects.length > 0 && (
           <section className="flex flex-col gap-y-6">

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -123,7 +123,10 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
             <h2 className="text-[32px] font-bold text-content-primary">
               {t('related_title')}
             </h2>
-            <ProjectList projects={relatedProjects} view="grid" />
+            <ProjectList
+              projects={relatedProjects}
+              view={relatedProjects.length === 1 ? 'row' : 'grid'}
+            />
           </section>
         )}
       </div>

--- a/packages/ui/globals.css
+++ b/packages/ui/globals.css
@@ -1,0 +1,9 @@
+@import 'github-markdown-css/github-markdown-dark.css';
+
+/* Override github-markdown colors to use the design system tokens */
+.markdown-body {
+  color: rgb(var(--tw-content-primary));
+  background-color: transparent;
+  font-family: inherit;
+  font-size: inherit;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@repo/ui",
   "version": "0.0.0",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "private": true,
   "exports": {
+    "./globals.css": "./globals.css",
     "./Control": {
       "types": "./dist/types/Control/index.d.ts",
       "import": "./dist/Control/index.mjs",
@@ -24,7 +25,8 @@
     "linux"
   ],
   "files": [
-    "dist/"
+    "dist/",
+    "globals.css"
   ],
   "scripts": {
     "build": "tsup",
@@ -42,6 +44,7 @@
     "classnames": "^2.5.1",
     "react": "^18",
     "react-dom": "^18",
+    "github-markdown-css": "^5.9.0",
     "react-markdown": "^9.0.1",
     "react-tooltip": "^5.28.0",
     "rehype-raw": "^7.0.0",

--- a/packages/ui/src/View/TextRich/index.tsx
+++ b/packages/ui/src/View/TextRich/index.tsx
@@ -2,6 +2,7 @@
 
 import { FC } from 'react';
 
+import classNames from 'classnames';
 import Markdown from 'react-markdown';
 
 import { REHYPE_PLUGINS, REMARK_PLUGINS } from './constants';
@@ -13,12 +14,10 @@ export interface ITextRichProps {
 
 export const TextRich: FC<ITextRichProps> = ({ content, className }) => {
   return (
-    <Markdown
-      className={className}
-      rehypePlugins={REHYPE_PLUGINS}
-      remarkPlugins={REMARK_PLUGINS}
-    >
-      {content}
-    </Markdown>
+    <div className={classNames('markdown-body', className)}>
+      <Markdown rehypePlugins={REHYPE_PLUGINS} remarkPlugins={REMARK_PLUGINS}>
+        {content}
+      </Markdown>
+    </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      github-markdown-css:
+        specifier: ^5.9.0
+        version: 5.9.0
       react:
         specifier: ^18
         version: 18.3.1
@@ -5882,6 +5885,11 @@ packages:
       meow: 12.1.1
       split2: 4.2.0
     dev: true
+
+  /github-markdown-css@5.9.0:
+    resolution: {integrity: sha512-tmT5sY+zvg2302XLYEfH2mtkViIM1SWf2nvYoF5N1ZsO0V6B2qZTiw3GOzw4vpjLygK/KG35qRlPFweHqfzz5w==}
+    engines: {node: '>=10'}
+    dev: false
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}


### PR DESCRIPTION
## Summary

- Add `github-markdown-css` to `@repo/ui` and expose `globals.css` for proper GFM paragraph spacing in `TextRich`
- Fix project detail page crashing in production (`DYNAMIC_SERVER_USAGE`) by replacing `generateStaticParams` with `dynamic = 'force-dynamic'`
- Fix `coverImage` shape mismatch in `generateMetadata` (was using non-existent `coverImageUrl`/`coverImageAlt` instead of `coverImage.url`/`alt`)
- Adapt related projects view: `row` for a single project, `grid` for two or more

## Test plan

- [ ] Visit a project detail page in production — should load without 500
- [ ] Verify markdown content renders with proper paragraph spacing
- [ ] Verify OG image is correctly populated on project detail pages
- [ ] Verify related projects section: single project shows full-width row, multiple show grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)