### PR TITLE
fix(i18n): centralize DEFAULT_LOCALE — remove hardcoded 'en-US' across site

### DIFF
--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -3,6 +3,7 @@ import { type Locale, LOCALES } from '@repo/core/shared';
 import type { Metadata } from 'next';
 import { setRequestLocale } from 'next-intl/server';
 
+import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
 import { CurriculumCTA } from '~features/about/CurriculumCTA';
 import { ExperiencesSection } from '~features/about/ExperiencesSection';
@@ -20,7 +21,7 @@ interface AboutPageProps {
 export async function generateMetadata({
   params,
 }: AboutPageProps): Promise<Metadata> {
-  const locale = ((await params)?.locale ?? 'en-US') as Locale;
+  const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
 
   const title =
@@ -46,7 +47,7 @@ export async function generateMetadata({
 }
 
 export default async function About({ params }: AboutPageProps) {
-  const locale = ((await params)?.locale ?? 'en-US') as Locale;
+  const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
 
   return (

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -3,6 +3,7 @@ import { type Locale, LOCALES } from '@repo/core/shared';
 import type { Metadata } from 'next';
 import { setRequestLocale } from 'next-intl/server';
 
+import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
 import { HeroSection } from '~features/home/HeroSection';
 import { ProjectsSection } from '~features/home/ProjectsSection';
@@ -18,7 +19,7 @@ interface HomePageProps {
 export async function generateMetadata({
   params,
 }: HomePageProps): Promise<Metadata> {
-  const locale = ((await params)?.locale ?? 'en-US') as Locale;
+  const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
 
   const profileResult = await new GetProfile(
@@ -41,7 +42,7 @@ export async function generateMetadata({
 }
 
 export default async function Home({ params }: HomePageProps) {
-  const locale = ((await params)?.locale ?? 'en-US') as Locale;
+  const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
 
   const { profileRepository, projectRepository, skillRepository } =

--- a/apps/site/src/app/[locale]/projects/[slug]/page.tsx
+++ b/apps/site/src/app/[locale]/projects/[slug]/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next';
 import { setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 
+import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
 import { ProjectDetail } from '~features/projects/ProjectDetail';
 
@@ -15,7 +16,7 @@ export async function generateStaticParams() {
   const result = await new GetPublishedProjects(
     projectRepository,
     skillRepository,
-  ).execute({ locale: 'en-US' });
+  ).execute({ locale: DEFAULT_LOCALE });
 
   const slugs = result.isRight() ? result.value.map((p) => p.slug) : [];
   return LOCALES.flatMap((locale) => slugs.map((slug) => ({ locale, slug })));

--- a/apps/site/src/app/[locale]/projects/page.tsx
+++ b/apps/site/src/app/[locale]/projects/page.tsx
@@ -3,6 +3,7 @@ import { type Locale, LOCALES } from '@repo/core/shared';
 import type { Metadata } from 'next';
 import { setRequestLocale } from 'next-intl/server';
 
+import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
 import { HeroSection } from '~features/projects/HeroSection';
 import { ProjectsSection } from '~features/projects/ProjectsSection';
@@ -18,7 +19,7 @@ interface ProjectsPageProps {
 export async function generateMetadata({
   params,
 }: ProjectsPageProps): Promise<Metadata> {
-  const locale = ((await params)?.locale ?? 'en-US') as Locale;
+  const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
 
   const title = locale.startsWith('pt')
@@ -36,7 +37,7 @@ export async function generateMetadata({
 }
 
 export default async function Projects({ params }: ProjectsPageProps) {
-  const locale = ((await params)?.locale ?? 'en-US') as Locale;
+  const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
 
   const { projectRepository, skillRepository } = getServerContainer();

--- a/apps/site/src/app/feed.xml/route.ts
+++ b/apps/site/src/app/feed.xml/route.ts
@@ -1,5 +1,6 @@
 import { GetPublishedProjects } from '@repo/application/portfolio';
 
+import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
 
 export const dynamic = 'force-static';
@@ -20,7 +21,7 @@ export async function GET(): Promise<Response> {
   const result = await new GetPublishedProjects(
     projectRepository,
     skillRepository,
-  ).execute({ locale: 'en-US' });
+  ).execute({ locale: DEFAULT_LOCALE });
 
   const projects = result.isRight() ? result.value : [];
 
@@ -29,9 +30,9 @@ export async function GET(): Promise<Response> {
       (p) => `
     <item>
       <title>${escapeXml(p.title)}</title>
-      <link>${SITE_URL}/en-US/projects/${escapeXml(p.slug)}</link>
+      <link>${SITE_URL}/${DEFAULT_LOCALE}/projects/${escapeXml(p.slug)}</link>
       <description>${escapeXml(p.caption)}</description>
-      <guid isPermaLink="true">${SITE_URL}/en-US/projects/${escapeXml(p.slug)}</guid>
+      <guid isPermaLink="true">${SITE_URL}/${DEFAULT_LOCALE}/projects/${escapeXml(p.slug)}</guid>
     </item>`,
     )
     .join('');

--- a/apps/site/src/app/sitemap.ts
+++ b/apps/site/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import { GetPublishedProjects } from '@repo/application/portfolio';
 import { LOCALES } from '@repo/core/shared';
 import type { MetadataRoute } from 'next';
 
+import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
 
 export const dynamic = 'force-static';
@@ -27,7 +28,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const result = await new GetPublishedProjects(
       projectRepository,
       skillRepository,
-    ).execute({ locale: 'en-US' });
+    ).execute({ locale: DEFAULT_LOCALE });
 
     const projects = result.isRight() ? result.value : [];
 

--- a/apps/site/src/components/Layout/SideNavigation/LanguageSelector.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/LanguageSelector.tsx
@@ -8,8 +8,8 @@ import {
   RadioGroupChildrenFn,
   RadioGroupProps,
 } from '@repo/ui/Control';
-import { useTranslations } from 'next-intl';
-import { useParams, usePathname, useRouter } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import { usePathname, useRouter } from 'next/navigation';
 
 import { LANGUAGES_OPTIONS } from './constants';
 import { MenuItem } from './MenuItem';
@@ -17,8 +17,7 @@ import { MenuItem } from './MenuItem';
 export const LanguageSelector: FC = () => {
   const t = useTranslations('SideNavigation');
   const tLang = useTranslations('Language');
-  const params = useParams();
-  const locale = (params?.locale as string) ?? 'en-US';
+  const locale = useLocale();
   const { replace } = useRouter();
   const pathname = usePathname();
 

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx
@@ -4,8 +4,8 @@ import { FC } from 'react';
 
 import { Icon } from '@repo/ui/Imagery';
 import classNames from 'classnames';
+import { useLocale } from 'next-intl';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
 
 import { Text } from '../Text';
 import { IGhostLinkProps } from '../types';
@@ -18,8 +18,7 @@ export const Item1: FC<IGhostLinkProps> = ({
   iconClassName,
   newTab = false,
 }) => {
-  const params = useParams();
-  const locale = (params?.locale as string) ?? 'en-US';
+  const locale = useLocale();
   const localizedHref = href === '/' ? `/${locale}` : `/${locale}${href}`;
   const newHref = newTab ? href : localizedHref;
 

--- a/apps/site/src/components/Layout/SideNavigation/constants.ts
+++ b/apps/site/src/components/Layout/SideNavigation/constants.ts
@@ -1,6 +1,8 @@
+import { DEFAULT_LOCALE } from '@repo/core/shared';
+
 export const LANGUAGES_OPTIONS = [
   {
-    option: 'en-US',
+    option: DEFAULT_LOCALE,
     labelKey: 'enUS' as const,
     icon: 'twemoji:flag-united-states',
   },

--- a/apps/site/src/i18n/routing.ts
+++ b/apps/site/src/i18n/routing.ts
@@ -1,12 +1,12 @@
+import { DEFAULT_LOCALE, LOCALES } from '@repo/core/shared';
 import { createNavigation } from 'next-intl/navigation';
 import { defineRouting } from 'next-intl/routing';
 
-export const routing = defineRouting({
-  // A list of all locales that are supported
-  locales: ['en-US', 'es', 'pt-BR'],
+export { DEFAULT_LOCALE } from '@repo/core/shared';
 
-  // Used when no locale matches
-  defaultLocale: 'en-US',
+export const routing = defineRouting({
+  locales: LOCALES,
+  defaultLocale: DEFAULT_LOCALE,
 });
 
 // Lightweight wrappers around Next.js' navigation APIs

--- a/apps/site/src/utils/constants/languages.ts
+++ b/apps/site/src/utils/constants/languages.ts
@@ -1,1 +1,3 @@
-export const LANGUAGES = ['en-US', 'pt-BR', 'es'];
+import { routing } from '~/i18n/routing';
+
+export const LANGUAGES = routing.locales;

--- a/apps/site/tests/app/[locale]/about.test.tsx
+++ b/apps/site/tests/app/[locale]/about.test.tsx
@@ -10,6 +10,7 @@ vi.mock('next-intl/server', () => ({
 }));
 
 vi.mock('@repo/core/shared', () => ({
+  DEFAULT_LOCALE: 'en-US',
   LOCALES: ['en-US', 'pt-BR', 'es'],
 }));
 

--- a/apps/site/tests/app/[locale]/home.test.tsx
+++ b/apps/site/tests/app/[locale]/home.test.tsx
@@ -10,6 +10,7 @@ vi.mock('next-intl/server', () => ({
 }));
 
 vi.mock('@repo/core/shared', () => ({
+  DEFAULT_LOCALE: 'en-US',
   LOCALES: ['en-US', 'pt-BR', 'es'],
 }));
 

--- a/apps/site/tests/app/[locale]/project-detail.test.tsx
+++ b/apps/site/tests/app/[locale]/project-detail.test.tsx
@@ -10,10 +10,13 @@ vi.mock('next-intl/server', () => ({
 }));
 
 vi.mock('@repo/core/shared', () => ({
+  DEFAULT_LOCALE: 'en-US',
   LOCALES: ['en-US', 'pt-BR', 'es'],
 }));
 
 vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
   notFound: vi.fn(() => {
     throw new Error('NEXT_NOT_FOUND');
   }),

--- a/apps/site/tests/app/[locale]/projects.test.tsx
+++ b/apps/site/tests/app/[locale]/projects.test.tsx
@@ -10,6 +10,7 @@ vi.mock('next-intl/server', () => ({
 }));
 
 vi.mock('@repo/core/shared', () => ({
+  DEFAULT_LOCALE: 'en-US',
   LOCALES: ['en-US', 'pt-BR', 'es'],
 }));
 

--- a/apps/site/tests/components/View/SideNavigation/LanguageSelector.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/LanguageSelector.test.tsx
@@ -7,6 +7,8 @@ let mockPathname = '/en-US/about';
 let mockLocale = 'en-US';
 
 vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
   useRouter: () => ({ replace: mockReplace }),
   usePathname: () => mockPathname,
   useParams: () => ({ locale: mockLocale }),
@@ -14,6 +16,7 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
+  useLocale: () => mockLocale,
 }));
 
 vi.mock('~/components/Layout/SideNavigation/MenuItem', () => ({

--- a/packages/utils/src/i18n/Translator.ts
+++ b/packages/utils/src/i18n/Translator.ts
@@ -3,25 +3,29 @@ import { Translatei18n } from './Translatei18n';
 import { I18n } from './types';
 
 export class Translator {
-  private static DEFAULT_LOCALE = 'en-US';
-  private static _locales: Set<string> = new Set([this.DEFAULT_LOCALE]);
+  private static _defaultLocale: string;
+  private static _locales: Set<string> = new Set();
 
   public static get locales(): Array<string | null> {
     return Array.from(this._locales);
   }
 
-  public static setLocales(locales: Array<string>) {
+  public static setDefaultLocale(locale: string): typeof Translator {
+    this._defaultLocale = locale;
+    this._locales = new Set([locale, ...this._locales]);
+    return this;
+  }
+
+  public static setLocales(locales: Array<string>): typeof Translator {
     const newLocales = [...this.locales, ...locales].filter(isNotNil);
-
     this._locales = new Set(newLocales as Array<string>);
-
     return this;
   }
 
   public static i18n(i18n: I18n, code: string, locale?: string): string | null {
-    const newLocale = locale ?? this.DEFAULT_LOCALE;
+    const newLocale = locale ?? this._defaultLocale;
 
-    if (this.locales.includes(newLocale)) {
+    if (newLocale && this.locales.includes(newLocale)) {
       return new Translatei18n(i18n, newLocale).translate(code);
     }
 

--- a/packages/utils/test/node/Translator.test.ts
+++ b/packages/utils/test/node/Translator.test.ts
@@ -1,5 +1,6 @@
 import { Translator } from '../../src/i18n';
 
+Translator.setDefaultLocale('en-US');
 Translator.setLocales(['pt-BR', 'es', 'fr']);
 
 describe('Translator', () => {


### PR DESCRIPTION
Closes #647

## Summary

- Export `DEFAULT_LOCALE` from `@repo/core/shared` (`packages/core/src/shared/i18n/Locale.ts`) — the domain source of truth for the default locale
- `routing.ts` now derives `locales` and `defaultLocale` from core and re-exports `DEFAULT_LOCALE` for downstream convenience
- Replace every hardcoded `'en-US'` literal outside the i18n config declaration across 8 site files
- `Translator` (utils) removes its own hardcoded default locale; consumers must call `setDefaultLocale()` to inject the value — resolves the circular-dep constraint (`core → utils`)
- Test mocks updated: `DEFAULT_LOCALE`, `redirect`, `permanentRedirect`, `useLocale`

## Files changed

| File | Change |
|------|--------|
| `i18n/routing.ts` | Imports `DEFAULT_LOCALE` + `LOCALES` from core; re-exports `DEFAULT_LOCALE` |
| `app/[locale]/page.tsx`, `about/page.tsx`, `projects/page.tsx` | `?? 'en-US'` → `?? DEFAULT_LOCALE` |
| `app/[locale]/projects/[slug]/page.tsx` | `generateStaticParams` locale |
| `app/feed.xml/route.ts` | execute locale + URL path segments |
| `app/sitemap.ts` | execute locale |
| `SideNavigation/LanguageSelector.tsx`, `MenuItem/Item1` | `?? 'en-US'` → `useLocale()` |
| `SideNavigation/constants.ts` | `LANGUAGES_OPTIONS` default option |
| `utils/constants/languages.ts` | `LANGUAGES` array entry |
| `packages/utils/src/i18n/Translator.ts` | `setDefaultLocale()` replaces hardcoded default |

## Test plan

- [ ] All 153 site tests pass (`pnpm --filter site test`)
- [ ] All 113 utils tests pass (`pnpm --filter @repo/utils test`)
- [ ] No `'en-US'` literals outside `packages/core/src/shared/i18n/Locale.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)