### PR TITLE
fix(site): make CurriculumCTA responsive

### DIFF
--- a/apps/site/src/features/about/CurriculumCTA/index.tsx
+++ b/apps/site/src/features/about/CurriculumCTA/index.tsx
@@ -23,11 +23,11 @@ export async function CurriculumCTA({
   return (
     <section
       className={classNames(
-        'flex flex-row items-center gap-14 bg-surface rounded-xl p-8',
+        'flex flex-col sm:flex-row items-center gap-6 sm:gap-14 bg-surface rounded-xl p-6 sm:p-8 mx-4 lg:mx-0',
         className,
       )}
     >
-      <div className="relative w-[320px] h-[317px] shrink-0">
+      <div className="relative w-full h-[220px] sm:w-[320px] sm:h-[317px] shrink-0">
         <Image
           src={illustrationSrc}
           alt={t('illustration_alt')}
@@ -36,7 +36,7 @@ export async function CurriculumCTA({
         />
       </div>
 
-      <div className="flex flex-col gap-y-8 w-[511px]">
+      <div className="flex flex-col gap-y-8 w-full sm:w-auto">
         <p className="text-2xl font-normal text-content-primary">
           {t('description')}
         </p>
@@ -44,7 +44,7 @@ export async function CurriculumCTA({
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-x-2 w-[292px] h-12 justify-center bg-brand-primary rounded-xl px-6 text-base font-bold text-white"
+          className="inline-flex items-center gap-x-2 w-full sm:w-[292px] h-12 justify-center bg-brand-primary rounded-xl px-6 text-base font-bold text-white"
         >
           {t('button')}
           <Icon icon="material-symbols:open-in-new" className="text-2xl" />


### PR DESCRIPTION
## Summary

- Layout: `flex-row` fixo → `flex-col` mobile, `sm:flex-row` a partir de 640px
- Ilustração: largura fixa `w-[320px]` → `w-full` no mobile, `sm:w-[320px]` no tablet+
- Texto: `w-[511px]` fixo → `w-full` no mobile, `sm:w-auto` no tablet+
- Botão: `w-[292px]` fixo → `w-full` no mobile, `sm:w-[292px]` no tablet+
- Padding: `p-8` → `p-6 sm:p-8`; gap: `gap-14` → `gap-6 sm:gap-14`
- Adicionado `mx-4 lg:mx-0` para gutter mobile alinhado com as demais seções

Refs #6

## Test plan

- [x] 375px — layout vertical: ilustração em cima (h-[220px]), texto e botão abaixo (full width)
- [x] 640px — layout horizontal: ilustração à esquerda, texto à direita
- [x] 1024px+ — layout horizontal com espaçamento completo

🤖 Generated with [Claude Code](https://claude.com/claude-code)