### PR TITLE
fix(i18n): replace locale.startsWith() checks with i18n metadata translations

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6022,8 +6022,9 @@
         "dependencies": [
           "1"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "in-progress",
+        "subtasks": [],
+        "updatedAt": "2026-06-10T15:56:54.269Z"
       },
       {
         "id": "3",
@@ -6033,8 +6034,9 @@
         "testStrategy": "- Add unit test in packages/core/test/shared/i18n/ERROR_MESSAGE.test.ts verifying INVALID_MESSAGE exists for all locales\n- Update/add tests in SendContactMessage use case test file to cover INVALID_MESSAGE error path\n- Test the contact form with empty message field to ensure error displays correctly in all three languages",
         "priority": "high",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-10T15:51:57.307Z"
       },
       {
         "id": "4",
@@ -6164,9 +6166,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-10T15:28:39.765Z",
+      "lastModified": "2026-06-10T15:56:54.269Z",
       "taskCount": 14,
-      "completedCount": 2,
+      "completedCount": 3,
       "tags": [
         "mvp-round-3"
       ]

--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -107,6 +107,15 @@
     "role_label": "Role",
     "period_label": "Period"
   },
+  "Metadata": {
+    "AboutPage": {
+      "title": "About"
+    },
+    "ProjectsPage": {
+      "title": "Projects",
+      "description": "Software projects developed by Wallace Ferreira — scalable web applications built with React, Next.js, and TypeScript."
+    }
+  },
   "LoginForm": {
     "title": "Sign in",
     "emailPlaceholder": "Email address",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -107,6 +107,15 @@
     "role_label": "Rol",
     "period_label": "Período"
   },
+  "Metadata": {
+    "AboutPage": {
+      "title": "Sobre"
+    },
+    "ProjectsPage": {
+      "title": "Proyectos",
+      "description": "Proyectos de software desarrollados por Wallace Ferreira — aplicaciones web escalables con React, Next.js y TypeScript."
+    }
+  },
   "LoginForm": {
     "title": "Iniciar sesión",
     "emailPlaceholder": "Correo electrónico",

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -107,6 +107,15 @@
     "role_label": "Função",
     "period_label": "Período"
   },
+  "Metadata": {
+    "AboutPage": {
+      "title": "Sobre"
+    },
+    "ProjectsPage": {
+      "title": "Projetos",
+      "description": "Projetos de software desenvolvidos por Wallace Ferreira — aplicações web escaláveis com React, Next.js e TypeScript."
+    }
+  },
   "LoginForm": {
     "title": "Entrar",
     "emailPlaceholder": "Endereço de e-mail",

--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -1,7 +1,7 @@
 import { GetProfile } from '@repo/application/portfolio';
 import { type Locale, LOCALES } from '@repo/core/shared';
 import type { Metadata } from 'next';
-import { setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
@@ -23,9 +23,9 @@ export async function generateMetadata({
 }: AboutPageProps): Promise<Metadata> {
   const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: 'Metadata' });
 
-  const title =
-    locale.startsWith('pt') || locale.startsWith('es') ? 'Sobre' : 'About';
+  const title = t('AboutPage.title');
 
   const profileResult = await new GetProfile(
     getServerContainer().profileRepository,

--- a/apps/site/src/app/[locale]/projects/page.tsx
+++ b/apps/site/src/app/[locale]/projects/page.tsx
@@ -1,7 +1,7 @@
 import { GetPublishedProjects } from '@repo/application/portfolio';
 import { type Locale, LOCALES } from '@repo/core/shared';
 import type { Metadata } from 'next';
-import { setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
@@ -21,17 +21,10 @@ export async function generateMetadata({
 }: ProjectsPageProps): Promise<Metadata> {
   const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: 'Metadata' });
 
-  const title = locale.startsWith('pt')
-    ? 'Projetos'
-    : locale.startsWith('es')
-      ? 'Proyectos'
-      : 'Projects';
-  const description = locale.startsWith('pt')
-    ? 'Projetos de software desenvolvidos por Wallace Ferreira — aplicações web escaláveis com React, Next.js e TypeScript.'
-    : locale.startsWith('es')
-      ? 'Proyectos de software desarrollados por Wallace Ferreira — aplicaciones web escalables con React, Next.js y TypeScript.'
-      : 'Software projects developed by Wallace Ferreira — scalable web applications built with React, Next.js, and TypeScript.';
+  const title = t('ProjectsPage.title');
+  const description = t('ProjectsPage.description');
 
   return { title, description, openGraph: { title, description } };
 }


### PR DESCRIPTION
## Summary

- Add `Metadata` namespace to all three locale files (`en-US`, `pt-BR`, `es`) with `AboutPage.title` and `ProjectsPage.title` + `ProjectsPage.description` keys
- Replace `locale.startsWith('pt'/'es')` inline string checks in `about/page.tsx` and `projects/page.tsx` with `getTranslations({ locale, namespace: 'Metadata' })`
- No Portuguese/Spanish literals remain hardcoded in page files

Closes #648

## Test plan

- [x] TypeScript compiles without errors
- [x] All 153 site tests pass
- [x] `grep -rn "locale.startsWith" apps/site/src/app` returns empty
- [ ] Verify `<title>` tag renders correctly in EN/PT-BR/ES in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)