### PR TITLE
fix(a11y): add visible focus indicator to Radio input

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6142,8 +6142,9 @@
         "testStrategy": "- Tab through radio buttons with keyboard and verify visible focus ring\n- Test disabled radio buttons have no focus ring\n- Test in contexts where Radio is used (theme selector, language selector, etc.)\n- Verify focus ring is visible in light and dark themes\n- Run axe DevTools to verify WCAG 2.1 SC 2.4.7 passes",
         "priority": "medium",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-13T01:24:54.144Z"
       },
       {
         "id": "13",
@@ -6173,9 +6174,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-13T01:20:37.784Z",
+      "lastModified": "2026-06-13T01:24:54.144Z",
       "taskCount": 14,
-      "completedCount": 12,
+      "completedCount": 13,
       "tags": [
         "mvp-round-3"
       ]

--- a/packages/ui/src/Control/Radio/index.tsx
+++ b/packages/ui/src/Control/Radio/index.tsx
@@ -51,8 +51,7 @@ export const Radio: FC<IRadioProps> = ({
           value={option}
           type="radio"
           checked={checked}
-          className="peer col-start-1 row-start-1 appearance-none shrink-0 w-4 h-4 border-2 border-white rounded-full focus:outline-none focus:ring-offset-0 disabled:border-gray-400 cursor-pointer
-"
+          className="peer col-start-1 row-start-1 appearance-none shrink-0 w-4 h-4 border-2 border-white rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-primary disabled:border-gray-400 disabled:focus-visible:ring-0 cursor-pointer"
         />
         {checked ? (
           <span className="pointer-events-none col-start-1 row-start-1 w-2 h-2 rounded-full peer-checked:bg-white peer-checked:peer-disabled:bg-gray-400" />


### PR DESCRIPTION
## Summary

- Replace `focus:outline-none focus:ring-offset-0` with `focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-primary`
- Consistent with the pattern used in Button.Base, Text.Base, and TextArea.Base
- Disabled state suppresses the ring via `disabled:focus-visible:ring-0`
- Satisfies WCAG 2.1 SC 2.4.7 (Focus Visible)

## Test plan

- [ ] Tab through Theme and Language selectors and verify visible focus ring on each Radio
- [ ] Verify disabled radio buttons have no focus ring
- [ ] Test in light and dark themes

Refs #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)