### PR TITLE
fix(perf): remove 'use client' from HeroBanner to fix LCP preload hint

### DIFF
--- a/apps/site/src/features/shared/HeroBanner/index.tsx
+++ b/apps/site/src/features/shared/HeroBanner/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { FC } from 'react';
 
 import classNames from 'classnames';


### PR DESCRIPTION
## Summary

- Removed unnecessary `'use client'` directive from `HeroBanner` component
- `HeroBanner` has no hooks, event handlers, or client-only APIs — it was mistakenly marked as a Client Component
- In Next.js App Router, `<Image priority>` only generates `<link rel="preload" fetchpriority="high">` in `<head>` from **Server Components**; in Client Components the preload hint is omitted even when `priority` is set

**Root cause of LCP 4.8s:** Lighthouse `lcp-discovery-insight` reported `priorityHinted: false`. The image was discoverable in the initial HTML and not lazy-loaded, but without `fetchpriority=high` on the preload request the browser deprioritized the hero image. FCP was 0.9s while LCP was 4.8s — a 3.9s gap explained by the missing preload hint.

**Expected impact:** With `HeroBanner` as a Server Component, Next.js will now emit `<link rel="preload" as="image" fetchpriority="high">` in `<head>`, allowing the browser to start fetching the LCP image immediately when HTML begins parsing — before any JS executes.

## Test plan

- [x] TypeScript check passes (`pnpm --filter site exec tsc --noEmit`)
- [x] All 178 tests pass
- [x] Production build succeeds (`turbo build`)
- [ ] Re-run Lighthouse after deploy to verify `priorityHinted: true` and LCP improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)