### PR TITLE
refactor(site): move TechnologiesModal to shared feature

### DIFF
--- a/apps/site/src/components/Layout/AppLayout/index.tsx
+++ b/apps/site/src/components/Layout/AppLayout/index.tsx
@@ -1,41 +1,15 @@
 'use client';
 
-import { FC, PropsWithChildren, useCallback } from 'react';
-
-import { useBoolean, useScrollLock, useEventListener } from 'usehooks-ts';
+import { FC, PropsWithChildren } from 'react';
 
 import { ContactSection } from '~features/contact/ContactSection';
-import { useThrottle } from '~hooks';
-import { BREAKPOINTS_NUMBERS } from '~utils';
 
 import { SideNavigation } from '../SideNavigation';
 
 export const AppLayout: FC<PropsWithChildren> = ({ children }) => {
-  const { value, setTrue, setFalse } = useBoolean(false);
-  const { lock, unlock } = useScrollLock({ autoLock: false });
-
-  const handleToggle = useCallback(() => {
-    if (value) {
-      setFalse();
-      unlock();
-      return;
-    }
-
-    setTrue();
-    lock();
-  }, [value, lock, unlock, setFalse, setTrue]);
-
-  const throttle = useThrottle(() => {
-    handleToggle();
-  }, 500);
-
-  useEventListener('resize', () => {
-    if (window.innerWidth < BREAKPOINTS_NUMBERS.lg) throttle();
-  });
-
   return (
     <>
-      <SideNavigation open={value} toggle={handleToggle} />
+      <SideNavigation />
       <div className="flex h-full flex-col ml-0 xl:ml-60 mt-header-mobile xl:mt-20">
         <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1">
           {children}

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -5,28 +5,31 @@ import { FC } from 'react';
 import { Divider } from '@repo/ui/View';
 import classNames from 'classnames';
 import { useTranslations } from 'next-intl';
+import { useBoolean, useScrollLock } from 'usehooks-ts';
+
+import { useBreakpoint } from '~hooks';
 
 import { Header } from '../Header';
 import { LanguageSelector } from './LanguageSelector';
 import { MenuItem } from './MenuItem';
 import { ThemeToggle } from './ThemeToggle';
 
-interface SideNavigationProps {
-  open: boolean;
-  toggle: () => void;
-}
-
-export const SideNavigation: FC<SideNavigationProps> = ({ open, toggle }) => {
+export const SideNavigation: FC = () => {
   const t = useTranslations('SideNavigation');
+  const isDesktop = useBreakpoint('xl');
+  const { value: open, toggle } = useBoolean(false);
+  const isOpen = !isDesktop && open;
+
+  useScrollLock({ autoLock: isOpen });
 
   return (
     <section className="fixed top-0 left-0 shadow-1 w-full xl:w-auto z-50">
-      <Header open={open} toggle={toggle} />
+      <Header open={isOpen} toggle={toggle} />
       <nav
         id="side-navigation"
         className={classNames(
           'h-sidenav-mobile xl:h-sidenav-desktop left-0 w-full xl:w-60 xl:px-4 bg-surface-sunken flex flex-col border-0 duration-300 ease-linear xl:!translate-x-0 z-9999',
-          open ? 'translate-x-0' : '-translate-x-full',
+          isOpen ? 'translate-x-0' : '-translate-x-full',
         )}
       >
         <ul className="flex flex-col gap-y-3 px-6 pt-10 xl:pt-15 xl:px-0">

--- a/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
@@ -10,8 +10,6 @@ import { useBoolean } from 'usehooks-ts';
 import { SkillGroup } from '~features/shared/SkillGroup';
 import { useBreakpoint } from '~hooks';
 
-import { TechnologiesModal } from '../TechnologiesModal';
-
 export interface IExperienceCardSkill {
   name: string;
   icon: string;
@@ -69,11 +67,6 @@ export const ExperienceCard: FC<IExperienceCardProps> = ({
 }) => {
   const t = useTranslations('ExperienceCard');
   const locale = useLocale();
-  const {
-    value: modalOpen,
-    setTrue: openModal,
-    setFalse: closeModal,
-  } = useBoolean(false);
   const { value: expanded, toggle: toggleDescription } = useBoolean(false);
   const isXL = useBreakpoint('xl');
 
@@ -84,55 +77,44 @@ export const ExperienceCard: FC<IExperienceCardProps> = ({
     .join(' • ');
 
   return (
-    <>
-      <article className="flex flex-col gap-y-2 py-6">
-        <h2 className="text-2xl font-bold text-content-primary">{position}</h2>
+    <article className="flex flex-col gap-y-2 py-6">
+      <h2 className="text-2xl font-bold text-content-primary">{position}</h2>
 
-        <div className="flex flex-wrap items-baseline gap-x-2">
-          <span className="text-xl font-bold uppercase text-content-primary">
-            {company}
-          </span>
-          <span className="text-base text-content-disabled">
-            {period} ({duration})
-          </span>
+      <div className="flex flex-wrap items-baseline gap-x-2">
+        <span className="text-xl font-bold uppercase text-content-primary">
+          {company}
+        </span>
+        <span className="text-base text-content-disabled">
+          {period} ({duration})
+        </span>
+      </div>
+
+      <span className="text-base text-content-disabled">{locationLine}</span>
+
+      {description && (
+        <div className="flex flex-col gap-y-1">
+          <TextRich
+            content={description}
+            className={classNames('text-base text-content-disabled', {
+              'line-clamp-1': !expanded,
+            })}
+          />
+          <button
+            type="button"
+            className="self-start text-sm text-content-disabled underline"
+            onClick={toggleDescription}
+          >
+            {expanded ? t('see_less') : t('see_more')}
+          </button>
         </div>
+      )}
 
-        <span className="text-base text-content-disabled">{locationLine}</span>
-
-        {description && (
-          <div className="flex flex-col gap-y-1">
-            <TextRich
-              content={description}
-              className={classNames('text-base text-content-disabled', {
-                'line-clamp-1': !expanded,
-              })}
-            />
-            <button
-              type="button"
-              className="self-start text-sm text-content-disabled underline"
-              onClick={toggleDescription}
-            >
-              {expanded ? t('see_less') : t('see_more')}
-            </button>
-          </div>
-        )}
-
-        <SkillGroup
-          skills={skills}
-          max={isXL ? 3 : 2}
-          initializeWithMax={2}
-          total={skills.length}
-          onShowAll={openModal}
-        />
-      </article>
-
-      <TechnologiesModal
-        open={modalOpen}
-        onClose={closeModal}
-        company={company}
-        position={position}
-        technologies={skills}
+      <SkillGroup
+        skills={skills}
+        max={isXL ? 3 : 2}
+        initializeWithMax={2}
+        total={skills.length}
       />
-    </>
+    </article>
   );
 };

--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -5,9 +5,7 @@ import { FC } from 'react';
 import { Icon } from '@repo/ui/Imagery';
 import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
-import { useBoolean } from 'usehooks-ts';
 
-import { TechnologiesModal } from '~features/about/TechnologiesModal';
 import { ShareButton } from '~features/shared/ShareButton';
 import { SkillGroup } from '~features/shared/SkillGroup';
 import { useBreakpoint } from '~hooks';
@@ -37,11 +35,6 @@ export const ProjectCard: FC<IProjectCardProps> = ({
   const t = useTranslations('ProjectCard');
   const isXL = useBreakpoint('xl');
   const locale = useLocale();
-  const {
-    value: modalOpen,
-    setTrue: openModal,
-    setFalse: closeModal,
-  } = useBoolean(false);
 
   if (view === 'row') {
     return (
@@ -76,7 +69,6 @@ export const ProjectCard: FC<IProjectCardProps> = ({
               max={3}
               initializeWithMax={3}
               total={skills.length}
-              onShowAll={openModal}
             />
             <Link
               href={`/projects/${slug}`}
@@ -89,12 +81,6 @@ export const ProjectCard: FC<IProjectCardProps> = ({
         </div>
 
         <ShareButton slug={slug} className="absolute top-3 right-3 z-10" />
-
-        <TechnologiesModal
-          open={modalOpen}
-          onClose={closeModal}
-          technologies={skills}
-        />
       </article>
     );
   }
@@ -128,7 +114,6 @@ export const ProjectCard: FC<IProjectCardProps> = ({
           max={isXL ? 3 : 2}
           initializeWithMax={2}
           total={skills.length}
-          onShowAll={openModal}
         />
         <Link
           href={`/projects/${slug}`}
@@ -139,12 +124,6 @@ export const ProjectCard: FC<IProjectCardProps> = ({
           <Icon icon="ic:round-arrow-forward" className="text-xl" />
         </Link>
       </div>
-
-      <TechnologiesModal
-        open={modalOpen}
-        onClose={closeModal}
-        technologies={skills}
-      />
     </article>
   );
 };

--- a/apps/site/src/features/shared/SkillGroup/index.tsx
+++ b/apps/site/src/features/shared/SkillGroup/index.tsx
@@ -3,7 +3,9 @@
 import { FC, useMemo, useState } from 'react';
 
 import { Badge } from '@repo/ui/View';
-import { useIsomorphicLayoutEffect } from 'usehooks-ts';
+import { useIsomorphicLayoutEffect, useBoolean } from 'usehooks-ts';
+
+import { TechnologiesModal } from '~/features/shared/TechnologiesModal';
 
 export type SkillSummary = { name: string; icon: string };
 
@@ -12,7 +14,6 @@ interface ISkillGroupProps {
   total: number;
   skills: SkillSummary[];
   initializeWithMax: number;
-  onShowAll?: () => void;
 }
 
 export const SkillGroup: FC<ISkillGroupProps> = ({
@@ -20,9 +21,13 @@ export const SkillGroup: FC<ISkillGroupProps> = ({
   skills,
   total,
   initializeWithMax,
-  onShowAll,
 }) => {
   const [storedMax, setStoredMax] = useState<number>(initializeWithMax);
+  const {
+    value: modalOpen,
+    setTrue: openModal,
+    setFalse: closeModal,
+  } = useBoolean(false);
 
   const renderedSkills = useMemo(
     () =>
@@ -45,23 +50,30 @@ export const SkillGroup: FC<ISkillGroupProps> = ({
   }, [max]);
 
   return (
-    <ul className="flex flex-row gap-2 flex-wrap">
-      {renderedSkills}
-      {skills.length > storedMax ? (
-        <li>
-          {onShowAll ? (
-            <button
-              type="button"
-              onClick={onShowAll}
-              className="hover:opacity-80 transition-opacity"
-            >
+    <>
+      <ul className="flex flex-row gap-2 flex-wrap">
+        {renderedSkills}
+        {skills.length > storedMax ? (
+          <li>
+            {modalOpen ? (
               <Badge.Count count={total - storedMax} />
-            </button>
-          ) : (
-            <Badge.Count count={total - storedMax} />
-          )}
-        </li>
-      ) : null}
-    </ul>
+            ) : (
+              <button
+                type="button"
+                className="hover:opacity-80 transition-opacity"
+                onClick={openModal}
+              >
+                <Badge.Count count={total - storedMax} />
+              </button>
+            )}
+          </li>
+        ) : null}
+      </ul>
+      <TechnologiesModal
+        open={modalOpen}
+        onClose={closeModal}
+        technologies={skills}
+      />
+    </>
   );
 };

--- a/apps/site/src/features/shared/TechnologiesModal/index.tsx
+++ b/apps/site/src/features/shared/TechnologiesModal/index.tsx
@@ -4,6 +4,7 @@ import { FC, useState } from 'react';
 
 import { Accordion, Modal } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
+import { useScrollLock } from 'usehooks-ts';
 
 export interface ITechnology {
   name: string;
@@ -28,8 +29,9 @@ export const TechnologiesModal: FC<ITechnologiesModalProps> = ({
 }) => {
   const hasDescriptions = technologies.some((t) => t.description);
   const [view, setView] = useState<'basic' | 'detailed'>('basic');
-
   const isDetailed = view === 'detailed';
+
+  useScrollLock({ autoLock: open });
 
   return (
     <Modal open={open} onClose={onClose} title="Tecnologias utilizadas">

--- a/apps/site/tests/features/about/TechnologiesModal.test.tsx
+++ b/apps/site/tests/features/about/TechnologiesModal.test.tsx
@@ -15,7 +15,11 @@ const mockLock = vi.fn();
 const mockUnlock = vi.fn();
 
 vi.mock('usehooks-ts', () => ({
-  useScrollLock: () => ({ lock: mockLock, unlock: mockUnlock, isLocked: false }),
+  useScrollLock: () => ({
+    lock: mockLock,
+    unlock: mockUnlock,
+    isLocked: false,
+  }),
   useOnClickOutside: vi.fn(),
   useEventListener: vi.fn(),
   useToggle: (initial = false) => {
@@ -26,13 +30,14 @@ vi.mock('usehooks-ts', () => ({
 }));
 
 vi.mock('@repo/ui/Control', async () => {
-  const actual = await vi.importActual<typeof import('@repo/ui/Control')>(
-    '@repo/ui/Control',
-  );
+  const actual =
+    await vi.importActual<typeof import('@repo/ui/Control')>(
+      '@repo/ui/Control',
+    );
   return actual;
 });
 
-import { TechnologiesModal } from '~features/about/TechnologiesModal';
+import { TechnologiesModal } from '~/features/shared/TechnologiesModal';
 
 const TECHS_WITHOUT_DESCRIPTIONS = [
   { name: 'React', icon: 'logos:react' },
@@ -41,7 +46,11 @@ const TECHS_WITHOUT_DESCRIPTIONS = [
 
 const TECHS_WITH_DESCRIPTIONS = [
   { name: 'React', icon: 'logos:react', description: 'UI library' },
-  { name: 'TypeScript', icon: 'logos:typescript-icon', description: 'Typed JS' },
+  {
+    name: 'TypeScript',
+    icon: 'logos:typescript-icon',
+    description: 'Typed JS',
+  },
 ];
 
 beforeEach(() => {
@@ -60,7 +69,9 @@ describe('TechnologiesModal', () => {
       />,
     );
 
-    expect(screen.queryByText('Tecnologias utilizadas')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Tecnologias utilizadas'),
+    ).not.toBeInTheDocument();
   });
 
   it('should render title, company and position when open', () => {


### PR DESCRIPTION
## Summary
- move `TechnologiesModal` from `features/about` into `features/shared`
- update all modal consumers and imports to use the shared feature location
- adjust associated tests to reflect the shared module path and behavior updates

## Testing
- not run (not requested)

## Context
- Conversation: https://app.warp.dev/conversation/6150f7c3-060e-4f8c-acd7-b69c27c005f2

Co-Authored-By: Oz <oz-agent@warp.dev>