### PR TITLE
fix(site): make ProfessionalValueCard grid responsive

### DIFF
--- a/apps/site/src/features/about/ValuesSection/ProfessionalValueCard.tsx
+++ b/apps/site/src/features/about/ValuesSection/ProfessionalValueCard.tsx
@@ -16,7 +16,7 @@ export const ProfessionalValueCard: FC<IProfessionalValueCardProps> = ({
   content,
 }) => {
   return (
-    <article className="w-[225px] h-[199px] border border-border-subtle bg-surface/20 rounded-xl px-4 py-6 flex flex-col gap-y-4">
+    <article className="w-full h-full border border-border-subtle bg-surface/20 rounded-xl px-4 py-6 flex flex-col gap-y-4">
       <Icon
         icon={icon}
         className="!text-[48px] text-brand-accent flex-shrink-0"

--- a/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
@@ -22,10 +22,10 @@ export async function ValuesSection({ locale }: { locale: Locale }) {
 
   return (
     <>
-      <h2 className="text-[32px] font-bold text-content-primary text-left mb-6">
+      <h2 className="text-[32px] font-bold text-content-primary text-left mb-6 mx-4 lg:mx-0">
         {t('values_title')}
       </h2>
-      <ul className="grid grid-cols-4 gap-4 items-stretch">
+      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 items-stretch mx-4 lg:mx-0">
         {professionalValues.map((professionalValue) => (
           <li key={professionalValue.id}>
             <ProfessionalValueCard {...professionalValue} />

--- a/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
@@ -1,12 +1,12 @@
 export function ValuesSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="h-8 w-64 bg-gray-700 rounded mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
-      <ul className="flex flex-row gap-x-4 mx-4 xl:mx-auto xl:max-w-237.5">
+      <div className="h-8 w-64 bg-gray-700 rounded mx-4 my-6 lg:mx-0" />
+      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 mx-4 lg:mx-0">
         {(['val-1', 'val-2', 'val-3', 'val-4'] as const).map((key) => (
           <li
             key={key}
-            className="w-full max-w-56 border border-border-subtle px-4 py-6 rounded-xl bg-surface/20 flex flex-col gap-y-3"
+            className="w-full border border-border-subtle px-4 py-6 rounded-xl bg-surface/20 flex flex-col gap-y-3"
           >
             <div className="h-12 w-12 bg-gray-700 rounded" />
             <div className="h-4 bg-gray-700 rounded w-full" />


### PR DESCRIPTION
## Summary

- `ValuesSection`: `grid-cols-4` → `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4`; added `mx-4 lg:mx-0` to h2 and ul
- `ProfessionalValueCard`: removed hardcoded `w-[225px] h-[199px]` → `w-full h-full` so cards fill grid cells
- `ValuesSkeleton`: converted from `flex flex-row` to matching responsive grid; fixed `xl:` → `lg:` breakpoints

Refs #5

## Test plan

- [ ] 375px — 2-column grid
- [ ] 640px — 3-column grid
- [ ] 1024px+ — 4-column grid
- [ ] Skeleton mirrors the same column breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)