### PR TITLE
fix(site): fix ProjectCard grid (Home) and row view (Projects) responsiveness

### DIFF
--- a/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -16,10 +16,10 @@ export async function ProjectsSection({
 
   return (
     <>
-      <h2 className="text-white mx-4 my-6 !text-xl xl:block xl:mx-auto xl:my-8 xl:w-full xl:!text-[32px] xl:max-w-237.5">
+      <h2 className="text-white mx-4 my-6 !text-xl lg:block lg:mx-auto lg:my-8 lg:w-full lg:!text-[32px] lg:max-w-237.5">
         {t('projects_title')}
       </h2>
-      <ProjectList projects={projects} className="pb-8 xl:pb-20" />
+      <ProjectList projects={projects} compact className="pb-8 lg:pb-20" />
     </>
   );
 }

--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -3,6 +3,8 @@
 import { FC } from 'react';
 
 import { Icon } from '@repo/ui/Imagery';
+import { screens } from '@repo/tailwind-config/screens';
+import classNames from 'classnames';
 import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
 
@@ -27,42 +29,70 @@ export const ProjectCard: FC<IProjectCardProps> = ({
   caption,
   coverImage,
   theme,
-  compact: _compact = false,
+  compact = false,
   skills,
 }) => {
   const t = useTranslations('ProjectCard');
   const locale = useLocale();
-  const isXL = useBreakpoint('xl');
+  const isLG = useBreakpoint('lg');
 
   return (
-    <article className="relative flex flex-col bg-surface rounded-xl overflow-hidden xl:flex-row xl:w-full xl:h-[339px]">
-      <div className="relative h-[244px] mx-3 mt-3 rounded-lg overflow-hidden xl:w-[380px] xl:h-auto xl:shrink-0 xl:m-3">
+    <article
+      className={classNames(
+        'relative flex flex-col bg-surface rounded-xl overflow-hidden',
+        !compact && 'lg:flex-row lg:w-full lg:h-[339px]',
+      )}
+    >
+      <div
+        className={classNames(
+          'relative h-[244px] mx-3 mt-3 rounded-lg overflow-hidden',
+          !compact && 'lg:w-[380px] lg:h-auto lg:shrink-0 lg:m-3',
+        )}
+      >
         <Image
           src={coverImage.url}
           fill
           alt={coverImage.alt}
           className="object-cover"
-          sizes="(min-width: 1280px) 380px, 463px"
+          sizes={`(min-width: ${screens.lg}) 380px, 463px`}
           priority
         />
       </div>
 
       <ShareButton
         slug={slug}
-        className="absolute top-5 right-5 z-10 xl:top-3 xl:right-3"
+        className={classNames(
+          'absolute top-5 right-5 z-10',
+          !compact && 'lg:top-3 lg:right-3',
+        )}
       />
 
-      <div className="flex flex-col flex-1 p-4 gap-4 xl:p-6 xl:gap-5">
+      <div
+        className={classNames(
+          'flex flex-col flex-1 p-4 gap-4',
+          !compact && 'lg:p-6 lg:gap-5',
+        )}
+      >
         <div className="flex flex-col gap-4 flex-1">
           {theme && (
-            <span className="text-xs font-bold text-content-muted uppercase tracking-wide xl:text-sm">
+            <span
+              className={classNames(
+                'text-xs font-bold text-content-muted uppercase tracking-wide',
+                !compact && 'lg:text-sm',
+              )}
+            >
               {theme}
             </span>
           )}
 
           <h3 className="text-2xl font-bold text-content-primary">{title}</h3>
 
-          <p className="text-base font-normal text-content-secondary line-clamp-2 xl:line-clamp-3">
+          <p
+            className={classNames(
+              'text-base font-normal text-content-secondary line-clamp-2',
+              !compact && 'lg:line-clamp-3',
+            )}
+          >
             {caption}
           </p>
         </div>
@@ -70,7 +100,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
         <div className="flex flex-col gap-4">
           <SkillGroup
             skills={skills}
-            max={isXL ? 3 : 2}
+            max={!compact && isLG ? 3 : 2}
             initializeWithMax={2}
             total={skills.length}
           />

--- a/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
@@ -46,7 +46,8 @@ export const ProjectList: FC<IProjectListProps> = ({
   return (
     <ul
       className={classNames(
-        'grid gap-4 md:grid-cols-2 xl:grid-cols-1 xl:gap-6 mx-4 xl:mx-auto max-w-237.5',
+        'grid grid-cols-1 gap-4 lg:gap-6 mx-4 lg:mx-auto max-w-237.5',
+        compact && 'lg:grid-cols-2',
         className,
       )}
     >

--- a/apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
@@ -1,13 +1,13 @@
 export function ProjectsSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="w-full flex justify-start mx-4 my-6 xl:mx-auto xl:max-w-237.5">
+      <div className="w-full flex justify-start mx-4 my-6 lg:mx-auto lg:max-w-237.5">
         <div className="h-8 w-32 bg-gray-700 rounded" />
       </div>
-      <ul className="mx-auto grid max-w-237.5 gap-4 md:grid-cols-2 xl:gap-6 pb-8 xl:pb-20">
+      <ul className="mx-4 lg:mx-auto grid grid-cols-1 lg:grid-cols-2 max-w-237.5 gap-4 lg:gap-6 pb-8 lg:pb-20">
         {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
           <li key={key} className="bg-surface p-3 rounded-5">
-            <div className="h-45 xl:h-61 bg-gray-700 rounded-lg mb-4" />
+            <div className="h-45 lg:h-61 bg-gray-700 rounded-lg mb-4" />
             <div className="h-5 w-3/4 bg-gray-700 rounded mb-2" />
             <div className="h-4 bg-gray-700 rounded mb-1" />
             <div className="h-4 w-5/6 bg-gray-700 rounded mb-5" />

--- a/apps/site/src/features/projects/ProjectsSection/index.tsx
+++ b/apps/site/src/features/projects/ProjectsSection/index.tsx
@@ -5,5 +5,5 @@ interface ProjectsSectionProps {
 }
 
 export function ProjectsSection({ projects }: ProjectsSectionProps) {
-  return <ProjectList projects={projects} className="py-8 xl:py-20" />;
+  return <ProjectList projects={projects} className="py-8 lg:py-20" />;
 }


### PR DESCRIPTION
## Summary

Fixes the inverted/incorrect responsive logic shared between the Home (grid) and Projects (row) project listings.

**Root problem:** `ProjectList` had a single class string (`md:grid-cols-2 xl:grid-cols-1`) that served both views incorrectly — 2 cols activated at 768px (too early) and then reset to 1 col at 1280px (backwards).

## Changes

| File | Change |
|---|---|
| `ProjectList` | `grid-cols-1` base + `lg:grid-cols-2` when `compact=true`; removes broken `md:/xl:` logic |
| `ProjectCard` | Activates `compact` prop (removes `_` prefix); `lg:flex-row` row layout only when `compact=false`; `useBreakpoint xl → lg`; `sizes` uses `screens.lg` constant |
| `HomeProjectsSection` | Passes `compact` to `ProjectList`; `xl: → lg:` |
| `ProjectsSection` (projects) | `xl:py-20 → lg:py-20` |
| `ProjectsSkeleton` | `md:grid-cols-2 xl: → lg:grid-cols-2 lg:` |

## Behavior after fix

| Breakpoint | Home | Projects |
|---|---|---|
| 375 / 640 | 1 col, card vertical | 1 col, card vertical |
| 1024+ | **2 cols**, card vertical | 1 col, card **horizontal** |

## Test plan

- [ ] Home at 375px/640px: project cards in single column, vertical layout
- [ ] Home at 1024px+: project cards in 2-column grid, still vertical
- [ ] Projects at 375px/640px: single column, card image on top
- [ ] Projects at 1024px+: single column, card image left + content right
- [ ] Skeleton matches Home grid layout (2-col at lg+)

Refs responsive task #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)