### PR TITLE
chore(task-master): mark mvp-round-3 task #8 as done

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6094,8 +6094,9 @@
         "testStrategy": "- Test with screen reader to verify button announces skill count\n- Verify button is keyboard accessible\n- Test with different skill counts (e.g., +3, +5) to ensure interpolation works\n- Manual test in all three locales",
         "priority": "medium",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-13T01:20:37.784Z"
       },
       {
         "id": "9",
@@ -6172,9 +6173,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-13T01:18:05.730Z",
+      "lastModified": "2026-06-13T01:20:37.784Z",
       "taskCount": 14,
-      "completedCount": 11,
+      "completedCount": 12,
       "tags": [
         "mvp-round-3"
       ]


### PR DESCRIPTION
## Summary

- Marks task #8 (Add accessible aria-label to +N skills overflow button in SkillGroup) as done
- Already implemented in PR #714 (commit 0edc3cf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)