### PR TITLE
fix(site): fix ValuesSection fragment causing double gap-y-20 on about page

### DIFF
--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -51,7 +51,7 @@ export default async function About({ params }: AboutPageProps) {
   setRequestLocale(locale);
 
   return (
-    <div className="flex flex-col gap-y-20 pb-20">
+    <div className="flex flex-col gap-y-10 lg:gap-y-20 pb-10 lg:pb-20">
       <HeroSection locale={locale} />
       <ValuesSection locale={locale} />
       <ExperiencesSection locale={locale} />

--- a/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
@@ -21,8 +21,8 @@ export async function ValuesSection({ locale }: { locale: Locale }) {
     valuesResult.isRight() ? valuesResult.value : [];
 
   return (
-    <>
-      <h2 className="text-[32px] font-bold text-content-primary text-left mb-6">
+    <section className="flex flex-col gap-y-6">
+      <h2 className="text-[32px] font-bold text-content-primary text-left">
         {t('values_title')}
       </h2>
       <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 items-stretch">
@@ -32,6 +32,6 @@ export async function ValuesSection({ locale }: { locale: Locale }) {
           </li>
         ))}
       </ul>
-    </>
+    </section>
   );
 }

--- a/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
@@ -1,7 +1,7 @@
 export function ValuesSkeleton() {
   return (
-    <div className="animate-pulse">
-      <div className="h-8 w-64 bg-gray-700 rounded my-6" />
+    <div className="animate-pulse flex flex-col gap-y-6">
+      <div className="h-8 w-64 bg-gray-700 rounded" />
       <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
         {(['val-1', 'val-2', 'val-3', 'val-4'] as const).map((key) => (
           <li


### PR DESCRIPTION
## Summary

- Wrapped `ValuesSection` fragment in `<section className="flex flex-col gap-y-6">` so the h2 and ul are no longer direct flex children of the about page's `gap-y-20` container — this was causing 80px gap between the title and the values grid
- Removed `mb-6` from h2 (spacing now comes from `gap-y-6` on the section wrapper)
- Aligned `ValuesSkeleton` to the same structure (single div with `flex flex-col gap-y-6`, no standalone margin)
- Made about page gap responsive: `gap-y-10 lg:gap-y-20` and `pb-10 lg:pb-20` to avoid excessive vertical spacing on mobile

## Test plan

- [ ] Mobile (375px): title and values grid have ~24px gap (gap-y-6), section spacing is 40px (gap-y-10)
- [ ] Desktop (≥1024px): section spacing is 80px (gap-y-20), no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)