### PR TITLE
fix(a11y): wrap ContactForm fields in fieldset+legend per WCAG H71

### DIFF
--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -44,73 +44,79 @@ export const ContactForm: FC = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="w-full" noValidate>
-      <p className="text-xl font-bold text-content-primary mb-6">
-        {tForm('title')}
-      </p>
+      <fieldset className="border-0 p-0 m-0 min-w-0">
+        <legend className="text-xl font-bold text-content-primary mb-6">
+          {tForm('title')}
+        </legend>
 
-      <div className="flex flex-col gap-y-6">
-        <div className="flex flex-col gap-y-1">
-          <Label htmlFor="name">{tForm('nameLabel')}</Label>
-          <Text.Base
-            type="text"
-            id="name"
-            placeholder={tForm('namePlaceholder')}
-            error={!!errors.name}
-            touched={!!touchedFields.name}
-            aria-invalid={!!errors.name}
-            aria-describedby={errors.name ? 'name-error' : undefined}
-            {...register('name')}
-          />
-          {errors.name && (
-            <span id="name-error" role="alert" className="text-error text-xs">
-              {tV(errors.name.message as Parameters<typeof tV>[0])}
-            </span>
-          )}
-        </div>
+        <div className="flex flex-col gap-y-6">
+          <div className="flex flex-col gap-y-1">
+            <Label htmlFor="name">{tForm('nameLabel')}</Label>
+            <Text.Base
+              type="text"
+              id="name"
+              placeholder={tForm('namePlaceholder')}
+              error={!!errors.name}
+              touched={!!touchedFields.name}
+              aria-invalid={!!errors.name}
+              aria-describedby={errors.name ? 'name-error' : undefined}
+              {...register('name')}
+            />
+            {errors.name && (
+              <span id="name-error" role="alert" className="text-error text-xs">
+                {tV(errors.name.message as Parameters<typeof tV>[0])}
+              </span>
+            )}
+          </div>
 
-        <div className="flex flex-col gap-y-1">
-          <Label htmlFor="email">{tForm('emailLabel')}</Label>
-          <Text.Base
-            type="email"
-            id="email"
-            placeholder={tForm('emailPlaceholder')}
-            error={!!errors.email}
-            touched={!!touchedFields.email}
-            aria-invalid={!!errors.email}
-            aria-describedby={errors.email ? 'email-error' : undefined}
-            {...register('email')}
-          />
-          {errors.email && (
-            <span id="email-error" role="alert" className="text-error text-xs">
-              {tV(errors.email.message as Parameters<typeof tV>[0])}
-            </span>
-          )}
-        </div>
+          <div className="flex flex-col gap-y-1">
+            <Label htmlFor="email">{tForm('emailLabel')}</Label>
+            <Text.Base
+              type="email"
+              id="email"
+              placeholder={tForm('emailPlaceholder')}
+              error={!!errors.email}
+              touched={!!touchedFields.email}
+              aria-invalid={!!errors.email}
+              aria-describedby={errors.email ? 'email-error' : undefined}
+              {...register('email')}
+            />
+            {errors.email && (
+              <span
+                id="email-error"
+                role="alert"
+                className="text-error text-xs"
+              >
+                {tV(errors.email.message as Parameters<typeof tV>[0])}
+              </span>
+            )}
+          </div>
 
-        <div className="flex flex-col gap-y-1">
-          <Label htmlFor="message">{tForm('messageLabel')}</Label>
-          <TextArea.Base
-            id="message"
-            maxLength={2000}
-            className="h-[124px]"
-            placeholder={tForm('messagePlaceholder')}
-            error={!!errors.message}
-            touched={!!touchedFields.message}
-            aria-invalid={!!errors.message}
-            aria-describedby={errors.message ? 'message-error' : undefined}
-            {...register('message')}
-          />
-          {errors.message && (
-            <span
-              id="message-error"
-              role="alert"
-              className="text-error text-xs"
-            >
-              {tV(errors.message.message as Parameters<typeof tV>[0])}
-            </span>
-          )}
+          <div className="flex flex-col gap-y-1">
+            <Label htmlFor="message">{tForm('messageLabel')}</Label>
+            <TextArea.Base
+              id="message"
+              maxLength={2000}
+              className="h-[124px]"
+              placeholder={tForm('messagePlaceholder')}
+              error={!!errors.message}
+              touched={!!touchedFields.message}
+              aria-invalid={!!errors.message}
+              aria-describedby={errors.message ? 'message-error' : undefined}
+              {...register('message')}
+            />
+            {errors.message && (
+              <span
+                id="message-error"
+                role="alert"
+                className="text-error text-xs"
+              >
+                {tV(errors.message.message as Parameters<typeof tV>[0])}
+              </span>
+            )}
+          </div>
         </div>
-      </div>
+      </fieldset>
 
       <Button.Base
         type="submit"

--- a/apps/site/tests/components/Forms/ContactForm/ContactForm.test.tsx
+++ b/apps/site/tests/components/Forms/ContactForm/ContactForm.test.tsx
@@ -75,6 +75,14 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('ContactForm', () => {
+  it('should render a fieldset with a legend as the first child', () => {
+    render(<ContactForm />);
+    const fieldset = screen.getByRole('group');
+    expect(fieldset).toBeInTheDocument();
+    expect(fieldset.firstElementChild?.tagName).toBe('LEGEND');
+    expect(fieldset.firstElementChild?.textContent).toBe('ContactForm.title');
+  });
+
   it('should render name, email and message fields', () => {
     render(<ContactForm />);
 


### PR DESCRIPTION
## Summary

- Replace the visual-only `<p>` title with a `<legend>` inside a `<fieldset>` wrapping the three form field groups
- `fieldset` styled with `border-0 p-0 m-0 min-w-0` to reset browser defaults and preserve existing layout
- Screen readers now announce the group label (e.g. "Contact Form, group") before each field
- Add unit test verifying `role="group"` and `<legend>` as first child

Refs #12

## Test plan

- [x] Visual regression: form layout unchanged across all locales
- [x] 6/6 unit tests pass
- [x] Pa11y CI: 0 new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)