### PR TITLE
fix(metadata): internationalize layout base description

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -141,6 +141,9 @@
     "period_label": "Period"
   },
   "Metadata": {
+    "Layout": {
+      "description": "Frontend Software Engineer with 6+ years of experience building scalable, performant, and accessible web products with React, Next.js, and TypeScript."
+    },
     "AboutPage": {
       "title": "About"
     },

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -141,6 +141,9 @@
     "period_label": "Período"
   },
   "Metadata": {
+    "Layout": {
+      "description": "Ingeniero de Software Frontend con más de 6 años de experiencia construyendo productos web escalables, eficientes y accesibles con React, Next.js y TypeScript."
+    },
     "AboutPage": {
       "title": "Sobre"
     },

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -141,6 +141,9 @@
     "period_label": "Período"
   },
   "Metadata": {
+    "Layout": {
+      "description": "Engenheiro de Software Frontend com mais de 6 anos de experiência construindo produtos web escaláveis, performáticos e acessíveis com React, Next.js e TypeScript."
+    },
     "AboutPage": {
       "title": "Sobre"
     },

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -2,7 +2,7 @@ import { LOCALES } from '@repo/core/shared';
 import classNames from 'classnames';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
-import { getMessages, setRequestLocale } from 'next-intl/server';
+import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
 import { Inter } from 'next/font/google';
 
 import { AppLayout } from '~components';
@@ -21,14 +21,14 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Metadata' });
   return {
     metadataBase: new URL(SITE_URL),
     title: {
       default: 'Wallace Ferreira',
       template: '%s | Wallace Ferreira',
     },
-    description:
-      'Frontend Software Engineer with 6+ years of experience building scalable, performant, and accessible web products with React, Next.js, and TypeScript.',
+    description: t('Layout.description'),
     openGraph: {
       type: 'website',
       siteName: 'Wallace Ferreira',


### PR DESCRIPTION
## Summary

A auditoria de metatags identificou um único campo sem internacionalização: a `description` no `generateMetadata` do layout base (`[locale]/layout.tsx`), que estava hardcoded em inglês.

**Mudanças:**
- Adiciona `Metadata.Layout.description` nos três arquivos de mensagens (`en-US`, `pt-BR`, `es`)
- `generateMetadata` no layout usa `getTranslations({ locale, namespace: 'Metadata' })` para ler a descrição traduzida

**Todos os outros campos já estavam internacionalizados:**
- `[locale]/page.tsx` — dados do banco via `GetProfile` com locale ✅
- `[locale]/about/page.tsx` — `Metadata.AboutPage` + bio do banco ✅
- `[locale]/projects/page.tsx` — `Metadata.ProjectsPage` ✅
- `[locale]/projects/[slug]/page.tsx` — dados do banco via `GetProjectBySlug` com locale ✅

## Test plan

- [ ] `<meta name="description">` em `/en-US` exibe texto em inglês
- [ ] `<meta name="description">` em `/pt-BR` exibe texto em português
- [ ] `<meta name="description">` em `/es` exibe texto em espanhol

🤖 Generated with [Claude Code](https://claude.com/claude-code)