### PR TITLE
feat(theme): fix body bg, input borders and skeleton colors for light mode

### DIFF
--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -61,7 +61,7 @@ export default async function RootLayout({
     <html dir="ltr" lang={locale}>
       <body
         className={classNames(
-          'flex flex-col h-screen antialiased dark:bg-dark overflow-x-clip',
+          'flex flex-col h-screen antialiased bg-surface-base overflow-x-clip',
           inter.className,
         )}
       >

--- a/apps/site/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx
@@ -1,17 +1,17 @@
 export function ExperiencesSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="h-px bg-gray-700 my-6" />
+      <div className="h-px bg-surface-raised my-6" />
       <ul className="flex flex-col gap-y-3">
         {(['exp-1', 'exp-2', 'exp-3'] as const).map((key) => (
           <li
             key={key}
             className="flex flex-col py-6 px-3 bg-surface-sunken rounded-xl gap-y-3"
           >
-            <div className="h-5 w-3/5 bg-gray-700 rounded" />
-            <div className="h-4 w-2/5 bg-gray-700 rounded" />
-            <div className="h-4 bg-gray-700 rounded w-full" />
-            <div className="h-4 bg-gray-700 rounded w-5/6" />
+            <div className="h-5 w-3/5 bg-surface-raised rounded" />
+            <div className="h-4 w-2/5 bg-surface-raised rounded" />
+            <div className="h-4 bg-surface-raised rounded w-full" />
+            <div className="h-4 bg-surface-raised rounded w-5/6" />
           </li>
         ))}
       </ul>

--- a/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
@@ -1,17 +1,17 @@
 export function ValuesSkeleton() {
   return (
     <div className="animate-pulse flex flex-col gap-y-6">
-      <div className="h-8 w-64 bg-gray-700 rounded" />
+      <div className="h-8 w-64 bg-surface-raised rounded" />
       <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
         {(['val-1', 'val-2', 'val-3', 'val-4'] as const).map((key) => (
           <li
             key={key}
             className="w-full border border-border-subtle px-4 py-6 rounded-xl bg-surface/20 flex flex-col gap-y-3"
           >
-            <div className="h-12 w-12 bg-gray-700 rounded" />
-            <div className="h-4 bg-gray-700 rounded w-full" />
-            <div className="h-4 bg-gray-700 rounded w-4/5" />
-            <div className="h-4 bg-gray-700 rounded w-3/5" />
+            <div className="h-12 w-12 bg-surface-raised rounded" />
+            <div className="h-4 bg-surface-raised rounded w-full" />
+            <div className="h-4 bg-surface-raised rounded w-4/5" />
+            <div className="h-4 bg-surface-raised rounded w-3/5" />
           </li>
         ))}
       </ul>

--- a/apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
@@ -2,16 +2,16 @@ export function ProjectsSkeleton() {
   return (
     <div className="animate-pulse">
       <div className="w-full flex justify-start my-6 lg:mx-auto lg:max-w-237.5">
-        <div className="h-8 w-32 bg-gray-700 rounded" />
+        <div className="h-8 w-32 bg-surface-raised rounded" />
       </div>
       <ul className="lg:mx-auto grid grid-cols-1 lg:grid-cols-2 max-w-237.5 gap-4 lg:gap-6 pb-8 lg:pb-20">
         {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
           <li key={key} className="bg-surface p-3 rounded-5">
-            <div className="h-45 lg:h-61 bg-gray-700 rounded-lg mb-4" />
-            <div className="h-5 w-3/4 bg-gray-700 rounded mb-2" />
-            <div className="h-4 bg-gray-700 rounded mb-1" />
-            <div className="h-4 w-5/6 bg-gray-700 rounded mb-5" />
-            <div className="h-10 bg-gray-700 rounded" />
+            <div className="h-45 lg:h-61 bg-surface-raised rounded-lg mb-4" />
+            <div className="h-5 w-3/4 bg-surface-raised rounded mb-2" />
+            <div className="h-4 bg-surface-raised rounded mb-1" />
+            <div className="h-4 w-5/6 bg-surface-raised rounded mb-5" />
+            <div className="h-10 bg-surface-raised rounded" />
           </li>
         ))}
       </ul>

--- a/apps/site/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
+++ b/apps/site/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
@@ -2,15 +2,15 @@ export function HeroBannerSkeleton() {
   return (
     <section className="animate-pulse flex flex-col bg-surface gap-y-6 lg:flex-row lg:rounded-xl lg:h-106">
       <div className="flex flex-col px-6 pb-6 lg:py-20 lg:pl-20 lg:w-1/2 gap-y-4">
-        <div className="h-8 w-48 bg-gray-700 rounded" />
-        <div className="h-8 w-64 bg-gray-700 rounded" />
+        <div className="h-8 w-48 bg-surface-raised rounded" />
+        <div className="h-8 w-64 bg-surface-raised rounded" />
         <div className="flex flex-col gap-y-2 pt-4">
-          <div className="h-4 bg-gray-700 rounded w-full" />
-          <div className="h-4 bg-gray-700 rounded w-5/6" />
-          <div className="h-4 bg-gray-700 rounded w-4/6" />
+          <div className="h-4 bg-surface-raised rounded w-full" />
+          <div className="h-4 bg-surface-raised rounded w-5/6" />
+          <div className="h-4 bg-surface-raised rounded w-4/6" />
         </div>
       </div>
-      <div className="lg:order-1 lg:w-1/2 bg-gray-700 lg:rounded-r-xl min-h-50" />
+      <div className="lg:order-1 lg:w-1/2 bg-surface-raised lg:rounded-r-xl min-h-50" />
     </section>
   );
 }

--- a/apps/site/tests/components/Control/Input/TextBase.test.tsx
+++ b/apps/site/tests/components/Control/Input/TextBase.test.tsx
@@ -16,7 +16,7 @@ describe('Text.Base', () => {
   it('should apply default border styling', () => {
     render(<Text.Base {...defaultProps} />);
     const input = screen.getByPlaceholderText('Enter text');
-    expect(input.className).toContain('border-content-disabled');
+    expect(input.className).toContain('border-border-default');
   });
 
   it('should apply error border when error and touched', () => {
@@ -51,6 +51,6 @@ describe('Text.Base', () => {
   it('should render without styling when unstyled', () => {
     render(<Text.Base {...defaultProps} unstyled />);
     const input = screen.getByPlaceholderText('Enter text');
-    expect(input.className).not.toContain('border-content-disabled');
+    expect(input.className).not.toContain('border-border-default');
   });
 });

--- a/packages/ui/src/Control/Text/Base/index.tsx
+++ b/packages/ui/src/Control/Text/Base/index.tsx
@@ -39,7 +39,7 @@ const Component: ForwardRefRenderFunction<
         type={isIn(type, ['text', 'email', 'password']) ? type : 'text'}
         className={classNames(
           {
-            'h-11 px-2 py-3 rounded-xl border border-content-disabled bg-transparent w-full text-sm text-content-primary placeholder:text-content-secondary focus:border-content-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-primary disabled:opacity-50 disabled:cursor-default':
+            'h-11 px-2 py-3 rounded-xl border border-border-default bg-transparent w-full text-sm text-content-primary placeholder:text-content-secondary focus:border-content-secondary [.light_&]:hover:border-content-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-primary disabled:opacity-50 disabled:cursor-default':
               !unstyled,
             '!border-error': hasError,
             '!border-success': hasSuccess,

--- a/packages/ui/src/Control/TextArea/Base/index.tsx
+++ b/packages/ui/src/Control/TextArea/Base/index.tsx
@@ -37,7 +37,7 @@ const Component: ForwardRefRenderFunction<
         {
           '!border-error': error && errorBorder && touched && !unstyled,
           '!border-accent': !error && errorBorder && touched && !unstyled,
-          'border border-content-disabled bg-surface h-12 rounded-xl p-3 w-full text-sm font-medium text-content-primary placeholder:font-normal placeholder:text-content-muted disabled:opacity-50 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-primary':
+          'border border-border-default bg-surface h-12 rounded-xl p-3 w-full text-sm font-medium text-content-primary placeholder:font-normal placeholder:text-content-muted [.light_&]:hover:border-content-secondary disabled:opacity-50 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-primary':
             !unstyled,
         },
         className,


### PR DESCRIPTION
## Summary

- **Task 3** — Body background: replace `dark:bg-dark` with `bg-surface-base` in `apps/site/src/app/[locale]/layout.tsx` so light mode gets `#F5F6FA` instead of browser default white
- **Task 7** — Input/TextArea borders: replace `border-content-disabled` with `border-border-default` (light: `#BABABA`); add `[.light_&]:hover:border-content-secondary` for the Figma-spec hover state; update `TextBase.test.tsx` to assert new class
- **Task 8** — Skeletons: replace `bg-gray-700` with `bg-surface-raised` in `HeroBannerSkeleton`, `ProjectsSkeleton`, `ExperiencesSkeleton`, and `ValuesSkeleton`

Refs #light-theme tasks 3, 7, 8

## Test plan

- [ ] Toggle to light mode — body background should be `#F5F6FA`, not white
- [ ] Hover over a text input in light mode — border should darken to `#555555`
- [ ] Default input border in light mode should be `#BABABA` (not `#A4A4A4`)
- [ ] Skeleton loading state (simulate slow network) — shimmer blocks should not appear dark-gray in light mode
- [ ] All 178 unit tests pass (`pnpm test`)
- [ ] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)