### PR TITLE
fix(a11y): set explicit LTR direction on root html element

### DIFF
--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -1,10 +1,9 @@
+import { LOCALES } from '@repo/core/shared';
 import classNames from 'classnames';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { Inter } from 'next/font/google';
-
-import { LOCALES } from '@repo/core/shared';
 
 import { AppLayout } from '~components';
 
@@ -59,7 +58,7 @@ export default async function RootLayout({
   const messages = await getMessages();
 
   return (
-    <html lang={locale}>
+    <html dir="ltr" lang={locale}>
       <body
         className={classNames(
           'flex flex-col h-screen antialiased dark:bg-dark',


### PR DESCRIPTION
## Summary

- Adds `dir="ltr"` to the root `<html>` element in the site layout
- Ensures consistent left-to-right text direction regardless of browser or locale defaults

## Test plan

- [ ] Load the site in the browser and inspect the `<html>` element — confirm `dir="ltr"` is present
- [ ] Verify layout and text alignment remain correct across locales (en-US, pt-BR)
- [ ] Check breadcrumb and navigation direction on mobile project detail page


Made with [Cursor](https://cursor.com)