### PR TITLE
feat(site): make logo a clickable link to home

### DIFF
--- a/apps/site/src/components/Layout/Header/index.tsx
+++ b/apps/site/src/components/Layout/Header/index.tsx
@@ -6,6 +6,7 @@ import { Button } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
+import NextLink from 'next/link';
 
 import logoDesktop from '~assets/images/logo-desktop.svg';
 import logoMobile from '~assets/images/logo-mobile.svg';
@@ -20,22 +21,24 @@ export const Header: FC<HeaderProps> = ({ open, toggle }) => {
 
   return (
     <header className="w-full xl:w-60 flex items-center xl:items-end justify-between xl:justify-center bg-surface xl:bg-surface-sunken px-4 py-3 xl:px-0 xl:py-0 transition-all duration-300 ease-linear h-header-mobile xl:h-header-desktop">
-      <Image
-        src={logoDesktop}
-        width={179}
-        height={66}
-        alt={t('logo_alt')}
-        className="hidden xl:block"
-        priority
-      />
-      <Image
-        src={logoMobile}
-        width={120}
-        height={44}
-        alt={t('logo_alt')}
-        className="block xl:hidden"
-        priority
-      />
+      <NextLink href="/" aria-label={t('logo_alt')}>
+        <Image
+          src={logoDesktop}
+          width={179}
+          height={66}
+          alt={t('logo_alt')}
+          className="hidden xl:block"
+          priority
+        />
+        <Image
+          src={logoMobile}
+          width={120}
+          height={44}
+          alt={t('logo_alt')}
+          className="block xl:hidden"
+          priority
+        />
+      </NextLink>
       <Button.Base
         className="flex items-center justify-center h-10 w-10 !bg-surface-raised hover:!bg-surface !rounded !p-0 xl:hidden"
         onClick={toggle}


### PR DESCRIPTION
## Summary

- Wraps both logo images (desktop and mobile) in a `NextLink` pointing to `/`
- `aria-label` preserves accessibility using the existing `Header.logo_alt` i18n key

## Test plan

- [ ] Click the logo on desktop and confirm it navigates to `/`
- [ ] Click the logo on mobile and confirm it navigates to `/`
- [ ] Confirm no visual change to the logo itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)