### PR TITLE
fix(site): enable scroll and bottom padding in mobile side navigation

### DIFF
--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -28,7 +28,7 @@ export const SideNavigation: FC = () => {
       <nav
         id="side-navigation"
         className={classNames(
-          'h-sidenav-mobile xl:h-sidenav-desktop left-0 w-full xl:w-60 xl:px-4 bg-surface-sunken flex flex-col border-0 duration-300 ease-linear xl:!translate-x-0 z-9999',
+          'h-sidenav-mobile xl:h-sidenav-desktop left-0 w-full xl:w-60 xl:px-4 bg-surface-sunken flex flex-col overflow-y-auto overscroll-y-contain border-0 duration-300 ease-linear xl:!translate-x-0 z-9999',
           isOpen ? 'translate-x-0' : '-translate-x-full',
         )}
       >
@@ -54,7 +54,7 @@ export const SideNavigation: FC = () => {
           </MenuItem.Item1>
         </ul>
         <Divider className="mx-6 xl:mx-0" />
-        <ul className="flex flex-col gap-y-3 px-6 xl:pb-8 xl:px-0 xl:justify-end">
+        <ul className="flex flex-col gap-y-3 px-6 pb-8 xl:px-0 xl:justify-end">
           <MenuItem.Item2.Link
             href={process.env.NEXT_PUBLIC_LINKEDIN_URL}
             icon="devicon:linkedin"


### PR DESCRIPTION
## Summary

- Add vertical scroll to the mobile side navigation when menu items exceed the viewport height
- Add `overscroll-y-contain` to prevent scroll from propagating to the page behind the open menu
- Apply bottom padding on mobile so the last menu items are not flush against the screen edge

## Test plan

- [ ] Open the site on a mobile viewport (or DevTools responsive mode)
- [ ] Open the hamburger menu and expand the language selector
- [ ] Confirm all menu items are reachable via scroll
- [ ] Confirm there is comfortable spacing below the last item when scrolled to the bottom
- [ ] Confirm desktop side navigation layout is unchanged


Made with [Cursor](https://cursor.com)