### PR TITLE
style(site): improve breadcrumb layout on mobile project detail

### DIFF
--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -66,17 +66,20 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
   );
 
   return (
-    <article className="flex flex-col gap-y-10 pb-12">
+    <article className="flex flex-col gap-y-10 pb-12 mt-6 xl:mt-0">
       <div className="mx-4 xl:mx-auto xl:w-full xl:max-w-237.5 flex flex-col gap-y-10">
-        <div className="flex items-center justify-between h-12">
+        <div className="flex flex-col justify-center items-start gap-y-1 xl:flex-row xl:items-center xl:justify-between">
+          <Breadcrumb
+            items={breadcrumbItems}
+            className="flex items-center min-h-12 xl:order-2"
+          />
           <Link
             href="/projects"
-            className="flex items-center gap-x-2 text-base text-content-primary"
+            className="flex items-center gap-x-2 text-base text-content-primary xl:order-1 xl:min-h-12"
           >
             <Icon icon="material-symbols:arrow-back" className="text-2xl" />
             {t('back')}
           </Link>
-          <Breadcrumb items={breadcrumbItems} />
         </div>
 
         <div className="flex flex-col gap-y-6">

--- a/apps/site/src/features/shared/Breadcrumb/index.tsx
+++ b/apps/site/src/features/shared/Breadcrumb/index.tsx
@@ -3,7 +3,6 @@
 import { FC } from 'react';
 
 import { Icon } from '@repo/ui/Imagery';
-import classNames from 'classnames';
 
 import { Link } from '~i18n/routing';
 
@@ -14,10 +13,11 @@ export interface BreadcrumbItem {
 
 interface IBreadcrumbProps {
   items: BreadcrumbItem[];
+  className?: string;
 }
 
-export const Breadcrumb: FC<IBreadcrumbProps> = ({ items }) => (
-  <nav aria-label="breadcrumb">
+export const Breadcrumb: FC<IBreadcrumbProps> = ({ items, className }) => (
+  <nav aria-label="breadcrumb" className={className}>
     <ol className="flex flex-row flex-wrap items-center gap-x-1">
       {items.map((item, i) => {
         const isLast = i === items.length - 1;


### PR DESCRIPTION
## Summary
- Reorganize project detail header on mobile: breadcrumb stacks above the back link; desktop layout unchanged (`xl` breakpoint).
- Add optional `className` prop to `Breadcrumb` for layout control and remove unused `classnames` import.

## Test plan
- [ ] Open a project detail page on mobile viewport — breadcrumb appears above the back link
- [ ] Open the same page on `xl` viewport — back link and breadcrumb remain side by side
- [ ] Verify breadcrumb links still navigate correctly


Made with [Cursor](https://cursor.com)