### PR TITLE
fix(a11y): replace ContactForm legend with h2 for section heading

### DIFF
--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -34,97 +34,109 @@ export const ContactForm: FC = () => {
   if (submitted) {
     return (
       <div className="w-full">
-        <p className="text-xl font-bold text-content-primary mb-6">
+        <h2 className="text-xl font-bold text-content-primary mb-6">
           {tForm('title')}
-        </p>
+        </h2>
         <p className="text-accent">{tForm('success')}</p>
       </div>
     );
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="w-full" noValidate>
-      <fieldset className="border-0 p-0 m-0 min-w-0">
-        <legend className="text-xl font-bold text-content-primary mb-6">
-          {tForm('title')}
-        </legend>
-
-        <div className="flex flex-col gap-y-6">
-          <div className="flex flex-col gap-y-1">
-            <Label htmlFor="name">{tForm('nameLabel')}</Label>
-            <Text.Base
-              type="text"
-              id="name"
-              placeholder={tForm('namePlaceholder')}
-              error={!!errors.name}
-              touched={!!touchedFields.name}
-              aria-invalid={!!errors.name}
-              aria-describedby={errors.name ? 'name-error' : undefined}
-              {...register('name')}
-            />
-            {errors.name && (
-              <span id="name-error" role="alert" className="text-error text-xs">
-                {tV(errors.name.message as Parameters<typeof tV>[0])}
-              </span>
-            )}
-          </div>
-
-          <div className="flex flex-col gap-y-1">
-            <Label htmlFor="email">{tForm('emailLabel')}</Label>
-            <Text.Base
-              type="email"
-              id="email"
-              placeholder={tForm('emailPlaceholder')}
-              error={!!errors.email}
-              touched={!!touchedFields.email}
-              aria-invalid={!!errors.email}
-              aria-describedby={errors.email ? 'email-error' : undefined}
-              {...register('email')}
-            />
-            {errors.email && (
-              <span
-                id="email-error"
-                role="alert"
-                className="text-error text-xs"
-              >
-                {tV(errors.email.message as Parameters<typeof tV>[0])}
-              </span>
-            )}
-          </div>
-
-          <div className="flex flex-col gap-y-1">
-            <Label htmlFor="message">{tForm('messageLabel')}</Label>
-            <TextArea.Base
-              id="message"
-              maxLength={2000}
-              className="h-[124px]"
-              placeholder={tForm('messagePlaceholder')}
-              error={!!errors.message}
-              touched={!!touchedFields.message}
-              aria-invalid={!!errors.message}
-              aria-describedby={errors.message ? 'message-error' : undefined}
-              {...register('message')}
-            />
-            {errors.message && (
-              <span
-                id="message-error"
-                role="alert"
-                className="text-error text-xs"
-              >
-                {tV(errors.message.message as Parameters<typeof tV>[0])}
-              </span>
-            )}
-          </div>
-        </div>
-      </fieldset>
-
-      <Button.Base
-        type="submit"
-        className="w-full xl:w-[216px] h-[46px] mt-6"
-        disabled={isSubmitting}
+    <>
+      <h2
+        id="contact-form-title"
+        className="text-xl font-bold text-content-primary mb-6"
       >
-        {tForm('submit')}
-      </Button.Base>
-    </form>
+        {tForm('title')}
+      </h2>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="w-full" noValidate>
+        <fieldset
+          aria-labelledby="contact-form-title"
+          className="border-0 p-0 m-0 min-w-0"
+        >
+          <div className="flex flex-col gap-y-6">
+            <div className="flex flex-col gap-y-1">
+              <Label htmlFor="name">{tForm('nameLabel')}</Label>
+              <Text.Base
+                type="text"
+                id="name"
+                placeholder={tForm('namePlaceholder')}
+                error={!!errors.name}
+                touched={!!touchedFields.name}
+                aria-invalid={!!errors.name}
+                aria-describedby={errors.name ? 'name-error' : undefined}
+                {...register('name')}
+              />
+              {errors.name && (
+                <span
+                  id="name-error"
+                  role="alert"
+                  className="text-error text-xs"
+                >
+                  {tV(errors.name.message as Parameters<typeof tV>[0])}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-y-1">
+              <Label htmlFor="email">{tForm('emailLabel')}</Label>
+              <Text.Base
+                type="email"
+                id="email"
+                placeholder={tForm('emailPlaceholder')}
+                error={!!errors.email}
+                touched={!!touchedFields.email}
+                aria-invalid={!!errors.email}
+                aria-describedby={errors.email ? 'email-error' : undefined}
+                {...register('email')}
+              />
+              {errors.email && (
+                <span
+                  id="email-error"
+                  role="alert"
+                  className="text-error text-xs"
+                >
+                  {tV(errors.email.message as Parameters<typeof tV>[0])}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-y-1">
+              <Label htmlFor="message">{tForm('messageLabel')}</Label>
+              <TextArea.Base
+                id="message"
+                maxLength={2000}
+                className="h-[124px]"
+                placeholder={tForm('messagePlaceholder')}
+                error={!!errors.message}
+                touched={!!touchedFields.message}
+                aria-invalid={!!errors.message}
+                aria-describedby={errors.message ? 'message-error' : undefined}
+                {...register('message')}
+              />
+              {errors.message && (
+                <span
+                  id="message-error"
+                  role="alert"
+                  className="text-error text-xs"
+                >
+                  {tV(errors.message.message as Parameters<typeof tV>[0])}
+                </span>
+              )}
+            </div>
+          </div>
+        </fieldset>
+
+        <Button.Base
+          type="submit"
+          className="w-full xl:w-[216px] h-[46px] mt-6"
+          disabled={isSubmitting}
+        >
+          {tForm('submit')}
+        </Button.Base>
+      </form>
+    </>
   );
 };

--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -34,7 +34,7 @@ export const ContactForm: FC = () => {
   if (submitted) {
     return (
       <div className="w-full">
-        <h2 className="text-xl font-bold text-content-primary mb-6">
+        <h2 className="text-2xl font-bold text-content-primary mb-6">
           {tForm('title')}
         </h2>
         <p className="text-accent">{tForm('success')}</p>
@@ -46,7 +46,7 @@ export const ContactForm: FC = () => {
     <>
       <h2
         id="contact-form-title"
-        className="text-xl font-bold text-content-primary mb-6"
+        className="text-2xl font-bold text-content-primary mb-6"
       >
         {tForm('title')}
       </h2>

--- a/apps/site/tests/components/Forms/ContactForm/ContactForm.test.tsx
+++ b/apps/site/tests/components/Forms/ContactForm/ContactForm.test.tsx
@@ -75,12 +75,16 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('ContactForm', () => {
-  it('should render a fieldset with a legend as the first child', () => {
+  it('should render title as h2 heading', () => {
     render(<ContactForm />);
-    const fieldset = screen.getByRole('group');
+    const heading = screen.getByRole('heading', { level: 2, name: 'ContactForm.title' });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('should render fieldset labeled by the h2 heading', () => {
+    render(<ContactForm />);
+    const fieldset = screen.getByRole('group', { name: 'ContactForm.title' });
     expect(fieldset).toBeInTheDocument();
-    expect(fieldset.firstElementChild?.tagName).toBe('LEGEND');
-    expect(fieldset.firstElementChild?.textContent).toBe('ContactForm.title');
   });
 
   it('should render name, email and message fields', () => {


### PR DESCRIPTION
## Summary

- Replace `<legend>` with `<h2 id="contact-form-title">` before the `<form>`, so "Contact us" appears in the page heading map alongside "Get in touch" (`ContactInfo`'s `h2`)
- Keep `<fieldset>` with `aria-labelledby="contact-form-title"` for field group semantics — no `<legend>` needed
- Fix success state `<p>` → `<h2>` for consistency

## Why

A `<legend>` labels a fieldset's field group but is invisible to heading-based navigation (screen reader `H` key). "Contact us" is a section title parallel to "Get in touch" — both should be `<h2>` so users can jump between them.

## Test plan

- [x] 7 `ContactForm` tests pass
- [ ] `node scripts/heading-map.mjs` — "Contact us" appears as `h2` in all locales
- [ ] Visual inspection — no layout regression
- [ ] Screen reader: navigating with `H` reaches "Contact us" and "Get in touch" as `h2`

Refs #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)