### PR TITLE
fix(site): make ProjectDetail responsive (xl → lg/sm breakpoints)

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6490,8 +6490,9 @@
         "dependencies": [
           "7"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-17T00:51:42.505Z"
       },
       {
         "id": "9",
@@ -6522,9 +6523,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-17T00:26:52.335Z",
+      "lastModified": "2026-06-17T00:51:42.505Z",
       "taskCount": 10,
-      "completedCount": 7,
+      "completedCount": 8,
       "tags": [
         "responsive"
       ]

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -66,16 +66,16 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
   );
 
   return (
-    <article className="flex flex-col gap-y-10 pb-12 mt-6 xl:mt-0">
-      <div className="mx-4 xl:mx-auto xl:w-full xl:max-w-237.5 flex flex-col gap-y-10">
-        <div className="flex flex-col justify-center items-start gap-y-1 xl:flex-row xl:items-center xl:justify-between">
+    <article className="flex flex-col gap-y-10 pb-12 mt-6 lg:mt-0">
+      <div className="mx-4 lg:mx-auto lg:w-full lg:max-w-237.5 flex flex-col gap-y-10">
+        <div className="flex flex-col justify-center items-start gap-y-1 lg:flex-row lg:items-center lg:justify-between">
           <Breadcrumb
             items={breadcrumbItems}
-            className="flex items-center min-h-12 xl:order-2"
+            className="flex items-center min-h-12 lg:order-2"
           />
           <Link
             href="/projects"
-            className="flex items-center gap-x-2 text-base text-content-primary xl:order-1 xl:min-h-12"
+            className="flex items-center gap-x-2 text-base text-content-primary lg:order-1 lg:min-h-12"
           >
             <Icon icon="material-symbols:arrow-back" className="text-2xl" />
             {t('back')}
@@ -83,7 +83,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
         </div>
 
         <div className="flex flex-col gap-y-6">
-          <div className="relative w-full xl:h-[485px] h-60 rounded-lg overflow-hidden">
+          <div className="relative w-full lg:h-[485px] h-60 rounded-lg overflow-hidden">
             <Image
               src={coverImage.url}
               fill

--- a/apps/site/src/features/projects/ProjectDetail/ProjectMetaGrid.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectMetaGrid.tsx
@@ -37,9 +37,9 @@ export const ProjectMetaGrid: FC<IProjectMetaGridProps> = ({
   return (
     <div className="flex flex-col gap-y-6">
       {hasCards && (
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           {summary && (
-            <div className="bg-surface rounded-xl p-6 flex flex-col gap-y-2 xl:h-[150px]">
+            <div className="bg-surface rounded-xl p-6 flex flex-col gap-y-2 sm:h-[150px]">
               <dt className="text-xl font-bold text-content-muted">
                 {labels.summary}
               </dt>
@@ -47,7 +47,7 @@ export const ProjectMetaGrid: FC<IProjectMetaGridProps> = ({
             </div>
           )}
           {objectives && (
-            <div className="bg-surface rounded-xl p-6 flex flex-col gap-y-2 xl:h-[150px]">
+            <div className="bg-surface rounded-xl p-6 flex flex-col gap-y-2 sm:h-[150px]">
               <dt className="text-xl font-bold text-content-muted">
                 {labels.objectives}
               </dt>


### PR DESCRIPTION
## Summary

- `ProjectDetail`: changed all `xl:` breakpoints to `lg:` for container width, nav row (breadcrumb/back-button order), and hero image height
- `ProjectMetaGrid`: changed summary/objectives grid from `xl:grid-cols-2` → `sm:grid-cols-2` and card min-height from `xl:h-[150px]` → `sm:h-[150px]`

## Breakpoint behavior

| Viewport | Layout |
|---|---|
| `< sm` (< 640px) | Single column throughout; hero `h-60` |
| `≥ sm` (≥ 640px) | Summary + Objectives in 2 columns (`sm:grid-cols-2`) |
| `≥ lg` (≥ 1024px) | Container max-width; breadcrumb/back in flex-row; hero `h-[485px]` |

## Test plan

- [ ] 375px — single column, hero h-60, all meta stacked
- [ ] 640px — Summary + Objectives in 2 columns
- [ ] 1023px — still 2-col info grid, still stacked nav
- [ ] 1024px — hero h-[485px], breadcrumb/back flex-row, container max-width
- [ ] 1280px+ — same as 1024px

Refs #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)