### PR TITLE
fix(perf): lazy load ContactForm to remove Zod from critical bundle

### DIFF
--- a/apps/site/src/features/contact/ContactSection/index.tsx
+++ b/apps/site/src/features/contact/ContactSection/index.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { ContactForm } from '~features/contact/ContactForm';
+import dynamic from 'next/dynamic';
+
 import { ContactInfo } from '~features/contact/ContactInfo';
+
+const ContactForm = dynamic(
+  () => import('~features/contact/ContactForm').then((m) => m.ContactForm),
+  { ssr: false },
+);
 
 export function ContactSection() {
   return (

--- a/apps/site/tests/features/contact/ContactSection.test.tsx
+++ b/apps/site/tests/features/contact/ContactSection.test.tsx
@@ -3,7 +3,21 @@
  */
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next/dynamic', () => ({
+  default: (fn: () => Promise<React.FC>, _opts?: unknown) => {
+    const Lazy = React.lazy(async () => {
+      const Component = await fn();
+      return { default: Component };
+    });
+    return (props: Record<string, unknown>) => (
+      <React.Suspense fallback={null}>
+        <Lazy {...props} />
+      </React.Suspense>
+    );
+  },
+}));
 
 vi.mock('@repo/ui/View', () => ({
   Divider: () => <hr />,
@@ -24,7 +38,9 @@ describe('ContactSection', () => {
     );
     render(React.createElement(ContactSection));
 
-    expect(screen.getByTestId('contact-form')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId('contact-form')).toBeInTheDocument(),
+    );
     expect(screen.getByTestId('contact-info')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Applied `next/dynamic` with `ssr: false` to `ContactForm` inside `ContactSection`
- `ContactSection` is in the footer of every page — with a static import, `ContactForm → contact-schema → Zod` (73KB) was bundled into the main client chunk on initial paint
- `ContactInfo` (email, social links) remains eagerly loaded — only the heavy form with Zod + react-hook-form is deferred
- This is the surgical fix: applied at the component that owns the heavy dependency, not at the layout level

## Test plan

- [x] TypeScript check passes
- [x] All 178 tests pass — `ContactSection` test updated with `next/dynamic` mock using `React.lazy + Suspense + waitFor`
- [x] Production build passes
- [ ] Re-run Lighthouse after deploy to verify unused JS reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)