### PR TITLE
fix(site): add horizontal padding to layout + fix CurriculumCTA breakpoint

### DIFF
--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -61,7 +61,7 @@ export default async function RootLayout({
     <html dir="ltr" lang={locale}>
       <body
         className={classNames(
-          'flex flex-col h-screen antialiased dark:bg-dark',
+          'flex flex-col h-screen antialiased dark:bg-dark overflow-x-clip',
           inter.className,
         )}
       >

--- a/apps/site/src/components/Layout/AppLayout/index.tsx
+++ b/apps/site/src/components/Layout/AppLayout/index.tsx
@@ -11,7 +11,7 @@ export const AppLayout: FC<PropsWithChildren> = ({ children }) => {
     <>
       <SideNavigation />
       <div className="flex h-full flex-col ml-0 lg:ml-60 mt-header-mobile lg:mt-0">
-        <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1 pt-6 lg:pt-16 xl:pt-20">
+        <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1 pt-6 lg:pt-16 xl:pt-20 px-4 lg:px-0">
           {children}
         </main>
         <footer className="w-full max-w-237.5 mx-auto">

--- a/apps/site/src/components/Layout/AppLayout/index.tsx
+++ b/apps/site/src/components/Layout/AppLayout/index.tsx
@@ -11,7 +11,7 @@ export const AppLayout: FC<PropsWithChildren> = ({ children }) => {
     <>
       <SideNavigation />
       <div className="flex h-full flex-col ml-0 lg:ml-60 mt-header-mobile lg:mt-0">
-        <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1 pt-6 lg:pt-16 xl:pt-20 px-4 lg:px-0">
+        <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1 pt-6 lg:pt-16 xl:pt-20 px-4 xl:px-0">
           {children}
         </main>
         <footer className="w-full max-w-237.5 mx-auto">

--- a/apps/site/src/features/about/CurriculumCTA/index.tsx
+++ b/apps/site/src/features/about/CurriculumCTA/index.tsx
@@ -23,7 +23,7 @@ export async function CurriculumCTA({
   return (
     <section
       className={classNames(
-        'flex flex-col lg:flex-row items-center gap-6 lg:gap-14 bg-surface rounded-xl p-6 lg:p-8 mx-4 lg:mx-0',
+        'flex flex-col lg:flex-row items-center gap-6 lg:gap-14 bg-surface rounded-xl p-6 lg:p-8',
         className,
       )}
     >

--- a/apps/site/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx
@@ -1,8 +1,8 @@
 export function ExperiencesSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="h-px bg-gray-700 mx-4 my-6 xl:mx-auto xl:max-w-237.5" />
-      <ul className="flex flex-col mx-4 gap-y-3 xl:mx-auto xl:max-w-237.5">
+      <div className="h-px bg-gray-700 my-6" />
+      <ul className="flex flex-col gap-y-3">
         {(['exp-1', 'exp-2', 'exp-3'] as const).map((key) => (
           <li
             key={key}

--- a/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
@@ -22,10 +22,10 @@ export async function ValuesSection({ locale }: { locale: Locale }) {
 
   return (
     <>
-      <h2 className="text-[32px] font-bold text-content-primary text-left mb-6 mx-4 lg:mx-0">
+      <h2 className="text-[32px] font-bold text-content-primary text-left mb-6">
         {t('values_title')}
       </h2>
-      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 items-stretch mx-4 lg:mx-0">
+      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 items-stretch">
         {professionalValues.map((professionalValue) => (
           <li key={professionalValue.id}>
             <ProfessionalValueCard {...professionalValue} />

--- a/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
@@ -1,8 +1,8 @@
 export function ValuesSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="h-8 w-64 bg-gray-700 rounded mx-4 my-6 lg:mx-0" />
-      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 mx-4 lg:mx-0">
+      <div className="h-8 w-64 bg-gray-700 rounded my-6" />
+      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
         {(['val-1', 'val-2', 'val-3', 'val-4'] as const).map((key) => (
           <li
             key={key}

--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -133,7 +133,7 @@ export const ContactForm: FC = () => {
 
         <Button.Base
           type="submit"
-          className="w-full lg:w-[216px] h-[46px] mt-6"
+          className="w-full xl:w-[216px] h-[46px] mt-6"
           disabled={isSubmitting}
         >
           {tForm('submit')}

--- a/apps/site/src/features/contact/ContactInfo/index.tsx
+++ b/apps/site/src/features/contact/ContactInfo/index.tsx
@@ -16,7 +16,7 @@ export const ContactInfo: FC = () => {
   const whatsappUrl = `https://wa.me/${process.env.NEXT_PUBLIC_CONTACT_NUMBER}?text=${encodeURIComponent(t('whatsappMessage'))}`;
 
   return (
-    <section className="flex flex-col gap-y-6 lg:w-[326px]">
+    <section className="flex flex-col gap-y-6 xl:w-[326px]">
       <h2 className="text-2xl font-bold text-content-primary">{t('title')}</h2>
 
       <address className="flex flex-col gap-y-6 not-italic">

--- a/apps/site/src/features/contact/ContactSection/index.tsx
+++ b/apps/site/src/features/contact/ContactSection/index.tsx
@@ -6,8 +6,8 @@ import { ContactInfo } from '~features/contact/ContactInfo';
 export function ContactSection() {
   return (
     <section className="bg-surface-overlay xl:border-2 xl:border-b-0 xl:border-border-subtle py-10 xl:-mx-[161px] xl:px-[161px]">
-      <div className="mx-4 lg:mx-auto flex flex-col gap-y-6 lg:flex-row lg:gap-x-16">
-        <div className="lg:w-[560px] shrink-0">
+      <div className="mx-4 xl:mx-auto flex flex-col gap-y-6 xl:flex-row xl:gap-x-16">
+        <div className="xl:w-[560px] xl:shrink-0">
           <ContactForm />
         </div>
         <ContactInfo />

--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -28,7 +28,7 @@ export async function HeroSection({ locale, profile }: HeroSectionProps) {
         imageClassName="object-contain 2xl:object-cover"
       />
       {profile?.stats && profile.stats.length > 0 && (
-        <section className="mx-4 my-6 grid grid-cols-2 gap-3 lg:mx-auto lg:my-8 lg:w-full lg:max-w-237.5 lg:grid-cols-4">
+        <section className="my-6 grid grid-cols-2 gap-3 lg:mx-auto lg:my-8 lg:w-full lg:max-w-237.5 lg:grid-cols-4">
           {profile.stats.map((stat) => (
             <StatCard key={stat.label} {...stat} />
           ))}

--- a/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -16,7 +16,7 @@ export async function ProjectsSection({
 
   return (
     <>
-      <h2 className="text-white mx-4 my-6 !text-xl lg:block lg:mx-auto lg:my-8 lg:w-full lg:!text-[32px] lg:max-w-237.5">
+      <h2 className="text-white my-6 !text-xl lg:block lg:mx-auto lg:my-8 lg:w-full lg:!text-[32px] lg:max-w-237.5">
         {t('projects_title')}
       </h2>
       <ProjectList projects={projects} compact className="pb-8 lg:pb-20" />

--- a/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
@@ -46,7 +46,7 @@ export const ProjectList: FC<IProjectListProps> = ({
   return (
     <ul
       className={classNames(
-        'grid grid-cols-1 gap-4 lg:gap-6 mx-4 lg:mx-auto max-w-237.5',
+        'grid grid-cols-1 gap-4 lg:gap-6 lg:mx-auto max-w-237.5',
         compact && 'lg:grid-cols-2',
         className,
       )}

--- a/apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
@@ -1,10 +1,10 @@
 export function ProjectsSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="w-full flex justify-start mx-4 my-6 lg:mx-auto lg:max-w-237.5">
+      <div className="w-full flex justify-start my-6 lg:mx-auto lg:max-w-237.5">
         <div className="h-8 w-32 bg-gray-700 rounded" />
       </div>
-      <ul className="mx-4 lg:mx-auto grid grid-cols-1 lg:grid-cols-2 max-w-237.5 gap-4 lg:gap-6 pb-8 lg:pb-20">
+      <ul className="lg:mx-auto grid grid-cols-1 lg:grid-cols-2 max-w-237.5 gap-4 lg:gap-6 pb-8 lg:pb-20">
         {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
           <li key={key} className="bg-surface p-3 rounded-5">
             <div className="h-45 lg:h-61 bg-gray-700 rounded-lg mb-4" />

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -67,7 +67,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
 
   return (
     <article className="flex flex-col gap-y-10 pb-12 mt-6 lg:mt-0">
-      <div className="mx-4 lg:mx-auto lg:w-full lg:max-w-237.5 flex flex-col gap-y-10">
+      <div className="lg:mx-auto lg:w-full lg:max-w-237.5 flex flex-col gap-y-10">
         <div className="flex flex-col justify-center items-start gap-y-1 lg:flex-row lg:items-center lg:justify-between">
           <Breadcrumb
             items={breadcrumbItems}


### PR DESCRIPTION
## Problemas corrigidos

### 1. CurriculumCTA — breakpoint `sm:` → `lg:`
A task 6 implementou o layout horizontal com `sm:flex-row` (640px) em vez de `lg:flex-row` (1024px), causando quebra em tablet.

### 2. Respiro lateral em todas as páginas
`main` no `AppLayout` não tinha padding horizontal — conteúdo colava nas bordas em mobile e tablet.

**Solução:** `px-4 xl:px-0` no `main`:
- `< xl` (< 1280px): 16px de respiro em cada lado
- `≥ xl` (≥ 1280px): sem padding — `max-w-237.5 mx-auto` provê margem automática (≥45px cada lado)

Todos os componentes que tinham `mx-4` próprio foram limpos para evitar padding duplo. O `footer` (ContactSection full-bleed) **não foi tocado**.

### 3. Scroll horizontal
Após adicionar `px-4` ao `main`, o scroll horizontal apareceu — provavelmente expondo o `translate-x-full` da `SideNavigation` fechada vazando para a direita em alguns browsers.

**Solução:** `overflow-x-clip` no `body` (layout.tsx).
- Diferente de `overflow-x: hidden`, `clip` não cria novo BFC → `position: fixed` funciona normalmente.

### 4. ContactSection quebrado em laptop
O `ContactSection` usava `lg:flex-row` com form (560px) + gap (64px) + info (326px) = **950px total**, mas a área disponível em `lg` com sidebar (240px) é só **784px** (1024 − 240).

**Solução:** `lg:flex-row` → `xl:flex-row` no ContactSection, ContactInfo e botão do ContactForm.
- `≥ xl` (≥ 1280px): área disponível = 1040px, capada em 950px pelo `max-w-237.5`. Encaixa.

## Breakpoint summary

| Viewport | Padding main | ContactSection |
|---|---|---|
| `< xl` (< 1280px) | `px-4` — 16px cada lado | `flex-col` empilhado |
| `≥ xl` (≥ 1280px) | `px-0` — `max-w` centra | `flex-row` lado a lado |

## Arquivos modificados

- `apps/site/src/app/[locale]/layout.tsx` — `overflow-x-clip` no body
- `apps/site/src/components/Layout/AppLayout/index.tsx` — `px-4 xl:px-0` no main
- `apps/site/src/features/about/CurriculumCTA/index.tsx` — `sm:` → `lg:`
- `apps/site/src/features/about/ValuesSection/ValuesSection.tsx` — remove `mx-4`
- `apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx` — remove `mx-4`
- `apps/site/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx` — remove `mx-4`
- `apps/site/src/features/contact/ContactSection/index.tsx` — `lg:` → `xl:`
- `apps/site/src/features/contact/ContactInfo/index.tsx` — `lg:w-[326px]` → `xl:`
- `apps/site/src/features/contact/ContactForm/index.tsx` — `lg:w-[216px]` → `xl:`
- `apps/site/src/features/home/HeroSection/index.tsx` — remove `mx-4`
- `apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx` — remove `mx-4`
- `apps/site/src/features/home/ProjectsSection/ProjectList.tsx` — remove `mx-4`
- `apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx` — remove `mx-4`
- `apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx` — remove `mx-4`

## Test plan

- [ ] 375px — respiro lateral visível, sem scroll horizontal
- [ ] 640px — CurriculumCTA ainda empilhado
- [ ] 1024px — ContactSection empilhado (não transborda), conteúdo com 16px respiro
- [ ] 1280px — ContactSection flex-row, conteúdo centralizado pelo max-w
- [ ] ContactSection (footer) — full-bleed mantido em todos os breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)