### PR TITLE
fix(site): side navigation overlay blocks all touch events on mobile

### DIFF
--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -29,7 +29,7 @@ export const SideNavigation: FC = () => {
         id="side-navigation"
         aria-label={t('mainNav')}
         className={classNames(
-          'h-sidenav-mobile xl:h-sidenav-desktop left-0 w-full xl:w-60 xl:px-4 bg-surface-sunken flex flex-col overflow-y-auto overscroll-y-contain border-0 duration-300 ease-linear xl:!translate-x-0 z-9999',
+          'absolute top-full xl:relative xl:top-auto h-sidenav-mobile xl:h-sidenav-desktop left-0 w-full xl:w-60 xl:px-4 bg-surface-sunken flex flex-col overflow-y-auto overscroll-y-contain border-0 duration-300 ease-linear xl:!translate-x-0 z-9999',
           isOpen ? 'translate-x-0' : '-translate-x-full',
         )}
       >


### PR DESCRIPTION
## Summary

- On mobile, the `SideNavigation` outer `div` (`fixed top-0 left-0 w-full z-50`) had no explicit height, so it grew to include the `nav`'s full `h-sidenav-mobile = calc(100vh - header-height)` even when the nav was hidden via `translateX(-100%)`
- CSS `transform` does **not** remove elements from the document flow — the invisible overlay was `100vh` tall at z-index 50, intercepting every touch event across all pages
- Fix: `absolute top-full` on mobile (removes nav from flow, anchors it just below the header) + `xl:relative xl:top-auto` on desktop (restores sidebar full-height behaviour)

## Affected elements (reported by user)

- View Project button
- Inputs and Textarea
- Submit form button
- `+N` tag button
- Share project button
- Clipboard button
- Footer social media buttons

## Test plan

- [ ] All 172 site tests pass
- [ ] Manual mobile: all buttons, inputs and links respond to tap
- [ ] Manual desktop: sidebar renders at full height as before
- [ ] Manual mobile: hamburger menu opens/closes the nav correctly

Refs #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)