### PR TITLE
fix(ui): make Modal responsive — full-width mobile, fixed width lg+

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6504,8 +6504,9 @@
         "dependencies": [
           "8"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-06-17T01:06:25.265Z"
       },
       {
         "id": "10",
@@ -6523,9 +6524,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-17T00:51:42.505Z",
+      "lastModified": "2026-06-17T01:06:25.265Z",
       "taskCount": 10,
-      "completedCount": 8,
+      "completedCount": 9,
       "tags": [
         "responsive"
       ]

--- a/packages/ui/src/Control/Modal/index.tsx
+++ b/packages/ui/src/Control/Modal/index.tsx
@@ -102,7 +102,7 @@ export const Modal: FC<IModalProps> = ({
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? titleId : undefined}
-        className="bg-surface rounded-xl p-6 w-[690px] max-h-[80vh] overflow-y-auto"
+        className="bg-surface rounded-xl p-6 w-[calc(100vw-2rem)] lg:w-[642px] max-h-[80vh] overflow-y-auto"
       >
         <div className="flex items-center justify-between gap-2 mb-6">
           {title && (


### PR DESCRIPTION
## Summary

- `Modal`: substituído `w-[690px]` fixo por `w-[calc(100vw-2rem)] lg:w-[642px]`
  - Mobile: ocupa toda a largura da viewport menos 1rem de margem em cada lado
  - `≥ lg` (1024px+): largura fixa de 642px conforme PRD

## Breakpoint behavior

| Viewport | Largura do modal |
|---|---|
| `< lg` (< 1024px) | `calc(100vw - 2rem)` — ~16px de margem em cada lado |
| `≥ lg` (≥ 1024px) | `642px` fixo, centralizado pelo `flex items-center justify-center` do backdrop |

## Test plan

- [ ] 375px — modal não ultrapassa viewport, ~16px de margem em cada lado
- [ ] 640px — ainda responsivo com margens
- [ ] 1023px — ainda responsivo
- [ ] 1024px — largura fixa 642px, centralizado
- [ ] Conteúdo longo: `max-h-[80vh]` + `overflow-y-auto` funcionando
- [ ] Botão fechar acessível em todos os breakpoints
- [ ] Click fora fecha o modal
- [ ] Esc fecha o modal

Refs #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)