### PR TITLE
feat(site): add ShortLink for icon-only ghost buttons in contact info

### DIFF
--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/ShortLink/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/ShortLink/index.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { FC } from 'react';
+
+import { Icon } from '@repo/ui/Imagery';
+import classNames from 'classnames';
+import NextLink from 'next/link';
+
+import { IGhostLinkProps } from '../../types';
+import { ROOT_STYLE } from '../constants';
+import { Container } from '../Container';
+
+export const ShortLink: FC<IGhostLinkProps> = ({
+  href,
+  icon,
+  className,
+  iconClassName,
+  newTab,
+}) => {
+  return (
+    <NextLink
+      href={href}
+      className={classNames(ROOT_STYLE, className)}
+      target={newTab ? '_blank' : '_self'}
+      rel={newTab ? 'noopener noreferrer' : undefined}
+    >
+      <Container>
+        <Icon className={iconClassName} icon={icon} />
+      </Container>
+    </NextLink>
+  );
+};

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/index.ts
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/index.ts
@@ -1,4 +1,5 @@
 import { Expandable } from './Expandable';
 import { Link } from './Link';
+import { ShortLink } from './ShortLink';
 
-export const Item2 = { Expandable, Link };
+export const Item2 = { Expandable, Link, ShortLink };

--- a/apps/site/src/features/contact/ContactInfo/index.tsx
+++ b/apps/site/src/features/contact/ContactInfo/index.tsx
@@ -79,22 +79,24 @@ export const ContactInfo: FC = () => {
       <p className="text-base text-content-primary">{t('paragraph1')}</p>
       <p className="text-base text-content-primary">{t('paragraph2')}</p>
 
-      <nav className="flex flex-col gap-y-3">
-        <MenuItem.Item2.Link
+      <nav className="flex gap-x-3">
+        <MenuItem.Item2.ShortLink
           href={process.env.NEXT_PUBLIC_LINKEDIN_URL}
           icon="devicon:linkedin"
           newTab
-        >
-          Linkedin
-        </MenuItem.Item2.Link>
-        <MenuItem.Item2.Link
+        />
+        <MenuItem.Item2.ShortLink
           href={process.env.NEXT_PUBLIC_GITHUB_URL}
           icon="mdi:github"
           iconClassName="text-white"
           newTab
-        >
-          GitHub
-        </MenuItem.Item2.Link>
+        />
+        <MenuItem.Item2.ShortLink
+          href="/feed.xml"
+          icon="mdi:rss"
+          iconClassName="text-white"
+          newTab
+        />
       </nav>
     </section>
   );


### PR DESCRIPTION
## Summary
- Add `MenuItem.Item2.ShortLink`, a compact icon-only variant of the existing ghost link button
- Update contact info social links to use horizontal icon-only buttons (LinkedIn, GitHub, RSS)

## Test plan
- [ ] Open the contact page and verify LinkedIn, GitHub, and RSS icons render in a horizontal row
- [ ] Confirm each icon link opens in a new tab with correct destination
- [ ] Verify ghost button hover/active styles match existing `Item2.Link` behavior


Made with [Cursor](https://cursor.com)