### PR TITLE
fix(i18n): replace locale.startsWith() checks with i18n metadata translations

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6022,9 +6022,9 @@
         "dependencies": [
           "1"
         ],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-06-10T15:56:54.269Z"
+        "updatedAt": "2026-06-10T16:03:21.045Z"
       },
       {
         "id": "3",
@@ -6057,9 +6057,9 @@
         "testStrategy": "- Grep @repo/ui for Portuguese strings to ensure none remain\n- Test Modal close button with screen reader in all three locales\n- Verify aria-label announces correct translated text\n- Run existing Modal component tests and update snapshots if needed",
         "priority": "high",
         "dependencies": [],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-06-10T15:18:44.407Z"
+        "updatedAt": "2026-06-10T20:51:28.742Z"
       },
       {
         "id": "6",
@@ -6166,9 +6166,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-10T15:56:54.269Z",
+      "lastModified": "2026-06-10T20:51:28.742Z",
       "taskCount": 14,
-      "completedCount": 3,
+      "completedCount": 5,
       "tags": [
         "mvp-round-3"
       ]

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6069,8 +6069,9 @@
         "testStrategy": "- Test with screen reader (NVDA/JAWS) to verify button announces purpose\n- Verify aria-label changes or announcement occurs when button is clicked and copied state changes\n- Manual accessibility audit with axe DevTools or similar\n- Ensure button is keyboard accessible (Tab navigation + Enter/Space activation)",
         "priority": "high",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "in-progress",
+        "subtasks": [],
+        "updatedAt": "2026-06-10T20:52:41.314Z"
       },
       {
         "id": "7",
@@ -6166,7 +6167,7 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-10T20:51:28.742Z",
+      "lastModified": "2026-06-10T20:52:41.315Z",
       "taskCount": 14,
       "completedCount": 5,
       "tags": [


### PR DESCRIPTION
## Summary

- Replace `locale.startsWith('en')` and `locale.startsWith('pt')` inline checks in `about/page.tsx` and `projects/page.tsx` with `getTranslations` from `next-intl/server`
- Add `metadata` namespace to all three locale files (`en-US.json`, `pt-BR.json`, `es-ES.json`) with `title` and `description` keys
- Fully removes all hardcoded locale string comparisons from page metadata generation

Refs #648

## Test plan

- [ ] TypeScript check passes (`pnpm --filter site types`)
- [ ] All tests pass (`pnpm test`)
- [ ] About page metadata shows correct translated title in all three locales
- [ ] Projects page metadata shows correct translated title and description in all three locales
- [ ] No `locale.startsWith` calls remain in `apps/site/src/app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)