### PR TITLE
fix(a11y): fix landmark structure in SideNavigation

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -47,7 +47,8 @@
     "theme": "Theme",
     "linkedin": "LinkedIn",
     "github": "GitHub",
-    "rss": "RSS Feed"
+    "rss": "RSS Feed",
+    "mainNav": "Main navigation"
   },
   "Theme": {
     "light": "Light",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -47,7 +47,8 @@
     "theme": "Tema",
     "linkedin": "LinkedIn",
     "github": "GitHub",
-    "rss": "RSS Feed"
+    "rss": "RSS Feed",
+    "mainNav": "Navegación principal"
   },
   "Theme": {
     "light": "Claro",

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -47,7 +47,8 @@
     "theme": "Tema",
     "linkedin": "LinkedIn",
     "github": "GitHub",
-    "rss": "RSS Feed"
+    "rss": "RSS Feed",
+    "mainNav": "Navegação principal"
   },
   "Theme": {
     "light": "Claro",

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -23,10 +23,11 @@ export const SideNavigation: FC = () => {
   useScrollLock({ autoLock: isOpen });
 
   return (
-    <section className="fixed top-0 left-0 shadow-1 w-full xl:w-auto z-50">
+    <div className="fixed top-0 left-0 shadow-1 w-full xl:w-auto z-50">
       <Header open={isOpen} toggle={toggle} />
       <nav
         id="side-navigation"
+        aria-label={t('mainNav')}
         className={classNames(
           'h-sidenav-mobile xl:h-sidenav-desktop left-0 w-full xl:w-60 xl:px-4 bg-surface-sunken flex flex-col overflow-y-auto overscroll-y-contain border-0 duration-300 ease-linear xl:!translate-x-0 z-9999',
           isOpen ? 'translate-x-0' : '-translate-x-full',
@@ -100,6 +101,6 @@ export const SideNavigation: FC = () => {
           </li>
         </ul>
       </nav>
-    </section>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary

- Replace outer `<section>` (fixed-position layout wrapper, no heading) with `<div>`
- Add `aria-label={t('mainNav')}` to `<nav id="side-navigation">` so screen readers can distinguish it from other nav landmarks (e.g. ContactInfo footer nav)
- Add `mainNav` translation key to all 3 locale files (en-US, pt-BR, es)

Refs #10

## Test plan

- [x] No visual changes across all pages/breakpoints
- [x] DevTools Accessibility: `<nav>` accessible name shows "Main navigation" / "Navegação principal" / "Navegación principal"
- [x] Pa11y CI: 0 new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)