### PR TITLE
fix(a11y): add aria-label and aria-expanded to Header mobile menu toggle

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6022,9 +6022,8 @@
         "dependencies": [
           "1"
         ],
-        "status": "done",
-        "subtasks": [],
-        "updatedAt": "2026-06-10T16:03:21.045Z"
+        "status": "pending",
+        "subtasks": []
       },
       {
         "id": "3",
@@ -6036,7 +6035,7 @@
         "dependencies": [],
         "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-06-10T15:51:57.307Z"
+        "updatedAt": "2026-06-10T21:27:30.487Z"
       },
       {
         "id": "4",
@@ -6059,7 +6058,7 @@
         "dependencies": [],
         "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-06-10T20:51:28.742Z"
+        "updatedAt": "2026-06-10T21:27:33.328Z"
       },
       {
         "id": "6",
@@ -6069,9 +6068,9 @@
         "testStrategy": "- Test with screen reader (NVDA/JAWS) to verify button announces purpose\n- Verify aria-label changes or announcement occurs when button is clicked and copied state changes\n- Manual accessibility audit with axe DevTools or similar\n- Ensure button is keyboard accessible (Tab navigation + Enter/Space activation)",
         "priority": "high",
         "dependencies": [],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-06-10T20:52:41.314Z"
+        "updatedAt": "2026-06-10T21:27:36.473Z"
       },
       {
         "id": "7",
@@ -6081,8 +6080,9 @@
         "testStrategy": "- Test with screen reader to verify toggle announces current state\n- Verify aria-expanded reflects actual menu state (true/false)\n- Test keyboard navigation: button focusable and activatable with Enter/Space\n- Verify mobile viewport behavior in Chrome DevTools",
         "priority": "high",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "in-progress",
+        "subtasks": [],
+        "updatedAt": "2026-06-10T21:27:39.506Z"
       },
       {
         "id": "8",
@@ -6167,7 +6167,7 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-10T20:52:41.315Z",
+      "lastModified": "2026-06-10T21:27:39.506Z",
       "taskCount": 14,
       "completedCount": 5,
       "tags": [

--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -96,7 +96,9 @@
     "close": "Close modal"
   },
   "Header": {
-    "logo_alt": "Logo"
+    "logo_alt": "Logo",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu"
   },
   "ProjectDetail": {
     "breadcrumb_home": "Home",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -96,7 +96,9 @@
     "close": "Cerrar modal"
   },
   "Header": {
-    "logo_alt": "Logo"
+    "logo_alt": "Logo",
+    "openMenu": "Abrir menú",
+    "closeMenu": "Cerrar menú"
   },
   "ProjectDetail": {
     "breadcrumb_home": "Inicio",

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -96,7 +96,9 @@
     "close": "Fechar modal"
   },
   "Header": {
-    "logo_alt": "Logo"
+    "logo_alt": "Logo",
+    "openMenu": "Abrir menu",
+    "closeMenu": "Fechar menu"
   },
   "ProjectDetail": {
     "breadcrumb_home": "Início",

--- a/apps/site/src/components/Layout/Header/index.tsx
+++ b/apps/site/src/components/Layout/Header/index.tsx
@@ -41,6 +41,8 @@ export const Header: FC<HeaderProps> = ({ open, toggle }) => {
       <Button.Base
         className="flex items-center justify-center h-10 w-10 !bg-surface-raised hover:!bg-surface !rounded !p-0 xl:hidden"
         onClick={toggle}
+        aria-label={open ? t('closeMenu') : t('openMenu')}
+        aria-expanded={open}
       >
         {open ? (
           <Icon icon="ic:round-close" className="!text-content-secondary" />


### PR DESCRIPTION
## Summary

- Add `aria-label` (dynamic: "Open menu" / "Close menu") and `aria-expanded` to the mobile menu toggle button in `Header`
- Add `openMenu` and `closeMenu` translation keys to the `Header` namespace in all three locale files (`en-US`, `pt-BR`, `es`)
- Screen readers now announce the button purpose and current state on every locale

Refs #653

## Test plan

- [ ] TypeScript check passes
- [ ] All site tests pass
- [ ] `aria-expanded` reflects open/closed state correctly
- [ ] Screen reader announces "Open menu" when closed and "Close menu" when open

🤖 Generated with [Claude Code](https://claude.com/claude-code)