### PR TITLE
fix(a11y): add visible labels to ContactForm fields

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -2,6 +2,9 @@
   "ContactForm": {
     "title": "Contact us",
     "submit": "Send",
+    "nameLabel": "Name",
+    "emailLabel": "Email",
+    "messageLabel": "Message",
     "namePlaceholder": "Your name",
     "emailPlaceholder": "Your e-mail",
     "messagePlaceholder": "Your message here...",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -2,6 +2,9 @@
   "ContactForm": {
     "title": "Contáctenos",
     "submit": "Enviar",
+    "nameLabel": "Nombre",
+    "emailLabel": "Correo electrónico",
+    "messageLabel": "Mensaje",
     "namePlaceholder": "Su nombre",
     "emailPlaceholder": "Su correo electrónico",
     "messagePlaceholder": "Su mensaje aquí...",

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -2,6 +2,9 @@
   "ContactForm": {
     "title": "Entre em contato",
     "submit": "Enviar",
+    "nameLabel": "Nome",
+    "emailLabel": "E-mail",
+    "messageLabel": "Mensagem",
     "namePlaceholder": "Seu nome",
     "emailPlaceholder": "Seu e-mail",
     "messagePlaceholder": "Sua mensagem aqui...",

--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -3,7 +3,7 @@
 import { FC, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Button, Text, TextArea } from '@repo/ui/Control';
+import { Button, Label, Text, TextArea } from '@repo/ui/Control';
 import { useTranslations } from 'next-intl';
 import { useForm } from 'react-hook-form';
 
@@ -50,6 +50,7 @@ export const ContactForm: FC = () => {
 
       <div className="flex flex-col gap-y-6">
         <div className="flex flex-col gap-y-1">
+          <Label htmlFor="name">{tForm('nameLabel')}</Label>
           <Text.Base
             type="text"
             id="name"
@@ -68,6 +69,7 @@ export const ContactForm: FC = () => {
         </div>
 
         <div className="flex flex-col gap-y-1">
+          <Label htmlFor="email">{tForm('emailLabel')}</Label>
           <Text.Base
             type="email"
             id="email"
@@ -86,6 +88,7 @@ export const ContactForm: FC = () => {
         </div>
 
         <div className="flex flex-col gap-y-1">
+          <Label htmlFor="message">{tForm('messageLabel')}</Label>
           <TextArea.Base
             id="message"
             maxLength={2000}

--- a/apps/site/tests/components/Forms/ContactForm/ContactForm.test.tsx
+++ b/apps/site/tests/components/Forms/ContactForm/ContactForm.test.tsx
@@ -14,6 +14,9 @@ vi.mock('next-intl', () => ({
 }));
 
 vi.mock('@repo/ui/Control', () => ({
+  Label: ({ children, htmlFor }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
   Button: {
     Base: ({
       children,


### PR DESCRIPTION
## Summary

- Add `Label` elements for name, email, and message inputs in `ContactForm`
- Add i18n keys (`nameLabel`, `emailLabel`, `messageLabel`) across `en-US`, `es`, and `pt-BR` locales
- Update `ContactForm` test mock to include the `Label` export from `@repo/ui/Control`

## Test plan

- [ ] All 153 `apps/site` tests pass
- [ ] Labels are visible above each form field in all three locales
- [ ] Each label is properly associated to its input via `htmlFor` / `id`

Refs #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)