### PR TITLE
fix(site): make ContactSection responsive (xl → lg)

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6398,7 +6398,7 @@
         "testStrategy": "Manual visual testing:\n1. Test at 375px width - verify hamburger menu opens full-screen overlay\n2. Test at 640px width - verify hamburger menu opens drawer from right (~375px width)\n3. Test at 1023px width - verify hamburger menu still present\n4. Test at 1024px width - verify persistent sidebar appears, header adapts\n5. Test at 1280px+ width - verify no layout changes from 1024px\n6. Verify scroll lock works when overlay is open on mobile\n7. Check z-index stacking (SideNavigation should be z-50 per line 26)",
         "priority": "high",
         "dependencies": [],
-        "status": "pending",
+        "status": "done",
         "subtasks": []
       },
       {
@@ -6411,7 +6411,7 @@
         "dependencies": [
           1
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": []
       },
       {
@@ -6424,7 +6424,7 @@
         "dependencies": [
           2
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": []
       },
       {
@@ -6437,7 +6437,7 @@
         "dependencies": [
           3
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": []
       },
       {
@@ -6450,7 +6450,7 @@
         "dependencies": [
           4
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": []
       },
       {
@@ -6463,7 +6463,7 @@
         "dependencies": [
           5
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": []
       },
       {

--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -131,7 +131,7 @@ export const ContactForm: FC = () => {
 
         <Button.Base
           type="submit"
-          className="w-full xl:w-[216px] h-[46px] mt-6"
+          className="w-full lg:w-[216px] h-[46px] mt-6"
           disabled={isSubmitting}
         >
           {tForm('submit')}

--- a/apps/site/src/features/contact/ContactInfo/index.tsx
+++ b/apps/site/src/features/contact/ContactInfo/index.tsx
@@ -16,7 +16,7 @@ export const ContactInfo: FC = () => {
   const whatsappUrl = `https://wa.me/${process.env.NEXT_PUBLIC_CONTACT_NUMBER}?text=${encodeURIComponent(t('whatsappMessage'))}`;
 
   return (
-    <section className="flex flex-col gap-y-6 xl:w-[326px]">
+    <section className="flex flex-col gap-y-6 lg:w-[326px]">
       <h2 className="text-2xl font-bold text-content-primary">{t('title')}</h2>
 
       <address className="flex flex-col gap-y-6 not-italic">

--- a/apps/site/src/features/contact/ContactSection/index.tsx
+++ b/apps/site/src/features/contact/ContactSection/index.tsx
@@ -6,8 +6,8 @@ import { ContactInfo } from '~features/contact/ContactInfo';
 export function ContactSection() {
   return (
     <section className="bg-surface-overlay xl:border-2 xl:border-b-0 xl:border-border-subtle py-10 xl:-mx-[161px] xl:px-[161px]">
-      <div className="mx-4 xl:mx-auto flex flex-col gap-y-6 xl:flex-row xl:gap-x-16">
-        <div className="xl:w-[560px] shrink-0">
+      <div className="mx-4 lg:mx-auto flex flex-col gap-y-6 lg:flex-row lg:gap-x-16">
+        <div className="lg:w-[560px] shrink-0">
           <ContactForm />
         </div>
         <ContactInfo />


### PR DESCRIPTION
## Summary

- `ContactSection`: `xl:flex-row` → `lg:flex-row`; `xl:gap-x-16` → `lg:gap-x-16`; `mx-4 xl:mx-auto` → `mx-4 lg:mx-auto`; `xl:w-[560px]` → `lg:w-[560px]`
- `ContactInfo`: `xl:w-[326px]` → `lg:w-[326px]`
- `ContactForm`: botão `xl:w-[216px]` → `lg:w-[216px]`
- Bleed e border (`xl:-mx-[161px]`, `xl:border-*`) mantidos em `xl:` — válidos apenas quando `max-w-237.5` está constraindo (≥ 1280px)
- `tasks.json`: marca tarefas responsivas 1–6 como done

Refs #7

## Test plan

- [ ] 375px / 640px — layout coluna única: formulário acima, info de contato abaixo (full width)
- [ ] 1024px — 2 colunas: formulário à esquerda (560px), info à direita (326px)
- [ ] 1280px+ — border e bleed negativo ativados

🤖 Generated with [Claude Code](https://claude.com/claude-code)