### PR TITLE
chore(site): fine-tuning — locale links, ShareButton extract, ProjectCard cleanup

### DIFF
--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx
@@ -21,10 +21,11 @@ export const Item1: FC<IGhostLinkProps> = ({
   const params = useParams();
   const locale = (params?.locale as string) ?? 'en-US';
   const localizedHref = href === '/' ? `/${locale}` : `/${locale}${href}`;
+  const newHref = newTab ? href : localizedHref;
 
   return (
     <Link
-      href={localizedHref}
+      href={newHref}
       className={classNames(
         'flex flex-row items-center hover:bg-surface active:bg-surface-sunken transition-all px-4 py-3 gap-4 rounded-lg [&>span]:hover:font-bold [&>span]:active:font-bold [&>*]:active:!text-content-primary',
         className,

--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { FC, useState } from 'react';
+import { FC } from 'react';
 
 import { Icon } from '@repo/ui/Imagery';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
+import { useBoolean } from 'usehooks-ts';
 
 import { TechnologiesModal } from '~features/about/TechnologiesModal';
 import { ShareButton } from '~features/shared/ShareButton';
@@ -35,7 +36,12 @@ export const ProjectCard: FC<IProjectCardProps> = ({
 }) => {
   const t = useTranslations('ProjectCard');
   const isXL = useBreakpoint('xl');
-  const [modalOpen, setModalOpen] = useState(false);
+  const locale = useLocale();
+  const {
+    value: modalOpen,
+    setTrue: openModal,
+    setFalse: closeModal,
+  } = useBoolean(false);
 
   if (view === 'row') {
     return (
@@ -70,10 +76,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
               max={3}
               initializeWithMax={3}
               total={skills.length}
-              onShowAll={() => {
-                // close?.();
-                setModalOpen(true);
-              }}
+              onShowAll={openModal}
             />
             <Link
               href={`/projects/${slug}`}
@@ -89,7 +92,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
 
         <TechnologiesModal
           open={modalOpen}
-          onClose={() => setModalOpen(false)}
+          onClose={closeModal}
           technologies={skills}
         />
       </article>
@@ -125,13 +128,11 @@ export const ProjectCard: FC<IProjectCardProps> = ({
           max={isXL ? 3 : 2}
           initializeWithMax={2}
           total={skills.length}
-          onShowAll={() => {
-            close?.();
-            setModalOpen(true);
-          }}
+          onShowAll={openModal}
         />
         <Link
           href={`/projects/${slug}`}
+          locale={locale}
           className="flex flex-row justify-center items-center gap-2 bg-brand-primary text-body-sm text-content-primary font-bold rounded-xl hover:bg-brand-primary-hover transition-colors duration-300 py-3 px-6"
         >
           {t('view_project')}
@@ -141,7 +142,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
 
       <TechnologiesModal
         open={modalOpen}
-        onClose={() => setModalOpen(false)}
+        onClose={closeModal}
         technologies={skills}
       />
     </article>

--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -2,12 +2,12 @@
 
 import { FC, useState } from 'react';
 
-import { Button } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
 import { TechnologiesModal } from '~features/about/TechnologiesModal';
+import { ShareButton } from '~features/shared/ShareButton';
 import { SkillGroup } from '~features/shared/SkillGroup';
 import { useBreakpoint } from '~hooks';
 import { Link } from '~i18n/routing';
@@ -40,7 +40,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
   if (view === 'row') {
     return (
       <article className="relative flex flex-row bg-surface rounded-xl w-full h-[339px] overflow-hidden">
-        <div className="relative w-[380px] shrink-0">
+        <div className="relative w-[380px] shrink-0 m-3 rounded-lg overflow-hidden">
           <Image
             src={coverImage.url}
             fill
@@ -85,19 +85,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
           </div>
         </div>
 
-        <Button.Clipboard
-          unstyled
-          text={`${typeof window !== 'undefined' ? window.location.origin : ''}/projects/${slug}`}
-          tooltip={t('share_tooltip')}
-          className="absolute top-3 right-3 z-10 flex items-center justify-center w-9 h-9 rounded-lg bg-surface-raised hover:bg-surface-interactive transition-colors"
-        >
-          {(copied) => (
-            <Icon
-              icon={copied ? 'ic:round-check' : 'ic:round-share'}
-              className="text-xl text-content-secondary"
-            />
-          )}
-        </Button.Clipboard>
+        <ShareButton slug={slug} className="absolute top-3 right-3 z-10" />
 
         <TechnologiesModal
           open={modalOpen}
@@ -119,19 +107,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
           sizes="463px"
           priority
         />
-        <Button.Clipboard
-          unstyled
-          text={`${typeof window !== 'undefined' ? window.location.origin : ''}/projects/${slug}`}
-          tooltip={t('share_tooltip')}
-          className="absolute top-2 right-2 z-10 flex items-center justify-center w-9 h-9 rounded-lg bg-surface-raised hover:bg-surface-interactive transition-colors"
-        >
-          {(copied) => (
-            <Icon
-              icon={copied ? 'ic:round-check' : 'ic:round-share'}
-              className="text-xl text-content-secondary"
-            />
-          )}
-        </Button.Clipboard>
+        <ShareButton slug={slug} className="absolute top-2 right-2 z-10" />
       </div>
 
       <div className="flex flex-col p-4 gap-4">

--- a/apps/site/src/features/shared/ShareButton/index.tsx
+++ b/apps/site/src/features/shared/ShareButton/index.tsx
@@ -5,7 +5,7 @@ import { FC } from 'react';
 import { Button } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
 import classNames from 'classnames';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 interface IShareButtonProps {
   slug: string;
@@ -13,8 +13,9 @@ interface IShareButtonProps {
 }
 
 export const ShareButton: FC<IShareButtonProps> = ({ slug, className }) => {
+  const locale = useLocale();
   const t = useTranslations('ProjectCard');
-  const url = `${typeof window !== 'undefined' ? window.location.origin : ''}/projects/${slug}`;
+  const url = `${typeof window !== 'undefined' ? window.location.origin : ''}/${locale}/projects/${slug}`;
 
   return (
     <Button.Clipboard

--- a/apps/site/src/features/shared/ShareButton/index.tsx
+++ b/apps/site/src/features/shared/ShareButton/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { FC } from 'react';
+
+import { Button } from '@repo/ui/Control';
+import { Icon } from '@repo/ui/Imagery';
+import classNames from 'classnames';
+import { useTranslations } from 'next-intl';
+
+interface IShareButtonProps {
+  slug: string;
+  className?: string;
+}
+
+export const ShareButton: FC<IShareButtonProps> = ({ slug, className }) => {
+  const t = useTranslations('ProjectCard');
+  const url = `${typeof window !== 'undefined' ? window.location.origin : ''}/projects/${slug}`;
+
+  return (
+    <Button.Clipboard
+      unstyled
+      text={url}
+      tooltip={t('share_tooltip')}
+      className={classNames(
+        'flex items-center justify-center w-9 h-9 rounded-lg',
+        'bg-surface-raised hover:bg-surface-interactive transition-colors',
+        className,
+      )}
+    >
+      {(copied) => (
+        <Icon
+          icon={copied ? 'ic:round-check' : 'ic:round-share'}
+          className="text-xl text-content-secondary"
+        />
+      )}
+    </Button.Clipboard>
+  );
+};

--- a/apps/site/tests/components/View/ProjectCard/ProjectCard.test.tsx
+++ b/apps/site/tests/components/View/ProjectCard/ProjectCard.test.tsx
@@ -3,6 +3,7 @@ import { vi } from 'vitest';
 
 vi.mock('next-intl', () => ({
   useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+  useLocale: () => 'en-US',
 }));
 
 vi.mock('~hooks', () => ({

--- a/plans/ssg-ssr-refactor.md
+++ b/plans/ssg-ssr-refactor.md
@@ -1,0 +1,126 @@
+# Plano: Migração das Pages do Site para SSG/ISR
+
+## Objetivo
+
+Converter todas as pages públicas de `apps/site` de SSR dinâmico (`force-dynamic` + fetch HTTP interno)
+para SSG/ISR com chamada direta aos use cases, eliminando a ida e volta HTTP desnecessária e
+aproveitando o CDN da Vercel para máxima performance.
+
+## Contexto
+
+Hoje as pages fazem:
+```
+Server Component → fetch('/api/v1/...') → API Route → Use Case → Prisma → DB
+```
+
+Após a refatoração:
+```
+Build/Revalidação → Server Component → Use Case → Prisma → DB → HTML no CDN
+Visitante → recebe HTML pronto
+```
+
+As rotas `/api/v1/...` continuam existindo para o **admin** (CSR).
+
+---
+
+## Páginas afetadas
+
+| Página | Rota | Use Cases envolvidos |
+|--------|------|----------------------|
+| Home | `/` | `GetProfile`, `GetFeaturedProjects`, `GetProfessionalValues` |
+| About | `/about` | `GetProfile`, `GetExperiences`, `GetProfessionalValues` |
+| Projects | `/projects` | `GetProjects` |
+| Project Detail | `/projects/[slug]` | `GetProjectBySlug` |
+
+---
+
+## Fases
+
+### Fase 1 — Infraestrutura compartilhada
+
+**Objetivo:** Preparar o terreno sem tocar nas pages ainda.
+
+- [ ] Criar helper `getServerContainer()` em `apps/site/src/lib/server/container.ts`
+  - Encapsula `getContainer()` de `@repo/infra` para uso nas pages
+  - Evita importar `@repo/infra` espalhado pelas pages
+- [ ] Remover `getInternalBaseUrl()` de `apps/site/src/lib/api/internal.ts`
+  - Ou manter apenas para rotas que permanecerem dinâmicas (contato, auth)
+- [ ] Definir `REVALIDATE_SECONDS` como constante de configuração (ex.: `86400` = 24h)
+
+**Commit:** `feat(site): add server container helper for SSG pages`
+
+---
+
+### Fase 2 — Home page (`/`)
+
+**Objetivo:** Primeira page migrada como tracer bullet.
+
+- [ ] Substituir fetch HTTP por chamadas diretas aos use cases em `page.tsx`
+- [ ] Adicionar `export const revalidate = 86400`
+- [ ] Remover `loading.tsx` da rota `/`
+- [ ] Remover o Skeleton correspondente (se exclusivo desta rota)
+
+**Commit:** `feat(site/home): migrate to SSG with direct use case calls`
+
+---
+
+### Fase 3 — About page (`/about`)
+
+- [ ] Substituir fetch HTTP por use cases diretos em `page.tsx`
+- [ ] Adicionar `export const revalidate = 86400`
+- [ ] Remover `loading.tsx` da rota `/about`
+- [ ] Remover Skeletons correspondentes
+
+**Commit:** `feat(site/about): migrate to SSG with direct use case calls`
+
+---
+
+### Fase 4 — Projects list (`/projects`)
+
+- [ ] Substituir fetch HTTP por `GetProjects` direto em `page.tsx`
+- [ ] Adicionar `export const revalidate = 86400`
+- [ ] Remover `loading.tsx` da rota `/projects`
+- [ ] Remover Skeletons correspondentes
+
+**Commit:** `feat(site/projects): migrate to SSG with direct use case calls`
+
+---
+
+### Fase 5 — Project detail (`/projects/[slug]`)
+
+- [ ] Substituir fetch HTTP por `GetProjectBySlug` direto em `page.tsx`
+- [ ] Adicionar `generateStaticParams` usando `GetProjects` direto (sem fetch HTTP)
+- [ ] Remover `export const dynamic = 'force-dynamic'`
+- [ ] Adicionar `export const revalidate = 86400`
+- [ ] Remover `loading.tsx` da rota `/projects/[slug]`
+
+**Commit:** `feat(site/project-detail): migrate to ISR with generateStaticParams`
+
+---
+
+### Fase 6 — Limpeza final
+
+- [ ] Remover `getInternalBaseUrl` se não houver mais usos nas pages
+- [ ] Avaliar se `/api/v1/projects`, `/api/v1/experiences`, `/api/v1/professional-values`,
+  `/api/v1/profile` ainda têm consumidores além do admin — se não, marcar como admin-only
+- [ ] Atualizar testes de page que mockavam fetch HTTP
+
+**Commit:** `chore(site): remove unused internal fetch helpers after SSG migration`
+
+---
+
+## Decisões
+
+### Tempo de revalidação
+`86400s` (24h) é um bom ponto de partida para um portfolio. Pode ser ajustado por rota:
+- Home/About/Projects: 24h (dados muito estáveis)
+- Project detail: 24h (conteúdo muda raramente)
+
+### `dynamicParams` no project detail
+Com `generateStaticParams`, slugs não listados no build retornam 404 por padrão.
+Para gerar sob demanda (primeiro acesso gera e cacheia), manter `dynamicParams = true` (já é o padrão do Next.js).
+
+### Skeletons e `loading.tsx`
+Com SSG/ISR, o HTML chega completo — não há estado de carregamento visível.
+Os `loading.tsx` e Skeletons das rotas migradas podem ser removidos com segurança.
+Manter apenas para rotas que permanecerem dinâmicas (contato).


### PR DESCRIPTION
## Summary

- **Item1**: respect `newTab` prop — external links skip locale prefix, internal links use it
- **ProjectCard**: extract `ShareButton` into `~features/shared/ShareButton`, replace `useState` with `useBoolean`, add `locale` prop to project link, add image margin on row view
- **ShareButton**: new shared component that builds the localized share URL using `useLocale`
- **Tests**: add `useLocale` to `next-intl` mock in `ProjectCard` test

## Test plan

- [ ] All existing tests pass (`pnpm test:ci`)
- [ ] Navigation links with `newTab=true` open the original (non-localized) href
- [ ] Navigation links with `newTab=false` navigate to the localized href
- [ ] Share button copies the correct localized URL (`/{locale}/projects/{slug}`)
- [ ] Project card "View project" link navigates with correct locale

Refs #chore/fine-tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)