### PR TITLE
fix(hero-banner): refactor semantics, responsive sizing, and about page layout

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -30,7 +30,6 @@
     "view_all_projects": "View all projects",
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Software Engineer",
-    "hero_content": "Lorem ipsum odor amet, consectetuer adipiscing elit. Nisl ad dictumst donec consequat sollicitudin mauris. Id inceptos nibh varius; maecenas congue ullamcorper. Senectus massa tellus metus, nullam diam amet fringilla.",
     "hero_image_alt": "Professional Picture 1 of Wallace Ferreira"
   },
   "ProjectCard": {
@@ -80,13 +79,11 @@
   "Projects": {
     "hero_title": "Portfolio",
     "hero_caption": "Discover some of my projects",
-    "hero_content": "A selection of projects I've worked on — from product features to full-stack applications.",
     "hero_image_alt": "Professional Picture 1 of Wallace Ferreira"
   },
   "About": {
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Frontend Engineer · React · Next.js · TypeScript",
-    "hero_content": "Frontend engineer with over 6 years of experience building scalable web applications. Passionate about clean architecture, performance, and accessibility.",
     "hero_image_alt": "Wallace Ferreira — Frontend Engineer",
     "values_title": "My professional values"
   },

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -30,7 +30,6 @@
     "view_all_projects": "Ver todos los proyectos",
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Ingeniero de Software",
-    "hero_content": "Lorem ipsum odor amet, consectetuer adipiscing elit. Nisl ad dictumst donec consequat sollicitudin mauris. Id inceptos nibh varius; maecenas congue ullamcorper. Senectus massa tellus metus, nullam diam amet fringilla.",
     "hero_image_alt": "Foto profesional 1 de Wallace Ferreira"
   },
   "ProjectCard": {
@@ -80,13 +79,11 @@
   "Projects": {
     "hero_title": "Portafolio",
     "hero_caption": "Conoce algunos de mis proyectos",
-    "hero_content": "Una selección de proyectos en los que he trabajado — desde funcionalidades de producto hasta aplicaciones full-stack.",
     "hero_image_alt": "Foto profesional 1 de Wallace Ferreira"
   },
   "About": {
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Ingeniero Front-end · React · Next.js · TypeScript",
-    "hero_content": "Ingeniero front-end con más de 6 años de experiencia construyendo aplicaciones web escalables. Apasionado por la arquitectura limpia, el rendimiento y la accesibilidad.",
     "hero_image_alt": "Wallace Ferreira — Ingeniero Front-end",
     "values_title": "Mis valores profesionales"
   },

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -30,7 +30,6 @@
     "view_all_projects": "Ver todos os projetos",
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Engenheiro de Software",
-    "hero_content": "Lorem ipsum odor amet, consectetuer adipiscing elit. Nisl ad dictumst donec consequat sollicitudin mauris. Id inceptos nibh varius; maecenas congue ullamcorper. Senectus massa tellus metus, nullam diam amet fringilla.",
     "hero_image_alt": "Foto profissional 1 de Wallace Ferreira"
   },
   "ProjectCard": {
@@ -80,13 +79,11 @@
   "Projects": {
     "hero_title": "Portfólio",
     "hero_caption": "Conheça alguns dos meus projetos",
-    "hero_content": "Uma seleção de projetos em que trabalhei — de funcionalidades de produto a aplicações full-stack.",
     "hero_image_alt": "Foto profissional 1 de Wallace Ferreira"
   },
   "About": {
     "hero_title": "Wallace Ferreira",
     "hero_caption": "Engenheiro Front-end · React · Next.js · TypeScript",
-    "hero_content": "Engenheiro front-end com mais de 6 anos de experiência construindo aplicações web escaláveis. Apaixonado por arquitetura limpa, performance e acessibilidade.",
     "hero_image_alt": "Wallace Ferreira — Engenheiro Front-end",
     "values_title": "Meus valores profissionais"
   },

--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -1,5 +1,6 @@
 import { GetProfile } from '@repo/application/portfolio';
 import { type Locale, LOCALES } from '@repo/core/shared';
+import { Divider } from '@repo/ui/View';
 import type { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
@@ -51,9 +52,10 @@ export default async function About({ params }: AboutPageProps) {
   setRequestLocale(locale);
 
   return (
-    <div className="flex flex-col pb-10 lg:pb-20">
+    <div className="flex flex-col pb-10 xl:pb-16 2xl:pb-20">
       <HeroSection locale={locale} />
       <ValuesSection locale={locale} />
+      <Divider />
       <ExperiencesSection locale={locale} />
       <CurriculumCTA locale={locale} />
     </div>

--- a/apps/site/src/features/about/CurriculumCTA/index.tsx
+++ b/apps/site/src/features/about/CurriculumCTA/index.tsx
@@ -24,7 +24,7 @@ export async function CurriculumCTA({
   return (
     <section
       className={classNames(
-        'flex flex-col lg:flex-row items-center gap-6 lg:gap-14 bg-surface rounded-xl p-6 lg:p-8 shadow-drop-sm',
+        'flex flex-col lg:flex-row items-center gap-6 lg:gap-14 bg-surface rounded-xl mt-8 lg:mt-10 xl:mt-16 2xl:mt-20 p-6 lg:p-8 shadow-drop-sm',
         className,
       )}
     >

--- a/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
@@ -10,6 +10,7 @@ import { useBoolean } from 'usehooks-ts';
 
 import { SkillGroup } from '~features/shared/SkillGroup';
 import { useBreakpoint } from '~hooks';
+
 import {
   EMPLOYMENT_TYPE_ICONS,
   LOCATION_ICON,
@@ -86,7 +87,7 @@ export const ExperienceCard: FC<IExperienceCardProps> = ({
     LOCATION_TYPE_ICONS[locationType] ?? 'mdi:map-marker-outline';
 
   return (
-    <article className="flex flex-col gap-y-2 py-6">
+    <article className="flex flex-col gap-y-2">
       <h2 className="text-2xl font-bold text-content-primary">{position}</h2>
 
       <div className="flex flex-wrap items-baseline gap-x-2">

--- a/apps/site/src/features/about/ExperiencesSection/ExperiencesSection.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperiencesSection.tsx
@@ -1,5 +1,6 @@
 import { GetExperiences } from '@repo/application/portfolio';
 import { type Locale } from '@repo/core/shared';
+import classNames from 'classnames';
 
 import { getServerContainer } from '~/lib/server/container';
 
@@ -18,10 +19,16 @@ export async function ExperiencesSection({ locale }: { locale: Locale }) {
 
   return (
     <ul className="flex flex-col">
-      {experiences.map((experience) => (
+      {experiences.map((experience, i) => (
         <li
           key={experience.id}
-          className="border-b border-border-default last:border-b-0"
+          className={classNames(
+            'border-b border-border-default last:border-b-0 py-6',
+            {
+              'pt-0': i === 0,
+              'pb-0': i === experiences.length - 1,
+            },
+          )}
         >
           <ExperienceCard {...experience} />
         </li>

--- a/apps/site/src/features/about/HeroSection/index.tsx
+++ b/apps/site/src/features/about/HeroSection/index.tsx
@@ -17,13 +17,12 @@ export async function HeroSection({ locale }: { locale: Locale }) {
   return (
     <HeroBanner
       src={HeroAbout}
-      title={profile?.headline ?? t('hero_caption')}
-      caption={profile?.name ?? t('hero_title')}
-      content={profile?.bio ?? t('hero_content')}
+      title={profile?.name ?? t('hero_title')}
+      caption={profile?.headline ?? t('hero_caption')}
       alt={t('hero_image_alt')}
       titleSize="xl"
       titleAs="h1"
-      textColumnClassName="lg:w-[382px]"
+      textColumnClassName="lg:w-1/2"
       imageClassName="object-contain"
       className="shadow-drop-md"
     />

--- a/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
@@ -21,7 +21,7 @@ export async function ValuesSection({ locale }: { locale: Locale }) {
     valuesResult.isRight() ? valuesResult.value : [];
 
   return (
-    <section className="flex flex-col gap-y-6">
+    <section className="flex flex-col gap-y-4 mt-10 xl:mt-16 2xl:mt-20">
       <h2 className="text-[32px] font-bold text-content-primary text-left">
         {t('values_title')}
       </h2>

--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -42,7 +42,6 @@ export async function HeroSection({ locale, profile }: HeroSectionProps) {
         src={profile?.photo.url ?? HeroLandingPage}
         title={profile?.name ?? t('hero_title')}
         caption={profile?.headline ?? t('hero_caption')}
-        content={profile?.bio ?? t('hero_content')}
         alt={profile?.photo.alt ?? t('hero_image_alt')}
         titleSize="lg"
         titleAs="h1"

--- a/apps/site/src/features/projects/HeroSection/index.tsx
+++ b/apps/site/src/features/projects/HeroSection/index.tsx
@@ -12,7 +12,6 @@ export async function HeroSection({ locale }: { locale: Locale }) {
       src={HeroProjects}
       title={t('hero_title')}
       caption={t('hero_caption')}
-      content={t('hero_content')}
       alt={t('hero_image_alt')}
       titleAs="h1"
       imageClassName="object-contain p-6 lg:py-8"

--- a/apps/site/src/features/shared/HeroBanner/index.tsx
+++ b/apps/site/src/features/shared/HeroBanner/index.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 
+import { screens } from '@repo/tailwind-config/screens';
 import classNames from 'classnames';
 import Image, { StaticImageData } from 'next/image';
 
@@ -7,7 +8,6 @@ export interface IHeroBannerProps {
   src: string | StaticImageData;
   title: string;
   caption: string;
-  content: string;
   alt: string;
   titleSize?: 'lg' | 'xl';
   titleAs?: 'h1' | 'h2';
@@ -20,7 +20,6 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
   src,
   title,
   caption,
-  content,
   alt,
   titleSize = 'lg',
   titleAs: TitleTag = 'h2',
@@ -29,9 +28,9 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
   textColumnClassName = '',
 }) => {
   return (
-    <section
+    <div
       className={classNames(
-        'flex flex-col bg-surface gap-y-6 lg:flex-row lg:gap-x-8 lg:rounded-xl lg:h-106 2xl:-mx-[97px]',
+        'flex flex-col bg-surface gap-y-6 rounded-xl lg:flex-row lg:gap-x-8 lg:h-106 2xl:-mx-[97px]',
         className,
       )}
     >
@@ -43,31 +42,32 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
           quality={100}
           fill
           className={imageClassName}
-          sizes="(max-width: 1280px) 100vw, 50vw"
+          sizes={`(max-width: ${screens.xl}) 100vw, 50vw`}
         />
       </div>
       <div
         className={classNames(
-          'flex flex-col px-6 pb-6 lg:order-0 lg:py-20 lg:pl-20',
+          'flex flex-col justify-center overflow-hidden px-6 pb-6 lg:py-10 lg:pr-0 lg:order-0 xl:pl-10 2xl:pl-20',
           textColumnClassName,
         )}
       >
-        <p className="text-body-xl text-content-secondary pb-2">{title}</p>
         <TitleTag
           className={classNames(
-            'text-content-primary font-bold mb-8 line-clamp-2',
+            'text-content-primary font-bold mb-3 line-clamp-2',
             {
-              'text-[40px] leading-[56px]': titleSize === 'lg',
-              'text-5xl leading-[67.2px]': titleSize === 'xl',
+              'text-3xl leading-[42px] lg:text-[32px] lg:leading-[44.8px] 2xl:text-[40px] 2xl:leading-[56px]':
+                titleSize === 'lg',
+              'text-3xl leading-[42px] lg:text-4xl lg:leading-[50.4px] 2xl:text-5xl 2xl:leading-[67.2px]':
+                titleSize === 'xl',
             },
           )}
         >
-          {caption}
+          {title}
         </TitleTag>
-        <p className="text-body-sm text-content-primary line-clamp-3">
-          {content}
+        <p className="text-sm md:text-base lg:text-lg 2xl:text-2xl 2xl:leading-[33.6px] text-content-secondary">
+          {caption}
         </p>
       </div>
-    </section>
+    </div>
   );
 };

--- a/apps/site/tests/features/about/HeroSection.test.tsx
+++ b/apps/site/tests/features/about/HeroSection.test.tsx
@@ -62,10 +62,10 @@ describe('about/HeroSection', () => {
     render(await HeroSection({ locale: 'en-US' }));
 
     expect(screen.getByTestId('hero-title')).toHaveTextContent(
-      'Frontend Engineer',
+      'Wallace Ferreira',
     );
     expect(screen.getByTestId('hero-caption')).toHaveTextContent(
-      'Wallace Ferreira',
+      'Frontend Engineer',
     );
   });
 
@@ -75,9 +75,9 @@ describe('about/HeroSection', () => {
     const { HeroSection } = await import('~features/about/HeroSection');
     render(await HeroSection({ locale: 'en-US' }));
 
-    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_caption');
+    expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
     expect(screen.getByTestId('hero-caption')).toHaveTextContent(
-      't.hero_title',
+      't.hero_caption',
     );
   });
 


### PR DESCRIPTION
## Summary

- **Semântica corrigida**: `title` agora é o heading principal (`TitleTag`/h1/h2) e `caption` é o subtítulo (`<p>`); prop `content` removida por não fazer sentido no componente
- **Responsive font scale**: título escala de `text-3xl` (base) até o tamanho original em `2xl`; caption escala de `text-sm` (base) até `text-2xl` em `2xl`
- **`about/HeroSection`**: props estavam semanticamente invertidas — `name` era passado como `caption` e `headline` como `title`; corrigido e testes atualizados
- **About page**: Divider entre ValuesSection e ExperiencesSection, ajuste de espaçamentos e breakpoints

## Test plan

- [ ] Verificar HeroBanner nas páginas Home, About e Projects em mobile, md, lg e 2xl
- [ ] Confirmar hierarquia visual: título sempre maior que o caption em todos os BPs
- [ ] Confirmar que o nome aparece como heading e o headline como subtítulo na página About

🤖 Generated with [Claude Code](https://claude.com/claude-code)