### PR TITLE
chore(task-master): sync mvp-round-3 statuses with develop

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6022,8 +6022,9 @@
         "dependencies": [
           "1"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-11T22:15:00.000Z"
       },
       {
         "id": "3",
@@ -6080,9 +6081,9 @@
         "testStrategy": "- Test with screen reader to verify toggle announces current state\n- Verify aria-expanded reflects actual menu state (true/false)\n- Test keyboard navigation: button focusable and activatable with Enter/Space\n- Verify mobile viewport behavior in Chrome DevTools",
         "priority": "high",
         "dependencies": [],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-06-10T21:27:39.506Z"
+        "updatedAt": "2026-06-11T22:15:00.000Z"
       },
       {
         "id": "8",
@@ -6092,8 +6093,9 @@
         "testStrategy": "- Test with screen reader to verify button announces skill count\n- Verify button is keyboard accessible\n- Test with different skill counts (e.g., +3, +5) to ensure interpolation works\n- Manual test in all three locales",
         "priority": "medium",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-11T22:15:00.000Z"
       },
       {
         "id": "9",
@@ -6103,8 +6105,9 @@
         "testStrategy": "- Verify each input has visible label that doesn't disappear on focus\n- Test with screen reader to ensure label-input association works\n- Verify required fields are clearly indicated visually\n- Run axe DevTools to ensure WCAG 2.1 SC 1.3.1 passes\n- Test form submission with errors to ensure labels + error messages work together",
         "priority": "high",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-11T22:15:00.000Z"
       },
       {
         "id": "10",
@@ -6167,9 +6170,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-10T21:27:39.506Z",
+      "lastModified": "2026-06-11T22:15:00.000Z",
       "taskCount": 14,
-      "completedCount": 5,
+      "completedCount": 9,
       "tags": [
         "mvp-round-3"
       ]


### PR DESCRIPTION
Mark tasks 2, 7, 8, and 9 as done after verifying their implementations were merged to develop via PRs #708, #711, #713, and #714.