### PR TITLE
fix(utils): use international country code in cellphone mask

### DIFF
--- a/packages/utils/src/constants/masks.ts
+++ b/packages/utils/src/constants/masks.ts
@@ -1,1 +1,1 @@
-export const CELLPHONE_MASK = [{ mask: '+55 00 00000-0000' }];
+export const CELLPHONE_MASK = [{ mask: '+00 00 00000-0000' }];

--- a/packages/utils/test/node/formatCellphone.test.ts
+++ b/packages/utils/test/node/formatCellphone.test.ts
@@ -2,9 +2,9 @@ import { formatCellphone } from '../../src';
 
 describe('formatCellphone', () => {
   it('should format cellphone', () => {
-    expect(formatCellphone('11999999999')).toBe('+55 11 99999-9999');
+    expect(formatCellphone('5511999999999')).toBe('+55 11 99999-9999');
     expect(formatCellphone('')).toBe('');
-    expect(formatCellphone('Lorem')).toBe('+55 ');
+    expect(formatCellphone('Lorem')).toBe('+');
     expect(formatCellphone(undefined as unknown as string)).toBe('');
   });
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `+55` prefix in `CELLPHONE_MASK` with generic `+00` so the country code comes from the input digits
- Update `formatCellphone` test to use full international number (`5511999999999`), matching `NEXT_PUBLIC_CONTACT_NUMBER` format

## Test plan
- [x] `pnpm test` in `packages/utils` passes
- [x] Pre-commit hooks (format, lint, test, types) pass

Made with [Cursor](https://cursor.com)