### PR TITLE
fix(a11y): fix heading hierarchy in HomeProjectsSection (h4 → h2)

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6154,8 +6154,9 @@
         "testStrategy": "- Use browser DevTools or HeadingsMap extension to verify heading hierarchy on home page\n- Verify no heading levels are skipped (e.g., h1 → h2 → h3, NOT h1 → h2 → h4)\n- Test with screen reader's heading navigation (H key in NVDA/JAWS)\n- Run axe DevTools to verify WCAG 2.1 SC 1.3.1 passes (heading hierarchy)\n- Visual regression test to ensure text size change doesn't break layout",
         "priority": "medium",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-13T01:34:23.665Z"
       },
       {
         "id": "14",
@@ -6174,9 +6175,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-13T01:24:54.144Z",
+      "lastModified": "2026-06-13T01:34:23.666Z",
       "taskCount": 14,
-      "completedCount": 13,
+      "completedCount": 14,
       "tags": [
         "mvp-round-3"
       ]

--- a/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -16,9 +16,9 @@ export async function ProjectsSection({
 
   return (
     <>
-      <h4 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
+      <h2 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
         {t('projects_title')}
-      </h4>
+      </h2>
       <ProjectList projects={projects} className="pb-8 xl:pb-20" />
     </>
   );


### PR DESCRIPTION
## Summary

- Change `<h4>` → `<h2>` in `HomeProjectsSection`
- **Why h2 and not h3:** the home page has no `<h1>`; the HeroBanner caption renders as `<h2>` and the ProjectCard titles are `<h3>`. The section title is a sibling section heading (peer of the hero), not a child of it. Hierarchy: `h2` (hero) → `h2` (Projects section) → `h3` (project cards)
- `text-[32px]` kept as-is — no equivalent custom token in `tailwind-config`

## Test plan

- [x] Use HeadingsMap or axe DevTools on the home page and verify no skipped levels
- [x] Verify visual layout is unchanged

Refs #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)