### PR TITLE
fix(site): correct CurriculumCTA breakpoint sm → lg

### DIFF
--- a/apps/site/src/features/about/CurriculumCTA/index.tsx
+++ b/apps/site/src/features/about/CurriculumCTA/index.tsx
@@ -23,11 +23,11 @@ export async function CurriculumCTA({
   return (
     <section
       className={classNames(
-        'flex flex-col sm:flex-row items-center gap-6 sm:gap-14 bg-surface rounded-xl p-6 sm:p-8 mx-4 lg:mx-0',
+        'flex flex-col lg:flex-row items-center gap-6 lg:gap-14 bg-surface rounded-xl p-6 lg:p-8 mx-4 lg:mx-0',
         className,
       )}
     >
-      <div className="relative w-full h-[220px] sm:w-[320px] sm:h-[317px] shrink-0">
+      <div className="relative w-full h-[220px] lg:w-[320px] lg:h-[317px] shrink-0">
         <Image
           src={illustrationSrc}
           alt={t('illustration_alt')}
@@ -36,7 +36,7 @@ export async function CurriculumCTA({
         />
       </div>
 
-      <div className="flex flex-col gap-y-8 w-full sm:w-auto">
+      <div className="flex flex-col gap-y-8 w-full lg:w-auto">
         <p className="text-2xl font-normal text-content-primary">
           {t('description')}
         </p>
@@ -44,7 +44,7 @@ export async function CurriculumCTA({
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-x-2 w-full sm:w-[292px] h-12 justify-center bg-brand-primary rounded-xl px-6 text-base font-bold text-white"
+          className="inline-flex items-center gap-x-2 w-full lg:w-[292px] h-12 justify-center bg-brand-primary rounded-xl px-6 text-base font-bold text-white"
         >
           {t('button')}
           <Icon icon="material-symbols:open-in-new" className="text-2xl" />


### PR DESCRIPTION
## Summary

A task 6 implementou o layout horizontal do `CurriculumCTA` usando `sm:` (640px) em vez de `lg:` (1024px), causando quebra de layout em tablets/viewports intermediárias.

**Correção:** todos os `sm:` que controlam o flex-row foram trocados por `lg:`:
- `sm:flex-row` → `lg:flex-row`
- `sm:gap-14` → `lg:gap-14`
- `sm:p-8` → `lg:p-8`
- `sm:w-[320px] sm:h-[317px]` → `lg:w-[320px] lg:h-[317px]` (imagem)
- `sm:w-auto` → `lg:w-auto` (coluna de texto)
- `sm:w-[292px]` → `lg:w-[292px]` (botão)

## Breakpoint behavior

| Viewport | Layout |
|---|---|
| `< lg` (< 1024px) | `flex-col` — ilustração em cima (w-full, h-220px), texto e botão full-width abaixo |
| `≥ lg` (≥ 1024px) | `flex-row` — ilustração à esquerda (320×317px), conteúdo à direita |

## Test plan

- [ ] 375px — empilhado, ilustração full-width, botão full-width
- [ ] 640px — ainda empilhado (bug anterior mostrava flex-row aqui)
- [ ] 1023px — ainda empilhado
- [ ] 1024px — layout horizontal, ilustração fixa 320px

🤖 Generated with [Claude Code](https://claude.com/claude-code)