### PR TITLE
fix(site): shift layout breakpoint from xl to lg (1280px → 1024px)

### DIFF
--- a/apps/site/src/components/Layout/AppLayout/index.tsx
+++ b/apps/site/src/components/Layout/AppLayout/index.tsx
@@ -11,7 +11,7 @@ export const AppLayout: FC<PropsWithChildren> = ({ children }) => {
     <>
       <SideNavigation />
       <div className="flex h-full flex-col ml-0 lg:ml-60 mt-header-mobile lg:mt-0">
-        <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1">
+        <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1 pt-6 lg:pt-16 xl:pt-20">
           {children}
         </main>
         <footer className="w-full max-w-237.5 mx-auto">

--- a/apps/site/src/components/Layout/AppLayout/index.tsx
+++ b/apps/site/src/components/Layout/AppLayout/index.tsx
@@ -10,7 +10,7 @@ export const AppLayout: FC<PropsWithChildren> = ({ children }) => {
   return (
     <>
       <SideNavigation />
-      <div className="flex h-full flex-col ml-0 xl:ml-60 mt-header-mobile xl:mt-20">
+      <div className="flex h-full flex-col ml-0 lg:ml-60 mt-header-mobile lg:mt-0">
         <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1">
           {children}
         </main>

--- a/apps/site/src/components/Layout/Header/index.tsx
+++ b/apps/site/src/components/Layout/Header/index.tsx
@@ -20,11 +20,11 @@ export const Header: FC<HeaderProps> = ({ open, toggle }) => {
   const t = useTranslations('Header');
 
   return (
-    <header className="w-full xl:w-60 flex items-center xl:items-end justify-between xl:justify-center bg-surface xl:bg-surface-sunken px-4 py-3 xl:px-0 xl:py-0 transition-all duration-300 ease-linear h-header-mobile xl:h-header-desktop">
+    <header className="w-full lg:w-60 flex items-center lg:items-end justify-between lg:justify-center bg-surface lg:bg-surface-sunken px-4 py-3 lg:px-0 lg:py-0 transition-all duration-300 ease-linear h-header-mobile lg:h-header-desktop">
       <NextLink href="/" aria-label={t('logo_alt')}>
         <picture>
           <source
-            media={`(min-width: ${screens.xl})`}
+            media={`(min-width: ${screens.lg})`}
             srcSet={logoDesktop.src}
             width={179}
             height={66}
@@ -39,7 +39,7 @@ export const Header: FC<HeaderProps> = ({ open, toggle }) => {
         </picture>
       </NextLink>
       <Button.Base
-        className="flex items-center justify-center h-10 w-10 !bg-surface-raised hover:!bg-surface !rounded !p-0 xl:hidden"
+        className="flex items-center justify-center h-10 w-10 !bg-surface-raised hover:!bg-surface !rounded !p-0 lg:hidden"
         onClick={toggle}
         aria-label={open ? t('closeMenu') : t('openMenu')}
         aria-expanded={open}

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -16,24 +16,24 @@ import { ThemeToggle } from './ThemeToggle';
 
 export const SideNavigation: FC = () => {
   const t = useTranslations('SideNavigation');
-  const isDesktop = useBreakpoint('xl');
+  const isDesktop = useBreakpoint('lg');
   const { value: open, toggle } = useBoolean(false);
   const isOpen = !isDesktop && open;
 
   useScrollLock({ autoLock: isOpen });
 
   return (
-    <div className="fixed top-0 left-0 shadow-1 w-full xl:w-auto z-50">
+    <div className="fixed top-0 left-0 shadow-1 w-full lg:w-auto z-50">
       <Header open={isOpen} toggle={toggle} />
       <nav
         id="side-navigation"
         aria-label={t('mainNav')}
         className={classNames(
-          'absolute top-full xl:relative xl:top-auto h-sidenav-mobile xl:h-sidenav-desktop left-0 w-full xl:w-60 xl:px-4 bg-surface-sunken flex flex-col overflow-y-auto overscroll-y-contain border-0 duration-300 ease-linear xl:!translate-x-0 z-9999',
-          isOpen ? 'translate-x-0' : '-translate-x-full',
+          'absolute top-full lg:relative lg:top-auto h-sidenav-mobile lg:h-sidenav-desktop right-0 w-full sm:w-[375px] lg:w-60 lg:px-4 bg-surface-sunken flex flex-col overflow-y-auto overscroll-y-contain border-0 duration-300 ease-linear lg:!translate-x-0 z-9999',
+          isOpen ? 'translate-x-0' : 'translate-x-full',
         )}
       >
-        <ul className="flex flex-col gap-y-3 px-6 pt-10 xl:pt-15 xl:px-0">
+        <ul className="flex flex-col gap-y-3 px-6 pt-10 lg:pt-15 lg:px-0">
           <li>
             <MenuItem.Item1 href="/" icon="material-symbols:home">
               {t('home')}
@@ -62,8 +62,8 @@ export const SideNavigation: FC = () => {
             </MenuItem.Item1>
           </li>
         </ul>
-        <Divider className="mx-6 xl:mx-0" />
-        <ul className="flex flex-col gap-y-3 px-6 pb-8 xl:px-0 xl:justify-end">
+        <Divider className="mx-6 lg:mx-0" />
+        <ul className="flex flex-col gap-y-3 px-6 pb-8 lg:px-0 lg:justify-end">
           <li>
             <MenuItem.Item2.Link
               href={process.env.NEXT_PUBLIC_LINKEDIN_URL}


### PR DESCRIPTION
## Summary

- Moves the main layout inflection point from `xl` (1280px) to `lg` (1024px) to match the Figma design, where the persistent sidebar appears at 1024px
- Fixes the mobile drawer to slide from the **right** (`right-0`, `translate-x-full`) instead of from the left, matching the 640px Figma spec
- At 640px (`sm`), the drawer is `w-[375px]` (right-anchored); at 375px it remains full-width — both via a single responsive class

## Files changed

| File | Change |
|---|---|
| `AppLayout` | `xl:ml-60 xl:mt-20` → `lg:ml-60 lg:mt-0` |
| `Header` | all `xl:` → `lg:`; `<source>` media query uses `screens.lg` |
| `SideNavigation` | `useBreakpoint('xl')` → `'lg'`; nav `right-0 w-full sm:w-[375px] lg:w-60`; slide animation `translate-x-full`/`translate-x-0` |

## Test plan

- [ ] At 375px: hamburger opens a full-screen overlay sliding from right; page scrolls locked
- [ ] At 640px: hamburger opens a right drawer (~375px wide), page content visible on the left
- [ ] At 1024px: persistent sidebar visible, header/hamburger hidden, content area offset `ml-60`
- [ ] At 1280px+: same as 1024px, no regressions

Refs responsive task #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)