### PR TITLE
chore(task-master): mark mvp-round-3 task #7 as done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6080,9 +6080,9 @@
         "testStrategy": "- Test with screen reader to verify toggle announces current state\n- Verify aria-expanded reflects actual menu state (true/false)\n- Test keyboard navigation: button focusable and activatable with Enter/Space\n- Verify mobile viewport behavior in Chrome DevTools",
         "priority": "high",
         "dependencies": [],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-06-10T21:27:39.506Z"
+        "updatedAt": "2026-06-13T00:32:33.909Z"
       },
       {
         "id": "8",
@@ -6168,9 +6168,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-12T01:38:23.311Z",
+      "lastModified": "2026-06-13T00:32:33.909Z",
       "taskCount": 14,
-      "completedCount": 6,
+      "completedCount": 7,
       "tags": [
         "mvp-round-3"
       ]


### PR DESCRIPTION
## Summary

- Marks task #7 (Add accessible aria-label to mobile menu toggle in Header) as done
- Feature was already implemented in PR #711 (commit dc5d0f0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)