### PR TITLE
feat(feed): add locale-specific RSS feeds and update RSS links

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -149,6 +149,9 @@
       "description": "Software projects developed by Wallace Ferreira — scalable web applications built with React, Next.js, and TypeScript."
     }
   },
+  "Feed": {
+    "description": "Frontend Software Engineer — scalable web applications built with React, Next.js, and TypeScript."
+  },
   "LoginForm": {
     "title": "Sign in",
     "emailPlaceholder": "Email address",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -149,6 +149,9 @@
       "description": "Proyectos de software desarrollados por Wallace Ferreira — aplicaciones web escalables con React, Next.js y TypeScript."
     }
   },
+  "Feed": {
+    "description": "Ingeniero de Software Frontend — aplicaciones web escalables con React, Next.js y TypeScript."
+  },
   "LoginForm": {
     "title": "Iniciar sesión",
     "emailPlaceholder": "Correo electrónico",

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -149,6 +149,9 @@
       "description": "Projetos de software desenvolvidos por Wallace Ferreira — aplicações web escaláveis com React, Next.js e TypeScript."
     }
   },
+  "Feed": {
+    "description": "Engenheiro de Software Frontend — aplicações web escaláveis com React, Next.js e TypeScript."
+  },
   "LoginForm": {
     "title": "Entrar",
     "emailPlaceholder": "Endereço de e-mail",

--- a/apps/site/src/app/[locale]/feed.xml/route.ts
+++ b/apps/site/src/app/[locale]/feed.xml/route.ts
@@ -1,20 +1,13 @@
 import { GetPublishedProjects } from '@repo/application/portfolio';
 import { LOCALES } from '@repo/core/shared';
 import type { Locale } from '@repo/core/shared';
+import { getTranslations } from 'next-intl/server';
 
 import { getServerContainer } from '~/lib/server/container';
 
 export const dynamic = 'force-static';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
-
-const CHANNEL_DESCRIPTION: Record<string, string> = {
-  'en-US':
-    'Frontend Software Engineer — scalable web applications built with React, Next.js, and TypeScript.',
-  'pt-BR':
-    'Engenheiro de Software Frontend — aplicações web escaláveis com React, Next.js e TypeScript.',
-  es: 'Ingeniero de Software Frontend — aplicaciones web escalables con React, Next.js y TypeScript.',
-};
 
 function escapeXml(value: string): string {
   return value
@@ -34,6 +27,7 @@ export async function GET(
   { params }: { params: Promise<{ locale: string }> },
 ): Promise<Response> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Feed' });
   const { projectRepository, skillRepository } = getServerContainer();
 
   const result = await new GetPublishedProjects(
@@ -43,8 +37,7 @@ export async function GET(
 
   const projects = result.isRight() ? result.value : [];
 
-  const description =
-    CHANNEL_DESCRIPTION[locale] ?? CHANNEL_DESCRIPTION['en-US'] ?? '';
+  const description = t('description');
 
   const items = projects
     .map(

--- a/apps/site/src/app/[locale]/feed.xml/route.ts
+++ b/apps/site/src/app/[locale]/feed.xml/route.ts
@@ -1,0 +1,79 @@
+import { GetPublishedProjects } from '@repo/application/portfolio';
+import { LOCALES } from '@repo/core/shared';
+import type { Locale } from '@repo/core/shared';
+
+import { getServerContainer } from '~/lib/server/container';
+
+export const dynamic = 'force-static';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
+const CHANNEL_DESCRIPTION: Record<string, string> = {
+  'en-US':
+    'Frontend Software Engineer — scalable web applications built with React, Next.js, and TypeScript.',
+  'pt-BR':
+    'Engenheiro de Software Frontend — aplicações web escaláveis com React, Next.js e TypeScript.',
+  es: 'Ingeniero de Software Frontend — aplicaciones web escalables con React, Next.js y TypeScript.',
+};
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function generateStaticParams() {
+  return LOCALES.map((locale) => ({ locale }));
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ locale: string }> },
+): Promise<Response> {
+  const { locale } = await params;
+  const { projectRepository, skillRepository } = getServerContainer();
+
+  const result = await new GetPublishedProjects(
+    projectRepository,
+    skillRepository,
+  ).execute({ locale: locale as Locale });
+
+  const projects = result.isRight() ? result.value : [];
+
+  const description =
+    CHANNEL_DESCRIPTION[locale] ?? CHANNEL_DESCRIPTION['en-US'] ?? '';
+
+  const items = projects
+    .map(
+      (p) => `
+    <item>
+      <title>${escapeXml(p.title)}</title>
+      <link>${SITE_URL}/${locale}/projects/${escapeXml(p.slug)}</link>
+      <description>${escapeXml(p.caption)}</description>
+      <guid isPermaLink="true">${SITE_URL}/${locale}/projects/${escapeXml(p.slug)}</guid>
+    </item>`,
+    )
+    .join('');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Wallace Ferreira</title>
+    <link>${SITE_URL}/${locale}</link>
+    <description>${escapeXml(description)}</description>
+    <language>${locale}</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${SITE_URL}/${locale}/feed.xml" rel="self" type="application/rss+xml"/>
+    ${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+}

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -15,32 +15,42 @@ const inter = Inter({ subsets: ['latin'], display: 'swap' });
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
-export const metadata: Metadata = {
-  metadataBase: new URL(SITE_URL),
-  title: {
-    default: 'Wallace Ferreira',
-    template: '%s | Wallace Ferreira',
-  },
-  description:
-    'Frontend Software Engineer with 6+ years of experience building scalable, performant, and accessible web products with React, Next.js, and TypeScript.',
-  openGraph: {
-    type: 'website',
-    siteName: 'Wallace Ferreira',
-    images: [
-      { url: 'https://github.com/wallace-sf.png', alt: 'Wallace Ferreira' },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-  },
-  alternates: {
-    types: {
-      'application/rss+xml': [
-        { url: `${SITE_URL}/feed.xml`, title: 'Wallace Ferreira' },
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    metadataBase: new URL(SITE_URL),
+    title: {
+      default: 'Wallace Ferreira',
+      template: '%s | Wallace Ferreira',
+    },
+    description:
+      'Frontend Software Engineer with 6+ years of experience building scalable, performant, and accessible web products with React, Next.js, and TypeScript.',
+    openGraph: {
+      type: 'website',
+      siteName: 'Wallace Ferreira',
+      images: [
+        { url: 'https://github.com/wallace-sf.png', alt: 'Wallace Ferreira' },
       ],
     },
-  },
-};
+    twitter: {
+      card: 'summary_large_image',
+    },
+    alternates: {
+      types: {
+        'application/rss+xml': [
+          {
+            url: `${SITE_URL}/${locale}/feed.xml`,
+            title: 'Wallace Ferreira',
+          },
+        ],
+      },
+    },
+  };
+}
 
 export function generateStaticParams() {
   return LOCALES.map((locale) => ({ locale }));

--- a/apps/site/src/app/feed.xml/route.ts
+++ b/apps/site/src/app/feed.xml/route.ts
@@ -1,73 +1,9 @@
-import { GetPublishedProjects } from '@repo/application/portfolio';
-import { LOCALES } from '@repo/core/shared';
-
 import { DEFAULT_LOCALE } from '~/i18n/routing';
-import { getServerContainer } from '~/lib/server/container';
 
 export const dynamic = 'force-static';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
-const CHANNEL_DESCRIPTION: Record<string, string> = {
-  'en-US':
-    'Frontend Software Engineer — scalable web applications built with React, Next.js, and TypeScript.',
-  'pt-BR':
-    'Engenheiro de Software Frontend — aplicações web escaláveis com React, Next.js e TypeScript.',
-  es: 'Ingeniero de Software Frontend — aplicaciones web escalables con React, Next.js y TypeScript.',
-};
-
-function escapeXml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
-
-export async function GET(): Promise<Response> {
-  const { projectRepository, skillRepository } = getServerContainer();
-
-  const projectsByLocale = await Promise.all(
-    LOCALES.map(async (locale) => {
-      const result = await new GetPublishedProjects(
-        projectRepository,
-        skillRepository,
-      ).execute({ locale });
-      return { locale, projects: result.isRight() ? result.value : [] };
-    }),
-  );
-
-  const items = projectsByLocale
-    .flatMap(({ locale, projects }) =>
-      projects.map(
-        (p) => `
-    <item xml:lang="${locale}">
-      <title>${escapeXml(p.title)}</title>
-      <link>${SITE_URL}/${locale}/projects/${escapeXml(p.slug)}</link>
-      <description>${escapeXml(p.caption)}</description>
-      <guid isPermaLink="true">${SITE_URL}/${locale}/projects/${escapeXml(p.slug)}</guid>
-    </item>`,
-      ),
-    )
-    .join('');
-
-  const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>Wallace Ferreira</title>
-    <link>${SITE_URL}</link>
-    <description>${CHANNEL_DESCRIPTION[DEFAULT_LOCALE]}</description>
-    <language>${DEFAULT_LOCALE}</language>
-    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
-    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
-    ${items}
-  </channel>
-</rss>`;
-
-  return new Response(xml, {
-    headers: {
-      'Content-Type': 'application/xml; charset=utf-8',
-    },
-  });
+export function GET(): Response {
+  return Response.redirect(`${SITE_URL}/${DEFAULT_LOCALE}/feed.xml`, 301);
 }

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react';
 
 import { Divider } from '@repo/ui/View';
 import classNames from 'classnames';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { useBoolean, useScrollLock } from 'usehooks-ts';
 
 import { useBreakpoint } from '~hooks';
@@ -16,6 +16,7 @@ import { ThemeToggle } from './ThemeToggle';
 
 export const SideNavigation: FC = () => {
   const t = useTranslations('SideNavigation');
+  const locale = useLocale();
   const isDesktop = useBreakpoint('lg');
   const { value: open, toggle } = useBoolean(false);
   const isOpen = !isDesktop && open;
@@ -85,7 +86,7 @@ export const SideNavigation: FC = () => {
           </li>
           <li>
             <MenuItem.Item2.Link
-              href="/feed.xml"
+              href={`/${locale}/feed.xml`}
               icon="mdi:rss"
               iconClassName="text-content-primary"
               newTab

--- a/apps/site/src/features/contact/ContactInfo/index.tsx
+++ b/apps/site/src/features/contact/ContactInfo/index.tsx
@@ -6,13 +6,14 @@ import { Button } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
 import { Divider } from '@repo/ui/View';
 import { formatCellphone } from '@repo/utils';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { MenuItem } from '~/components/Layout/SideNavigation/MenuItem';
 
 export const ContactInfo: FC = () => {
   const t = useTranslations('ContactInfo');
   const tClip = useTranslations('Clipboard');
+  const locale = useLocale();
   const whatsappUrl = `https://wa.me/${process.env.NEXT_PUBLIC_CONTACT_NUMBER}?text=${encodeURIComponent(t('whatsappMessage'))}`;
 
   return (
@@ -103,7 +104,7 @@ export const ContactInfo: FC = () => {
           newTab
         />
         <MenuItem.Item2.ShortLink
-          href="/feed.xml"
+          href={`/${locale}/feed.xml`}
           icon="mdi:rss"
           iconClassName="text-content-primary"
           aria-label={t('rss')}


### PR DESCRIPTION
## Summary

- **`/[locale]/feed.xml`**: nova rota estática gerada para `en-US`, `pt-BR` e `es`. Cada feed contém apenas itens do seu locale, com `<language>` e `<link>` corretos.
- **`/feed.xml`**: agora retorna `301` redirect para `/${DEFAULT_LOCALE}/feed.xml` (backward compatibility).
- **`SideNavigation` e `ContactInfo`**: botões de RSS usam `useLocale()` para linkar para `/${locale}/feed.xml`.
- **`[locale]/layout.tsx`**: convertido de `metadata` estático para `generateMetadata` dinâmico, apontando `<link rel="alternate" type="application/rss+xml">` para o feed do locale atual.

## Test plan

- [ ] `/en-US/feed.xml` retorna feed em inglês com `<language>en-US</language>`
- [ ] `/pt-BR/feed.xml` retorna feed em português com `<language>pt-BR</language>`
- [ ] `/es/feed.xml` retorna feed em espanhol com `<language>es</language>`
- [ ] `/feed.xml` redireciona 301 para `/en-US/feed.xml`
- [ ] Botão RSS na SideNavigation linka para `/${locale}/feed.xml`
- [ ] `<head>` da página contém `<link rel="alternate" type="application/rss+xml" href="/${locale}/feed.xml">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)