### PR TITLE
refactor(site): unify ProjectCard grid/row layouts into single responsive component

### DIFF
--- a/apps/site/src/components/Layout/Header/index.tsx
+++ b/apps/site/src/components/Layout/Header/index.tsx
@@ -5,9 +5,9 @@ import { FC } from 'react';
 import { Button } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
 import { useTranslations } from 'next-intl';
-import Image from 'next/image';
 import NextLink from 'next/link';
 
+import { screens } from '@repo/tailwind-config/screens';
 import logoDesktop from '~assets/images/logo-desktop.svg';
 import logoMobile from '~assets/images/logo-mobile.svg';
 
@@ -22,22 +22,21 @@ export const Header: FC<HeaderProps> = ({ open, toggle }) => {
   return (
     <header className="w-full xl:w-60 flex items-center xl:items-end justify-between xl:justify-center bg-surface xl:bg-surface-sunken px-4 py-3 xl:px-0 xl:py-0 transition-all duration-300 ease-linear h-header-mobile xl:h-header-desktop">
       <NextLink href="/" aria-label={t('logo_alt')}>
-        <Image
-          src={logoDesktop}
-          width={179}
-          height={66}
-          alt={t('logo_alt')}
-          className="hidden xl:block"
-          priority
-        />
-        <Image
-          src={logoMobile}
-          width={120}
-          height={44}
-          alt={t('logo_alt')}
-          className="block xl:hidden"
-          priority
-        />
+        <picture>
+          <source
+            media={`(min-width: ${screens.xl})`}
+            srcSet={logoDesktop.src}
+            width={179}
+            height={66}
+          />
+          <img
+            src={logoMobile.src}
+            width={120}
+            height={44}
+            alt={t('logo_alt')}
+            fetchPriority="high"
+          />
+        </picture>
       </NextLink>
       <Button.Base
         className="flex items-center justify-center h-10 w-10 !bg-surface-raised hover:!bg-surface !rounded !p-0 xl:hidden"

--- a/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -19,7 +19,7 @@ export async function ProjectsSection({
       <h4 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
         {t('projects_title')}
       </h4>
-      <ProjectList projects={projects} view="grid" className="pb-8 xl:pb-20" />
+      <ProjectList projects={projects} className="pb-8 xl:pb-20" />
     </>
   );
 }

--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -6,13 +6,12 @@ import { Icon } from '@repo/ui/Imagery';
 import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
 
+import { useBreakpoint } from '~/hooks';
 import { ShareButton } from '~features/shared/ShareButton';
 import { SkillGroup } from '~features/shared/SkillGroup';
-import { useBreakpoint } from '~hooks';
 import { Link } from '~i18n/routing';
 
 export interface IProjectCardProps {
-  view: 'grid' | 'row';
   slug: string;
   title: string;
   caption: string;
@@ -23,7 +22,6 @@ export interface IProjectCardProps {
 }
 
 export const ProjectCard: FC<IProjectCardProps> = ({
-  view,
   slug,
   title,
   caption,
@@ -33,96 +31,59 @@ export const ProjectCard: FC<IProjectCardProps> = ({
   skills,
 }) => {
   const t = useTranslations('ProjectCard');
-  const isXL = useBreakpoint('xl');
   const locale = useLocale();
-
-  if (view === 'row') {
-    return (
-      <article className="relative flex flex-row bg-surface rounded-xl w-full h-[339px] overflow-hidden">
-        <div className="relative w-[380px] shrink-0 m-3 rounded-lg overflow-hidden">
-          <Image
-            src={coverImage.url}
-            fill
-            alt={coverImage.alt}
-            className="object-cover"
-            sizes="380px"
-            priority
-          />
-        </div>
-
-        <div className="flex flex-col flex-1 p-6 gap-5">
-          <div className="flex flex-col gap-4 flex-1">
-            {theme && (
-              <span className="text-sm font-bold text-content-muted uppercase tracking-wide">
-                {theme}
-              </span>
-            )}
-            <h3 className="text-2xl font-bold text-content-primary">{title}</h3>
-            <p className="text-base font-normal text-content-secondary line-clamp-3">
-              {caption}
-            </p>
-          </div>
-
-          <div className="flex flex-col gap-4">
-            <SkillGroup
-              skills={skills}
-              max={3}
-              initializeWithMax={3}
-              total={skills.length}
-            />
-            <Link
-              href={`/projects/${slug}`}
-              className="flex flex-row justify-center items-center gap-2 bg-brand-primary text-body-sm text-content-primary font-bold rounded-xl hover:bg-brand-primary-hover transition-colors duration-300 py-3 px-6"
-            >
-              {t('view_project')}
-              <Icon icon="ic:round-arrow-forward" className="text-xl" />
-            </Link>
-          </div>
-        </div>
-
-        <ShareButton slug={slug} className="absolute top-3 right-3 z-10" />
-      </article>
-    );
-  }
+  const isXL = useBreakpoint('xl');
 
   return (
-    <article className="relative bg-surface rounded-xl overflow-hidden">
-      <div className="relative h-[244px] mx-3 mt-3 rounded-lg overflow-hidden">
+    <article className="relative flex flex-col bg-surface rounded-xl overflow-hidden xl:flex-row xl:w-full xl:h-[339px]">
+      <div className="relative h-[244px] mx-3 mt-3 rounded-lg overflow-hidden xl:w-[380px] xl:h-auto xl:shrink-0 xl:m-3">
         <Image
           src={coverImage.url}
           fill
           alt={coverImage.alt}
           className="object-cover"
-          sizes="463px"
+          sizes="(min-width: 1280px) 380px, 463px"
           priority
         />
-        <ShareButton slug={slug} className="absolute top-2 right-2 z-10" />
       </div>
 
-      <div className="flex flex-col p-4 gap-4">
-        {theme && (
-          <span className="text-xs font-bold text-content-muted uppercase tracking-wide">
-            {theme}
-          </span>
-        )}
-        <h3 className="text-2xl font-bold text-content-primary">{title}</h3>
-        <p className="text-base font-normal text-content-secondary line-clamp-2">
-          {caption}
-        </p>
-        <SkillGroup
-          skills={skills}
-          max={isXL ? 3 : 2}
-          initializeWithMax={2}
-          total={skills.length}
-        />
-        <Link
-          href={`/projects/${slug}`}
-          locale={locale}
-          className="flex flex-row justify-center items-center gap-2 bg-brand-primary text-body-sm text-content-primary font-bold rounded-xl hover:bg-brand-primary-hover transition-colors duration-300 py-3 px-6"
-        >
-          {t('view_project')}
-          <Icon icon="ic:round-arrow-forward" className="text-xl" />
-        </Link>
+      <ShareButton
+        slug={slug}
+        className="absolute top-5 right-5 z-10 xl:top-3 xl:right-3"
+      />
+
+      <div className="flex flex-col flex-1 p-4 gap-4 xl:p-6 xl:gap-5">
+        <div className="flex flex-col gap-4 flex-1">
+          {theme && (
+            <span className="text-xs font-bold text-content-muted uppercase tracking-wide xl:text-sm">
+              {theme}
+            </span>
+          )}
+
+          <h3 className="text-2xl font-bold text-content-primary">{title}</h3>
+
+          <p className="text-base font-normal text-content-secondary line-clamp-2 xl:line-clamp-3">
+            {caption}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <SkillGroup
+            skills={skills}
+            max={isXL ? 3 : 2}
+            initializeWithMax={2}
+            total={skills.length}
+          />
+
+          <Link
+            href={`/projects/${slug}`}
+            locale={locale}
+            className="flex flex-row justify-center items-center gap-2 bg-brand-primary text-body-sm text-content-primary font-bold rounded-xl hover:bg-brand-primary-hover transition-colors duration-300 py-3 px-6"
+          >
+            {t('view_project')}
+            <Icon icon="ic:round-arrow-forward" className="text-xl" />
+          </Link>
+        </div>
       </div>
     </article>
   );

--- a/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
@@ -19,14 +19,12 @@ export interface ProjectSummary {
 interface IProjectListProps {
   projects: ProjectSummary[];
   compact?: IProjectCardProps['compact'];
-  view: IProjectCardProps['view'];
   className?: string;
 }
 
 export const ProjectList: FC<IProjectListProps> = ({
   projects,
   compact,
-  view,
   className,
 }) => {
   const renderedProjects = useMemo(() => {
@@ -40,20 +38,15 @@ export const ProjectList: FC<IProjectListProps> = ({
           theme={project.theme}
           skills={project.skills}
           compact={compact}
-          view={view}
         />
       </li>
     ));
-  }, [projects, compact, view]);
+  }, [projects, compact]);
 
   return (
     <ul
       className={classNames(
-        'mx-4 xl:mx-auto grid max-w-237.5',
-        {
-          'grid-cols-1 gap-6': view === 'row',
-          'gap-4 md:grid-cols-2 xl:gap-6': view === 'grid',
-        },
+        'grid gap-4 md:grid-cols-2 xl:grid-cols-1 xl:gap-6 mx-4 xl:mx-auto max-w-237.5',
         className,
       )}
     >

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -122,10 +122,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
             <h2 className="text-[32px] font-bold text-content-primary">
               {t('related_title')}
             </h2>
-            <ProjectList
-              projects={relatedProjects}
-              view={relatedProjects.length === 1 ? 'row' : 'grid'}
-            />
+            <ProjectList projects={relatedProjects} />
           </section>
         )}
       </div>

--- a/apps/site/src/features/projects/ProjectsSection/index.tsx
+++ b/apps/site/src/features/projects/ProjectsSection/index.tsx
@@ -5,7 +5,5 @@ interface ProjectsSectionProps {
 }
 
 export function ProjectsSection({ projects }: ProjectsSectionProps) {
-  return (
-    <ProjectList projects={projects} view="row" className="py-8 xl:py-20" />
-  );
+  return <ProjectList projects={projects} className="py-8 xl:py-20" />;
 }

--- a/apps/site/src/hooks/useBreakpoint.ts
+++ b/apps/site/src/hooks/useBreakpoint.ts
@@ -6,8 +6,24 @@ import twConfig from '../../tailwind.config';
 const resolvedConfig = resolveConfig(twConfig);
 const breakpoints = resolvedConfig.theme.screens;
 
-export const useBreakpoint = (breakpoint: keyof typeof breakpoints) => {
+export interface IUseBreakpointProps {
+  breakpoint: keyof typeof breakpoints;
+  defaultValue?: boolean;
+}
+
+export interface IUseBreakpointOptions {
+  initializeWithValue?: boolean;
+  defaultValue?: boolean;
+}
+
+export const useBreakpoint = (
+  breakpoint: keyof typeof breakpoints,
+  options: IUseBreakpointOptions = {},
+) => {
+  const { defaultValue = false, initializeWithValue = true } = options;
+
   return useMediaQuery(`(min-width: ${breakpoints[breakpoint]})`, {
-    defaultValue: false,
+    defaultValue,
+    initializeWithValue: initializeWithValue,
   });
 };

--- a/apps/site/src/hooks/useBreakpoint.ts
+++ b/apps/site/src/hooks/useBreakpoint.ts
@@ -1,10 +1,5 @@
-import resolveConfig from 'tailwindcss/resolveConfig';
+import { screens as breakpoints } from '@repo/tailwind-config/screens';
 import { useMediaQuery } from 'usehooks-ts';
-
-import twConfig from '../../tailwind.config';
-
-const resolvedConfig = resolveConfig(twConfig);
-const breakpoints = resolvedConfig.theme.screens;
 
 export interface IUseBreakpointProps {
   breakpoint: keyof typeof breakpoints;

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -3,8 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "main": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./screens": "./screens.ts"
+  },
   "files": [
     "index.ts",
+    "screens.ts",
     "tailwind.css"
   ],
   "scripts": {

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -5,7 +5,8 @@
   "main": "index.ts",
   "exports": {
     ".": "./index.ts",
-    "./screens": "./screens.ts"
+    "./screens": "./screens.ts",
+    "./tailwind.css": "./tailwind.css"
   },
   "files": [
     "index.ts",

--- a/packages/tailwind-config/screens.ts
+++ b/packages/tailwind-config/screens.ts
@@ -1,0 +1,9 @@
+export const screens = {
+  sm: '640px',
+  md: '768px',
+  lg: '1024px',
+  xl: '1280px',
+  '2xl': '1536px',
+} as const;
+
+export type Screen = keyof typeof screens;


### PR DESCRIPTION
## Summary

- Remove the \`view\` prop (\`'grid' | 'row'\`) from \`ProjectCard\` and \`ProjectList\` — the two visual layouts are now a single component that adapts via Tailwind responsive utilities (\`xl:flex-row\`, \`xl:w-[380px]\`, \`xl:grid-cols-1\`, etc.)
- Consolidate \`ShareButton\` positioning to a single absolute placement that works in both mobile and desktop layouts
- Extend \`useBreakpoint\` to accept an \`options\` object (\`defaultValue\`, \`initializeWithValue\`) instead of a hardcoded \`false\` default
- Fix \`useBreakpoint\` import path in \`ProjectCard\` (\`~hooks\` → \`~/hooks\`)
- Replace two \`next/image\` instances in \`Header\` (hidden/block toggle) with a single \`<picture>\`/\`<source media>\` — correct HTML art direction, no JS, no optimization loss for SVGs
- Add \`packages/tailwind-config/screens.ts\` as the single source of truth for Tailwind breakpoint values; exported via \`@repo/tailwind-config/screens\`
- Simplify \`useBreakpoint\` to import \`screens\` from \`@repo/tailwind-config/screens\` instead of resolving the full Tailwind config at runtime

## Test plan

- [ ] Home page: project cards render as 2-column grid on md, switch to single-column row layout on xl
- [ ] Projects list page: same responsive behavior
- [ ] Project detail page: related projects section renders correctly
- [ ] Header logo switches between mobile and desktop SVG at xl breakpoint
- [ ] ShareButton is visible and correctly positioned on all breakpoints
- [ ] No TypeScript errors (\`pnpm typecheck\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)