### PR TITLE
fix(perf): remove 'use client' from AppLayout to isolate Zod from critical bundle

### DIFF
--- a/apps/site/src/components/Layout/AppLayout/index.tsx
+++ b/apps/site/src/components/Layout/AppLayout/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { FC, PropsWithChildren } from 'react';
 
 import { ContactSection } from '~features/contact/ContactSection';


### PR DESCRIPTION
## Summary

- Removed unnecessary `'use client'` from `AppLayout` — it has no hooks, event handlers, or client-only APIs
- Root cause of 73KB of unused JS on every page: `AppLayout` (client) imported `ContactSection` statically, pulling `ContactForm` → `contact-schema.ts` → **Zod** into the main client bundle
- As a Server Component, Next.js creates isolated chunks for `SideNavigation` and `ContactSection`, keeping Zod out of the critical path

This is the same pattern applied to `HeroBanner` (PR #790) — removing accidental `'use client'` directives that cause unnecessary client bundle inflation.

## Expected impact

- ~73KB of Zod removed from the initial JS bundle loaded on every page
- TBT should decrease as less JS needs to be parsed on initial load

## Test plan

- [x] TypeScript check passes
- [x] All 178 tests pass
- [x] Production build passes (pre-push hook)
- [ ] Re-run Lighthouse after deploy to verify unused JS reduction and TBT improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)