### PR TITLE
fix(theme): replace remaining hardcoded colors for light mode (task 9)

### DIFF
--- a/apps/site/src/app/[locale]/not-found.tsx
+++ b/apps/site/src/app/[locale]/not-found.tsx
@@ -8,13 +8,15 @@ export default function NotFound() {
   const t = useTranslations('NotFound');
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-y-4 text-white">
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-y-4 text-content-primary">
       <h1 className="text-6xl font-bold">404</h1>
       <h2 className="text-2xl font-semibold">{t('title')}</h2>
-      <p className="text-dark-900 text-center max-w-sm">{t('description')}</p>
+      <p className="text-content-secondary text-center max-w-sm">
+        {t('description')}
+      </p>
       <Link
         href="/"
-        className="px-6 py-2 bg-white text-black rounded-lg font-medium hover:bg-gray-200 transition-colors"
+        className="px-6 py-2 bg-surface text-content-primary rounded-lg font-medium hover:bg-surface-interactive transition-colors"
       >
         {t('backToHome')}
       </Link>

--- a/apps/site/src/features/contact/ContactInfo/index.tsx
+++ b/apps/site/src/features/contact/ContactInfo/index.tsx
@@ -98,14 +98,14 @@ export const ContactInfo: FC = () => {
         <MenuItem.Item2.ShortLink
           href={process.env.NEXT_PUBLIC_GITHUB_URL}
           icon="mdi:github"
-          iconClassName="text-white"
+          iconClassName="text-content-primary"
           aria-label={t('github')}
           newTab
         />
         <MenuItem.Item2.ShortLink
           href="/feed.xml"
           icon="mdi:rss"
-          iconClassName="text-white"
+          iconClassName="text-content-primary"
           aria-label={t('rss')}
           newTab
         />

--- a/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -17,7 +17,7 @@ export async function ProjectsSection({
 
   return (
     <>
-      <h2 className="text-white my-6 !text-xl lg:block lg:mx-auto lg:my-8 lg:w-full lg:!text-[32px] lg:max-w-237.5">
+      <h2 className="text-content-primary my-6 !text-xl lg:block lg:mx-auto lg:my-8 lg:w-full lg:!text-[32px] lg:max-w-237.5">
         {t('projects_title')}
       </h2>
       <ProjectList projects={projects} compact className="pb-6" />

--- a/apps/site/src/features/shared/ErrorView/index.tsx
+++ b/apps/site/src/features/shared/ErrorView/index.tsx
@@ -12,12 +12,14 @@ export const ErrorView: FC<ErrorViewProps> = ({ reset }) => {
   const t = useTranslations('Error');
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-y-4 text-white">
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-y-4 text-content-primary">
       <h2 className="text-2xl font-semibold">{t('title')}</h2>
-      <p className="text-gray-400 text-center max-w-sm">{t('description')}</p>
+      <p className="text-content-muted text-center max-w-sm">
+        {t('description')}
+      </p>
       <button
         onClick={reset}
-        className="px-6 py-2 bg-white text-black rounded-lg font-medium hover:bg-gray-200 transition-colors"
+        className="px-6 py-2 bg-surface text-content-primary rounded-lg font-medium hover:bg-surface-interactive transition-colors"
       >
         {t('retry')}
       </button>


### PR DESCRIPTION
## Summary

Code audit identified 4 remaining hardcoded color usages that break light mode visibility:

- **HomeProjectsSection** — section heading `text-white` → `text-content-primary`
- **ContactInfo** — GitHub and RSS `ShortLink` icons `text-white` → `text-content-primary`
- **ErrorView** — container `text-white` → `text-content-primary`; description `text-gray-400` → `text-content-muted`; retry button `bg-white/text-black` → `bg-surface/text-content-primary/hover:bg-surface-interactive`
- **NotFound** — same pattern as ErrorView; `text-dark-900` → `text-content-secondary`

**Intentionally kept as-is:**
- `CurriculumCTA` CTA button: `bg-brand-primary text-white` — white on brand-purple is correct in both themes

Closes light-theme task 9

## Test plan

- [ ] Switch to light mode — home page "Projects" section heading visible (was white-on-white)
- [ ] Contact page — GitHub and RSS icon buttons show dark icons (not invisible white)
- [ ] Trigger an error state — error page text readable in light mode
- [ ] Navigate to a non-existent URL — 404 page text readable in light mode
- [ ] All 178 unit tests pass (`pnpm test --filter site`)
- [ ] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)