### PR TITLE
style(site): add horizontal margin on mobile for contact and projects sections

### DIFF
--- a/apps/site/src/features/contact/ContactSection/index.tsx
+++ b/apps/site/src/features/contact/ContactSection/index.tsx
@@ -6,7 +6,7 @@ import { ContactInfo } from '~features/contact/ContactInfo';
 export function ContactSection() {
   return (
     <section className="bg-surface-overlay xl:border-2 xl:border-b-0 xl:border-border-subtle py-10 xl:-mx-[161px] xl:px-[161px]">
-      <div className="flex flex-col gap-y-6 xl:flex-row xl:gap-x-16">
+      <div className="mx-4 xl:mx-auto flex flex-col gap-y-6 xl:flex-row xl:gap-x-16">
         <div className="xl:w-[560px] shrink-0">
           <ContactForm />
         </div>

--- a/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
@@ -49,7 +49,7 @@ export const ProjectList: FC<IProjectListProps> = ({
   return (
     <ul
       className={classNames(
-        'mx-auto grid max-w-237.5',
+        'mx-4 xl:mx-auto grid max-w-237.5',
         {
           'grid-cols-1 gap-6': view === 'row',
           'gap-4 md:grid-cols-2 xl:gap-6': view === 'grid',

--- a/apps/site/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
+++ b/apps/site/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
@@ -1,5 +1,21 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
   useLocale: () => 'pt-BR',
@@ -13,9 +29,16 @@ vi.mock('@repo/ui/View', () => ({
     content: string;
     className?: string;
   }) => <p className={className}>{content}</p>,
+  Badge: {
+    WithIcon: ({ label }: { label: string; icon: string }) => (
+      <span>{label}</span>
+    ),
+    Text: ({ label }: { label: string }) => <span>{label}</span>,
+    Count: ({ count }: { count: number }) => <span>+{count}</span>,
+  },
 }));
 
-vi.mock('~features/about/TechnologiesModal', () => ({
+vi.mock('~/features/shared/TechnologiesModal', () => ({
   TechnologiesModal: ({
     open,
     company,
@@ -24,10 +47,7 @@ vi.mock('~features/about/TechnologiesModal', () => ({
     company?: string;
     onClose: () => void;
     technologies: unknown[];
-  }) =>
-    open ? (
-      <div data-testid="technologies-modal">{company}</div>
-    ) : null,
+  }) => (open ? <div data-testid="technologies-modal">{company}</div> : null),
 }));
 
 import {
@@ -146,7 +166,7 @@ describe('ExperienceCard', () => {
     );
   });
 
-  it('should render up to 3 skill badges', () => {
+  it('should render up to 2 skill badges on mobile', () => {
     const fiveSkills = [
       { name: 'React', icon: '' },
       { name: 'TypeScript', icon: '' },
@@ -157,21 +177,21 @@ describe('ExperienceCard', () => {
     render(<ExperienceCard {...defaultProps} skills={fiveSkills} />);
     expect(screen.getByText('React')).toBeInTheDocument();
     expect(screen.getByText('TypeScript')).toBeInTheDocument();
-    expect(screen.getByText('Node.js')).toBeInTheDocument();
+    expect(screen.queryByText('Node.js')).not.toBeInTheDocument();
     expect(screen.queryByText('PostgreSQL')).not.toBeInTheDocument();
     expect(screen.queryByText('Docker')).not.toBeInTheDocument();
   });
 
-  it('should show +N badge when skills exceed 3', () => {
+  it('should show +N badge when skills exceed the visible max', () => {
     const fiveSkills = Array.from({ length: 5 }, (_, i) => ({
       name: `Skill${i}`,
       icon: '',
     }));
     render(<ExperienceCard {...defaultProps} skills={fiveSkills} />);
-    expect(screen.getByRole('button', { name: '+2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+3' })).toBeInTheDocument();
   });
 
-  it('should not show +N badge when skills are 3 or fewer', () => {
+  it('should not show +N badge when skills are 2 or fewer', () => {
     render(<ExperienceCard {...defaultProps} />);
     expect(
       screen.queryByRole('button', { name: /^\+\d/ }),
@@ -184,7 +204,7 @@ describe('ExperienceCard', () => {
       icon: '',
     }));
     render(<ExperienceCard {...defaultProps} skills={fiveSkills} />);
-    fireEvent.click(screen.getByRole('button', { name: '+2' }));
+    fireEvent.click(screen.getByRole('button', { name: '+3' }));
     expect(screen.getByTestId('technologies-modal')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- Add `mx-4 xl:mx-auto` to `ContactSection` and `ProjectList` for proper lateral spacing on mobile
- Fix pre-existing `ExperienceCard` test failures: missing `window.matchMedia` mock, incomplete `@repo/ui/View` mock (Badge sub-components), wrong `TechnologiesModal` import path, and expectations adjusted for mobile context (`max=2`)

## Test plan

- [ ] Verify contact and projects sections have correct horizontal margin on mobile
- [ ] Confirm all 153 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)