### PR TITLE
fix(site): fix HeroBanner responsive breakpoint (xl → lg)

### DIFF
--- a/apps/site/src/features/about/HeroSection/index.tsx
+++ b/apps/site/src/features/about/HeroSection/index.tsx
@@ -23,7 +23,7 @@ export async function HeroSection({ locale }: { locale: Locale }) {
       alt={t('hero_image_alt')}
       titleSize="xl"
       titleAs="h1"
-      textColumnClassName="xl:w-[382px]"
+      textColumnClassName="lg:w-[382px]"
       imageClassName="object-contain"
     />
   );

--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -24,7 +24,7 @@ export async function HeroSection({ locale, profile }: HeroSectionProps) {
         alt={profile?.photo.alt ?? t('hero_image_alt')}
         titleSize="lg"
         titleAs="h1"
-        textColumnClassName="xl:w-1/2"
+        textColumnClassName="lg:w-1/2"
         imageClassName="object-contain 2xl:object-cover"
       />
       {profile?.stats && profile.stats.length > 0 && (

--- a/apps/site/src/features/projects/HeroSection/index.tsx
+++ b/apps/site/src/features/projects/HeroSection/index.tsx
@@ -15,7 +15,7 @@ export async function HeroSection({ locale }: { locale: Locale }) {
       content={t('hero_content')}
       alt={t('hero_image_alt')}
       titleAs="h1"
-      imageClassName="object-contain p-6 xl:py-8"
+      imageClassName="object-contain p-6 lg:py-8"
     />
   );
 }

--- a/apps/site/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
+++ b/apps/site/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
@@ -1,7 +1,7 @@
 export function HeroBannerSkeleton() {
   return (
-    <section className="animate-pulse flex flex-col bg-surface gap-y-6 xl:flex xl:flex-row xl:rounded-xl xl:h-106">
-      <div className="flex flex-col px-6 pb-6 xl:py-20 xl:pl-20 xl:w-1/2 gap-y-4">
+    <section className="animate-pulse flex flex-col bg-surface gap-y-6 lg:flex-row lg:rounded-xl lg:h-106">
+      <div className="flex flex-col px-6 pb-6 lg:py-20 lg:pl-20 lg:w-1/2 gap-y-4">
         <div className="h-8 w-48 bg-gray-700 rounded" />
         <div className="h-8 w-64 bg-gray-700 rounded" />
         <div className="flex flex-col gap-y-2 pt-4">
@@ -10,7 +10,7 @@ export function HeroBannerSkeleton() {
           <div className="h-4 bg-gray-700 rounded w-4/6" />
         </div>
       </div>
-      <div className="xl:order-1 xl:w-1/2 bg-gray-700 xl:rounded-r-xl min-h-50" />
+      <div className="lg:order-1 lg:w-1/2 bg-gray-700 lg:rounded-r-xl min-h-50" />
     </section>
   );
 }

--- a/apps/site/src/features/shared/HeroBanner/index.tsx
+++ b/apps/site/src/features/shared/HeroBanner/index.tsx
@@ -33,11 +33,11 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
   return (
     <section
       className={classNames(
-        'flex flex-col bg-surface gap-y-6 xl:gap-x-8 xl:flex xl:flex-row xl:rounded-xl xl:h-106 xl:-mx-[97px]',
+        'flex flex-col bg-surface gap-y-6 lg:flex-row lg:gap-x-8 lg:rounded-xl lg:h-106 xl:-mx-[97px]',
         className,
       )}
     >
-      <div className="relative h-64 flex flex-row justify-center xl:order-1 xl:h-full xl:w-1/2">
+      <div className="relative h-64 flex flex-row justify-center lg:order-1 lg:h-full lg:w-1/2">
         <Image
           src={src}
           alt={alt}
@@ -50,7 +50,7 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
       </div>
       <div
         className={classNames(
-          'flex flex-col px-6 pb-6 xl:order-0 xl:py-20 xl:pl-20',
+          'flex flex-col px-6 pb-6 lg:order-0 lg:py-20 lg:pl-20',
           textColumnClassName,
         )}
       >


### PR DESCRIPTION
## Summary

- HeroBanner transitions from stacked (mobile/tablet) to 2-column layout at `lg` (1024px) instead of `xl` (1280px), aligning with the Figma design
- Mobile/tablet: `flex-col`, image on top (`h-64`), text below with `px-6 pb-6`
- Desktop (`lg+`): `flex-row`, text column left (`lg:order-0`), image column right (`lg:order-1 lg:w-1/2`)
- `xl:-mx-[97px]` kept at `xl` — the negative bleed only makes sense when `max-w-237.5` constrains the content area (≥1280px)

## Files changed

- `HeroBanner/index.tsx` — main component
- `HeroBanner/HeroBannerSkeleton.tsx` — skeleton loader
- `home/HeroSection/index.tsx` — `textColumnClassName` prop updated
- `about/HeroSection/index.tsx` — `textColumnClassName` prop updated
- `projects/HeroSection/index.tsx` — `imageClassName` prop updated

## Test plan

- [ ] At 375px / 640px: hero shows image stacked on top, text below
- [ ] At 1024px+: hero shows 2 columns (text left, image right)
- [ ] Skeleton matches same layout transitions
- [ ] All three pages (Home, About, Projects) render correctly at all breakpoints

Refs responsive task #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)