### PR TITLE
chore(task-master): mark mvp-round-3 task #2 as done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6022,8 +6022,9 @@
         "dependencies": [
           "1"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-13T01:15:41.528Z"
       },
       {
         "id": "3",
@@ -6170,9 +6171,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-13T00:41:15.385Z",
+      "lastModified": "2026-06-13T01:15:41.528Z",
       "taskCount": 14,
-      "completedCount": 9,
+      "completedCount": 10,
       "tags": [
         "mvp-round-3"
       ]


### PR DESCRIPTION
## Summary

- Marks task #2 (Add i18n translation keys for page metadata and remove locale.startsWith() calls) as done
- Already implemented: \`getTranslations({ namespace: 'Metadata' })\` in both about and projects pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)