### PR TITLE
fix(site): fix StatCards section breakpoint (xl → lg)

### DIFF
--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -28,7 +28,7 @@ export async function HeroSection({ locale, profile }: HeroSectionProps) {
         imageClassName="object-contain 2xl:object-cover"
       />
       {profile?.stats && profile.stats.length > 0 && (
-        <section className="mx-4 my-6 grid grid-cols-2 gap-3 xl:mx-auto xl:my-8 xl:w-full xl:max-w-237.5 xl:grid-cols-4">
+        <section className="mx-4 my-6 grid grid-cols-2 gap-3 lg:mx-auto lg:my-8 lg:w-full lg:max-w-237.5 lg:grid-cols-4">
           {profile.stats.map((stat) => (
             <StatCard key={stat.label} {...stat} />
           ))}


### PR DESCRIPTION
## Summary

- StatCards section wrapper now activates centered layout, `max-w-237.5`, and 4-column grid at `lg` (1024px) instead of `xl` (1280px)
- Base `grid-cols-2` unchanged — 2 cards remain side-by-side at all mobile/tablet sizes

## Test plan

- [ ] At 375px / 640px: 2 stat cards side-by-side, `mx-4` horizontal margin
- [ ] At 1024px+: section centered with `max-w-237.5`, switches to `grid-cols-4` (relevant if profile has 4 stats)

Refs responsive task #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)