### PR TITLE
fix(site): side navigation overlay blocks all touch events on mobile

### DIFF
--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Fixes invisible full-screen overlay from `SideNavigation` outer div intercepting touch events on mobile
- Changed `nav` from default flow positioning to `absolute top-full` on mobile (`xl:relative xl:top-auto` on desktop), removing it from document flow so touch events reach underlying elements
- Also upgrades React to v19 and adds `inert` to Accordion Body when collapsed (committed on this branch before the nav fix)

## Root cause

The outer `div` (`fixed w-full z-50`) had no explicit height, so it expanded to include the inner `nav`'s `h-sidenav-mobile = calc(100vh - header-height)` even when the nav was hidden via `translateX(-100%)`. CSS transforms don't remove elements from flow, making the wrapper a full-screen invisible overlay at z-50.

## Test plan

- [ ] On mobile viewport: tap buttons, inputs, links, and form elements across all pages — all should respond
- [ ] Toggle side navigation open/close on mobile — animation should work correctly
- [ ] On desktop (`xl+`): sidebar remains visible and full-height as before
- [ ] No regression on desktop layout

Refs #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)