### PR TITLE
feat(site): add 'View all projects' link to Home ProjectsSection

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -27,6 +27,7 @@
   },
   "Home": {
     "projects_title": "Projects",
+    "view_all_projects": "View all projects",
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Software Engineer",
     "hero_content": "Lorem ipsum odor amet, consectetuer adipiscing elit. Nisl ad dictumst donec consequat sollicitudin mauris. Id inceptos nibh varius; maecenas congue ullamcorper. Senectus massa tellus metus, nullam diam amet fringilla.",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -27,6 +27,7 @@
   },
   "Home": {
     "projects_title": "Proyectos",
+    "view_all_projects": "Ver todos los proyectos",
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Ingeniero de Software",
     "hero_content": "Lorem ipsum odor amet, consectetuer adipiscing elit. Nisl ad dictumst donec consequat sollicitudin mauris. Id inceptos nibh varius; maecenas congue ullamcorper. Senectus massa tellus metus, nullam diam amet fringilla.",

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -27,6 +27,7 @@
   },
   "Home": {
     "projects_title": "Projetos",
+    "view_all_projects": "Ver todos os projetos",
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Engenheiro de Software",
     "hero_content": "Lorem ipsum odor amet, consectetuer adipiscing elit. Nisl ad dictumst donec consequat sollicitudin mauris. Id inceptos nibh varius; maecenas congue ullamcorper. Senectus massa tellus metus, nullam diam amet fringilla.",

--- a/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -1,5 +1,6 @@
 import { type Locale } from '@repo/core/shared';
 import { getTranslations } from 'next-intl/server';
+import { Link } from '~/i18n/routing';
 
 import { ProjectList, ProjectSummary } from './ProjectList';
 
@@ -19,7 +20,15 @@ export async function ProjectsSection({
       <h2 className="text-white my-6 !text-xl lg:block lg:mx-auto lg:my-8 lg:w-full lg:!text-[32px] lg:max-w-237.5">
         {t('projects_title')}
       </h2>
-      <ProjectList projects={projects} compact className="pb-8 lg:pb-20" />
+      <ProjectList projects={projects} compact className="pb-6" />
+      <div className="flex justify-center pb-8 lg:pb-20">
+        <Link
+          href="/projects"
+          className="text-sm text-content-disabled underline"
+        >
+          {t('view_all_projects')}
+        </Link>
+      </div>
     </>
   );
 }

--- a/apps/site/tests/features/home/ProjectsSection.test.tsx
+++ b/apps/site/tests/features/home/ProjectsSection.test.tsx
@@ -9,6 +9,22 @@ vi.mock('next-intl/server', () => ({
   getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
 }));
 
+vi.mock('~/i18n/routing', () => ({
+  Link: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock('~features/home/ProjectsSection/ProjectList', () => ({
   ProjectList: ({
     projects,
@@ -69,5 +85,14 @@ describe('home/ProjectsSection', () => {
     render(await ProjectsSection({ locale: 'en-US', projects: [] }));
 
     expect(screen.getByText('t.projects_title')).toBeInTheDocument();
+  });
+
+  it('should render a "view all projects" link pointing to /projects', async () => {
+    const { ProjectsSection } = await import('~features/home/ProjectsSection');
+    render(await ProjectsSection({ locale: 'en-US', projects: PROJECTS }));
+
+    const link = screen.getByRole('link', { name: 't.view_all_projects' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/projects');
   });
 });


### PR DESCRIPTION
## Summary

- Added a simple underlined text link below the featured projects list, pointing to `/projects`
- Link respects the active locale via `next-intl`'s `Link`
- Added `view_all_projects` translation key to all three locales (`en-US`, `pt-BR`, `es`)
- Updated `ProjectsSection` test: added mock for `~/i18n/routing` Link and a new assertion that the link is rendered with the correct `href`

## Test plan

- [ ] Home page: "Ver todos os projetos" / "View all projects" link appears below the two featured project cards
- [ ] Clicking navigates to the `/projects` page
- [ ] Link is visible across all locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)