### PR TITLE
feat(seo): add localized Home title to home page metadata

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -144,6 +144,9 @@
     "Layout": {
       "description": "Frontend Software Engineer with 6+ years of experience building scalable, performant, and accessible web products with React, Next.js, and TypeScript."
     },
+    "HomePage": {
+      "title": "Home"
+    },
     "AboutPage": {
       "title": "About"
     },

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -144,6 +144,9 @@
     "Layout": {
       "description": "Ingeniero de Software Frontend con más de 6 años de experiencia construyendo productos web escalables, eficientes y accesibles con React, Next.js y TypeScript."
     },
+    "HomePage": {
+      "title": "Inicio"
+    },
     "AboutPage": {
       "title": "Sobre"
     },

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -144,6 +144,9 @@
     "Layout": {
       "description": "Engenheiro de Software Frontend com mais de 6 anos de experiência construindo produtos web escaláveis, performáticos e acessíveis com React, Next.js e TypeScript."
     },
+    "HomePage": {
+      "title": "Início"
+    },
     "AboutPage": {
       "title": "Sobre"
     },

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -2,7 +2,11 @@ import { LOCALES } from '@repo/core/shared';
 import classNames from 'classnames';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
-import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
+import {
+  getMessages,
+  getTranslations,
+  setRequestLocale,
+} from 'next-intl/server';
 import { Inter } from 'next/font/google';
 
 import { AppLayout } from '~components';

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import { GetFeaturedProjects, GetProfile } from '@repo/application/portfolio';
 import { type Locale, LOCALES } from '@repo/core/shared';
 import type { Metadata } from 'next';
-import { setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
@@ -22,16 +22,18 @@ export async function generateMetadata({
   const locale = ((await params)?.locale ?? DEFAULT_LOCALE) as Locale;
   setRequestLocale(locale);
 
+  const t = await getTranslations({ locale, namespace: 'Metadata' });
+
   const profileResult = await new GetProfile(
     getServerContainer().profileRepository,
   ).execute({ locale });
 
-  if (profileResult.isLeft()) return {};
+  if (profileResult.isLeft()) return { title: t('HomePage.title') };
 
   const { name, headline, photo } = profileResult.value;
 
   return {
-    title: name,
+    title: t('HomePage.title'),
     description: headline,
     openGraph: {
       title: name,


### PR DESCRIPTION
## Summary

- Home page was setting `title: name` (the profile name "Wallace Ferreira"), which with the template `%s | Wallace Ferreira` produced "Wallace Ferreira | Wallace Ferreira" in the browser tab
- Now uses a translated `Metadata.HomePage.title` key — "Home" / "Início" / "Inicio" per locale — so the tab shows "Home | Wallace Ferreira"
- OG title still uses the profile name for social sharing previews

## Test plan

- [ ] Visit `/en-US`, `/pt-BR`, `/es` and confirm tab title shows "Home | Wallace Ferreira", "Início | Wallace Ferreira", "Inicio | Wallace Ferreira"
- [ ] Confirm About, Projects, and project detail pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)