### PR TITLE
feat(theme): fix light mode semantic tokens and add surface-selected

### DIFF
--- a/packages/tailwind-config/index.ts
+++ b/packages/tailwind-config/index.ts
@@ -40,6 +40,7 @@ export default plugin(() => {}, {
           raised: 'rgb(var(--tw-surface-raised) / <alpha-value>)',
           overlay: 'rgb(var(--tw-surface-overlay) / <alpha-value>)',
           interactive: 'rgb(var(--tw-surface-interactive) / <alpha-value>)',
+          selected: 'rgb(var(--tw-surface-selected) / <alpha-value>)',
         },
         content: {
           primary: 'rgb(var(--tw-content-primary) / <alpha-value>)',

--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -10,6 +10,7 @@
   --tw-surface-raised: 73 73 73; /* dark-500 #494949 */
   --tw-surface-overlay: 38 38 38; /* #262626 — contact section bg */
   --tw-surface-interactive: 73 73 73; /* #494949 — badges, hover states */
+  --tw-surface-selected: 50 50 50; /* #323232 — breadcrumb active item dark */
   --tw-content-primary: 255 255 255;
   --tw-content-secondary: 186 186 186; /* dark-900 #BABABA */
   --tw-content-muted: 141 141 141; /* dark-700 #8D8D8D */
@@ -26,18 +27,19 @@
 }
 
 .light {
-  --tw-surface: 245 246 250; /* #F5F6FA */
-  --tw-surface-sunken: 255 255 255; /* #FFFFFF */
-  --tw-surface-base: 240 242 248; /* #F0F2F8 */
+  --tw-surface: 255 255 255; /* #FFFFFF — cards, hero, modais */
+  --tw-surface-sunken: 245 246 250; /* #F5F6FA — sidebar, page bg */
+  --tw-surface-base: 245 246 250; /* #F5F6FA — body background */
   --tw-surface-raised: 229 231 235; /* #E5E7EB */
-  --tw-surface-overlay: 255 255 255; /* #FFFFFF */
-  --tw-surface-interactive: 235 235 235; /* #EBEBEB */
-  --tw-content-primary: 28 28 28; /* #1C1C1C */
+  --tw-surface-overlay: 255 255 255; /* #FFFFFF — contact section */
+  --tw-surface-interactive: 235 235 235; /* #EBEBEB — hover fills */
+  --tw-surface-selected: 218 218 218; /* #DADADA — breadcrumb active, menu selected */
+  --tw-content-primary: 62 62 62; /* #3E3E3E */
   --tw-content-secondary: 85 85 85; /* #555555 */
-  --tw-content-muted: 136 136 136; /* #888888 */
+  --tw-content-muted: 141 141 141; /* #8D8D8D */
   --tw-content-disabled: 164 164 164; /* #A4A4A4 */
-  --tw-border-default: 209 213 219; /* #D1D5DB */
-  --tw-border-subtle: 229 231 235; /* #E5E7EB */
+  --tw-border-default: 186 186 186; /* #BABABA */
+  --tw-border-subtle: 186 186 186; /* #BABABA — separadores */
   --tw-border-muted: 186 186 186; /* #BABABA */
   --tw-brand-primary: 88 101 255; /* #5865FF */
   --tw-brand-accent: 111 227 127; /* #6FE37F */


### PR DESCRIPTION
## Summary

- Corrige valores errados/trocados nos tokens semânticos do bloco `.light` em `packages/tailwind-config/tailwind.css`
- Adiciona o novo token `surface-selected` (dark: `#323232` / light: `#DADADA`) em `tailwind.css` e `index.ts`

## Tokens corrigidos (`.light` block)

| Token | Antes | Depois | Motivo |
|---|---|---|---|
| `surface` | `#F5F6FA` | `#FFFFFF` | Estava com valor de page bg — cards devem ser brancos |
| `surface-sunken` | `#FFFFFF` | `#F5F6FA` | Estava com valor de card — sidebar/page bg deve ser #F5F6FA |
| `surface-base` | `#F0F2F8` | `#F5F6FA` | Valor incorreto para body background |
| `content-primary` | `#1C1C1C` | `#3E3E3E` | Spec Figma: texto primário light = #3E3E3E |
| `content-muted` | `#888888` | `#8D8D8D` | Alinhamento com spec Figma |
| `border-default` | `#D1D5DB` | `#BABABA` | Spec Figma: bordas default light = #BABABA |
| `border-subtle` | `#E5E7EB` | `#BABABA` | Alinhamento com spec Figma |

## Novo token: `surface-selected`

Adicionado para representar o estado "selecionado" em breadcrumb e menu items:
- **dark:** `#323232` (mesmo valor de `surface` — continuidade visual)
- **light:** `#DADADA` (pill cinza do Figma para item ativo)

Classe Tailwind disponível: `bg-surface-selected`

## Refs

Refs #light-theme tasks 1 e 2

## Test plan

- [ ] Alternar para light mode e verificar que cards (HeroBanner, ProjectCard, StatCard) exibem fundo branco (`#FFFFFF`)
- [ ] Verificar que o fundo da página é `#F5F6FA`
- [ ] Verificar que textos primários são `#3E3E3E` e não `#1C1C1C`
- [ ] Verificar que bordas de inputs e separadores usam `#BABABA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)