### PR TITLE
feat(theme): fix SideNavigation and Breadcrumb for light mode

### DIFF
--- a/apps/site/src/components/Layout/SideNavigation/LanguageSelector.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/LanguageSelector.tsx
@@ -57,7 +57,7 @@ export const LanguageSelector: FC = () => {
     <MenuItem.Item2.Expandable
       title={t('language')}
       icon="material-symbols:language"
-      iconClassName="text-white"
+      iconClassName="text-content-primary"
     >
       <RadioGroup
         name="language"

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx
@@ -6,6 +6,7 @@ import { Icon } from '@repo/ui/Imagery';
 import classNames from 'classnames';
 import { useLocale } from 'next-intl';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { Text } from '../Text';
 import { IGhostLinkProps } from '../types';
@@ -19,14 +20,26 @@ export const Item1: FC<IGhostLinkProps> = ({
   newTab = false,
 }) => {
   const locale = useLocale();
+  const pathname = usePathname();
   const localizedHref = href === '/' ? `/${locale}` : `/${locale}${href}`;
   const newHref = newTab ? href : localizedHref;
+
+  const isRoot = localizedHref === `/${locale}`;
+  const isActive =
+    !newTab &&
+    (isRoot
+      ? pathname === localizedHref
+      : pathname === localizedHref || pathname.startsWith(`${localizedHref}/`));
 
   return (
     <Link
       href={newHref}
+      aria-current={isActive ? 'page' : undefined}
       className={classNames(
-        'flex flex-row items-center justify-between hover:bg-surface active:bg-surface-sunken transition-all px-4 py-3 rounded-lg [&_span]:hover:font-bold [&_span]:active:font-bold [&_*]:active:!text-content-primary',
+        'flex flex-row items-center justify-between transition-all px-4 py-3 rounded-lg',
+        isActive
+          ? 'bg-brand-primary [&_span]:font-bold [&_*]:!text-white'
+          : 'hover:bg-surface active:bg-surface-sunken [&_span]:hover:font-bold [&_span]:active:font-bold [&_*]:active:!text-content-primary',
         className,
       )}
       target={newTab ? '_blank' : '_self'}
@@ -34,13 +47,26 @@ export const Item1: FC<IGhostLinkProps> = ({
     >
       <div className="flex flex-row items-center gap-x-4">
         <Icon
-          className={classNames('text-content-secondary', iconClassName)}
+          className={classNames(
+            isActive ? 'text-white' : 'text-content-secondary',
+            iconClassName,
+          )}
           icon={icon}
         />
-        <Text className="font-bold !text-content-secondary">{children}</Text>
+        <Text
+          className={classNames(
+            'font-bold',
+            isActive ? '!text-white' : '!text-content-secondary',
+          )}
+        >
+          {children}
+        </Text>
       </div>
       {newTab ? (
-        <Icon icon="material-symbols:open-in-new" className="text-dark-1000" />
+        <Icon
+          icon="material-symbols:open-in-new"
+          className="text-content-disabled"
+        />
       ) : null}
     </Link>
   );

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/Expandable/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/Expandable/index.tsx
@@ -29,11 +29,11 @@ export const Expandable: FC<IExpandableProps> = ({
           <Accordion.Header className="w-full cursor-pointer !px-4 !py-3">
             <Container>
               <Icon icon={icon} className={iconClassName} />
-              <Text className="!text-white">{title}</Text>
+              <Text className="!text-content-primary">{title}</Text>
             </Container>
             <Icon
               icon="material-symbols:arrow-drop-down"
-              className={classNames('text-dark-1000 transition-all', {
+              className={classNames('text-content-disabled transition-all', {
                 'rotate-180': expanded,
               })}
             />

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/Link/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/Link/index.tsx
@@ -28,9 +28,12 @@ export const Link: FC<IGhostLinkProps> = ({
     >
       <Container>
         <Icon className={iconClassName} icon={icon} />
-        <Text className="!text-white">{children}</Text>
+        <Text className="!text-content-primary">{children}</Text>
       </Container>
-      <Icon icon="material-symbols:open-in-new" className="text-dark-1000" />
+      <Icon
+        icon="material-symbols:open-in-new"
+        className="text-content-disabled"
+      />
     </NextLink>
   );
 };

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/constants.ts
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/constants.ts
@@ -1,2 +1,2 @@
 export const ROOT_STYLE =
-  'flex flex-row justify-between items-center px-4 py-3 border border-dark-400 rounded-xl transition-all hover:bg-dark-300';
+  'flex flex-row justify-between items-center px-4 py-3 border border-border-default rounded-xl transition-all hover:bg-surface-interactive';

--- a/apps/site/src/components/Layout/SideNavigation/ThemeToggle.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/ThemeToggle.tsx
@@ -56,7 +56,7 @@ export const ThemeToggle: FC = () => {
     <MenuItem.Item2.Expandable
       title={t('theme')}
       icon="material-symbols:contrast"
-      iconClassName="text-white"
+      iconClassName="text-content-primary"
     >
       <RadioGroup
         name="theme"

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -77,7 +77,7 @@ export const SideNavigation: FC = () => {
             <MenuItem.Item2.Link
               href={process.env.NEXT_PUBLIC_GITHUB_URL}
               icon="mdi:github"
-              iconClassName="text-white"
+              iconClassName="text-content-primary"
               newTab
             >
               {t('github')}
@@ -87,7 +87,7 @@ export const SideNavigation: FC = () => {
             <MenuItem.Item2.Link
               href="/feed.xml"
               icon="mdi:rss"
-              iconClassName="text-white"
+              iconClassName="text-content-primary"
               newTab
             >
               {t('rss')}

--- a/apps/site/src/features/shared/Breadcrumb/index.tsx
+++ b/apps/site/src/features/shared/Breadcrumb/index.tsx
@@ -27,11 +27,11 @@ export const Breadcrumb: FC<IBreadcrumbProps> = ({ items, className }) => (
             {i > 0 && (
               <Icon
                 icon="material-symbols:arrow-forward-ios"
-                className="!text-[20px] text-content-secondary [.light_&]:text-content-muted"
+                className="!text-[20px] text-content-muted"
               />
             )}
             {isLast ? (
-              <span className="px-3 py-1.5 rounded-lg text-sm text-content-primary bg-surface [.light_&]:bg-[#DADADA] [.light_&]:!text-content-secondary">
+              <span className="px-3 py-1.5 rounded-lg text-sm text-content-primary bg-surface-selected [.light_&]:!text-content-secondary">
                 {item.label}
               </span>
             ) : (


### PR DESCRIPTION
## Summary

- **Task 4** — Ghost links (`Item2`): replaced all hardcoded dark palette classes (`border-dark-400`, `hover:bg-dark-300`, `!text-white`, `text-dark-1000`) with semantic tokens (`border-border-default`, `hover:bg-surface-interactive`, `!text-content-primary`, `text-content-disabled`). Same fix applied to `ThemeToggle` and `LanguageSelector` expandable headers.
- **Task 5** — Active nav state (`Item1`): added `usePathname` to detect the active route; root uses exact match, sub-pages use `startsWith`. Active item gets `bg-brand-primary` + white text/icon; inactive items keep existing hover behavior. Added `aria-current="page"` for accessibility. Fixed external-link icon from `text-dark-1000` → `text-content-disabled`.
- **Task 6** — Breadcrumb: replaced `[.light_&]:bg-[#DADADA]` hardcoded hex with `bg-surface-selected`; separator icon now uses `text-content-muted` directly (same value in both themes, no need for the `[.light_&]:` variant).

Refs #light-theme tasks 4, 5, 6

## Test plan

- [ ] Switch to light mode — SideNavigation ghost links (LinkedIn, GitHub, RSS, ThemeToggle, LanguageSelector) should show a visible border (`#BABABA`) and a grey hover fill instead of invisible dark-on-dark
- [ ] Navigate between pages — active nav item (Home/Projects/About) should highlight with brand-purple background and white text in both dark and light modes
- [ ] Navigate to a project detail page — "Projects" nav item should remain highlighted (startsWith match)
- [ ] Open a project detail page — Breadcrumb active item should show `surface-selected` background (`#323232` dark / `#DADADA` light) without hardcoded hex
- [ ] All 178 unit tests pass (`pnpm test --filter site`)
- [ ] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)