### PR TITLE
fix(a11y): replace layout-only section elements with div in HeroBanner

### DIFF
--- a/apps/site/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
+++ b/apps/site/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
@@ -1,7 +1,7 @@
 export function HeroBannerSkeleton() {
   return (
     <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
-      <section className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
+      <div className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
         <div className="h-8 w-48 bg-gray-700 rounded" />
         <div className="h-8 w-64 bg-gray-700 rounded" />
         <div className="flex flex-col gap-y-2 pt-4">
@@ -9,8 +9,8 @@ export function HeroBannerSkeleton() {
           <div className="h-4 bg-gray-700 rounded w-5/6" />
           <div className="h-4 bg-gray-700 rounded w-4/6" />
         </div>
-      </section>
-      <section className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
+      </div>
+      <div className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
     </section>
   );
 }

--- a/apps/site/src/features/shared/HeroBanner/index.tsx
+++ b/apps/site/src/features/shared/HeroBanner/index.tsx
@@ -37,7 +37,7 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
         className,
       )}
     >
-      <section className="relative h-64 flex flex-row justify-center xl:order-1 xl:h-full xl:w-1/2">
+      <div className="relative h-64 flex flex-row justify-center xl:order-1 xl:h-full xl:w-1/2">
         <Image
           src={src}
           alt={alt}
@@ -47,8 +47,8 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
           className={imageClassName}
           sizes="(max-width: 1280px) 100vw, 50vw"
         />
-      </section>
-      <section
+      </div>
+      <div
         className={classNames(
           'flex flex-col px-6 pb-6 xl:order-0 xl:py-20 xl:pl-20',
           textColumnClassName,
@@ -69,7 +69,7 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
         <p className="text-body-sm text-content-primary line-clamp-3">
           {content}
         </p>
-      </section>
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
## Summary

- Replace two inner `<section>` elements in `HeroBanner` with `<div>` — they are CSS layout wrappers with no heading children and no thematic meaning, violating the HTML spec for `<section>`
- Apply the same fix to `HeroBannerSkeleton` for consistency
- Outer `<section>` (with `TitleTag` heading child) is left unchanged

Refs #9

## Test plan

- [x] Visual regression: home, projects, about pages render identically at all breakpoints
- [x] DOM structure: two inner containers are now `<div>`, outer `<section>` unchanged
- [x] Pa11y CI passes with no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)