### PR TITLE
fix(a11y): add aria-label to ShareButton icon-only button

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -28,6 +28,7 @@
   "ProjectCard": {
     "view_project": "View Project",
     "share_tooltip": "Copy link",
+    "share_button_label": "Share project link",
     "image_alt": "Project image"
   },
   "SideNavigation": {

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -28,6 +28,7 @@
   "ProjectCard": {
     "view_project": "Ver proyecto",
     "share_tooltip": "Copiar enlace",
+    "share_button_label": "Compartir enlace del proyecto",
     "image_alt": "Imagen del proyecto"
   },
   "SideNavigation": {

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -28,6 +28,7 @@
   "ProjectCard": {
     "view_project": "Ver projeto",
     "share_tooltip": "Copiar link",
+    "share_button_label": "Compartilhar link do projeto",
     "image_alt": "Imagem do projeto"
   },
   "SideNavigation": {

--- a/apps/site/src/features/shared/ShareButton/index.tsx
+++ b/apps/site/src/features/shared/ShareButton/index.tsx
@@ -22,6 +22,7 @@ export const ShareButton: FC<IShareButtonProps> = ({ slug, className }) => {
       unstyled
       text={url}
       tooltip={t('share_tooltip')}
+      aria-label={t('share_button_label')}
       className={classNames(
         'flex items-center justify-center w-9 h-9 rounded-lg',
         'bg-surface-raised hover:bg-surface-interactive transition-colors',


### PR DESCRIPTION
## Summary

- Add `aria-label={t('share_button_label')}` to `Button.Clipboard` in `ShareButton` to satisfy WCAG 2.1 SC 4.1.2 (icon-only buttons must have an accessible name)
- Add `share_button_label` translation key to `ProjectCard` namespace in all three locale files (`en-US`, `pt-BR`, `es`)

Refs #652

## Test plan

- [ ] TypeScript check passes
- [ ] All site tests pass
- [ ] Screen reader announces correct translated label

🤖 Generated with [Claude Code](https://claude.com/claude-code)