### PR TITLE
chore: add pre-push build check to lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,12 @@ commit-msg:
     commitlint:
       run: npx commitlint --edit
 
+pre-push:
+  parallel: false
+  commands:
+    build:
+      run: CI=1 pnpm build
+
 pre-commit:
   parallel: false
   commands:


### PR DESCRIPTION
## Summary

- Add `pre-push` hook to lefthook with `CI=1 pnpm build`
- Confirms the monorepo compiles cleanly before any push reaches the remote
- Catches build-time errors (missing exports, broken imports) that lint and unit tests don't cover
- Also confirmed existing `commit-msg` + commitlint hook works correctly (tested with invalid message → exit 1)

## Notes

- `commit-msg` with commitlint was already configured — no changes needed there
- `pre-push` is heavier than `pre-commit` by design; it runs once per push, not per commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)