### PR TITLE
fix(perf): add explicit fetchpriority=high preload for hero LCP image

### DIFF
--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -6,6 +6,9 @@ import HeroLandingPage from '~assets/images/hero-landing-page.webp';
 import { HeroBanner } from '~features/shared/HeroBanner';
 import { StatCard } from '~features/shared/StatCard';
 
+const HERO_WIDTHS = [384, 640, 750, 828, 1080, 1200, 1920, 2048];
+const HERO_SIZES = '(max-width: 1280px) 100vw, 50vw';
+
 interface HeroSectionProps {
   locale: Locale;
   profile: ProfileDTO | null;
@@ -14,8 +17,25 @@ interface HeroSectionProps {
 export async function HeroSection({ locale, profile }: HeroSectionProps) {
   const t = await getTranslations({ locale, namespace: 'Home' });
 
+  const photoUrl = profile?.photo.url;
+  const preloadSrcSet = photoUrl
+    ? HERO_WIDTHS.map(
+        (w) =>
+          `/_next/image?url=${encodeURIComponent(photoUrl)}&w=${w}&q=100 ${w}w`,
+      ).join(', ')
+    : undefined;
+
   return (
     <>
+      {preloadSrcSet && (
+        <link
+          rel="preload"
+          as="image"
+          fetchPriority="high"
+          imageSrcSet={preloadSrcSet}
+          imageSizes={HERO_SIZES}
+        />
+      )}
       <HeroBanner
         src={profile?.photo.url ?? HeroLandingPage}
         title={profile?.name ?? t('hero_title')}

--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -2,12 +2,14 @@ import { type ProfileDTO } from '@repo/application/portfolio';
 import { type Locale } from '@repo/core/shared';
 import { getTranslations } from 'next-intl/server';
 
+import { screens } from '@repo/tailwind-config/screens';
+
 import HeroLandingPage from '~assets/images/hero-landing-page.webp';
 import { HeroBanner } from '~features/shared/HeroBanner';
 import { StatCard } from '~features/shared/StatCard';
 
 const HERO_WIDTHS = [384, 640, 750, 828, 1080, 1200, 1920, 2048];
-const HERO_SIZES = '(max-width: 1280px) 100vw, 50vw';
+const HERO_SIZES = `(max-width: ${screens.xl}) 100vw, 50vw`;
 
 interface HeroSectionProps {
   locale: Locale;


### PR DESCRIPTION
## Summary

- Adds a manual `<link rel="preload" fetchPriority="high">` in the `HeroSection` Server Component for the hero LCP image
- Next.js 16 generates `<link rel="preload" as="image" imageSrcSet="...">` from `<Image priority>` but **does not** emit `fetchpriority="high"` on the preload tag — Lighthouse flags this as `priorityHinted: false`
- React 19 hoists `<link>` elements rendered in Server Components to `<head>` automatically
- The preload includes the full `imageSrcSet` with all Next.js optimizer widths (`384w` → `2048w`) so the browser picks the right variant for the viewport

**Expected impact:** Lighthouse `lcp-discovery-insight` should show `priorityHinted: true`, allowing the browser to fetch the LCP image at `fetchpriority=high` from the very start of HTML parsing — before JS executes and before the `<img>` tag is reached.

## Test plan

- [x] TypeScript check passes
- [x] All 178 tests pass
- [x] Production build passes (pre-push hook)
- [ ] Verify `priorityHinted: true` in next Lighthouse run after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)