### PR TITLE
fix(seo): use absolute title on home page to bypass layout template

### DIFF
--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -28,12 +28,13 @@ export async function generateMetadata({
     getServerContainer().profileRepository,
   ).execute({ locale });
 
-  if (profileResult.isLeft()) return { title: t('HomePage.title') };
+  if (profileResult.isLeft())
+    return { title: { absolute: `${t('HomePage.title')} | Wallace Ferreira` } };
 
   const { name, headline, photo } = profileResult.value;
 
   return {
-    title: t('HomePage.title'),
+    title: { absolute: `${t('HomePage.title')} | Wallace Ferreira` },
     description: headline,
     openGraph: {
       title: name,


### PR DESCRIPTION
## Summary

- O Next.js só aplica o `template` do layout a segmentos filhos (`/about`, `/projects`). A home page, estando no mesmo segmento do layout, não recebia o template e exibia apenas "Home".
- Corrigido usando `title: { absolute: '...' }` para montar o título completo diretamente: "Home | Wallace Ferreira", "Início | Wallace Ferreira", "Inicio | Wallace Ferreira".

## Test plan

- [ ] Acessar `/en-US` e confirmar título "Home | Wallace Ferreira" na aba
- [ ] Acessar `/pt-BR` e confirmar "Início | Wallace Ferreira"
- [ ] Acessar `/es` e confirmar "Inicio | Wallace Ferreira"
- [ ] Confirmar que About, Projects e projeto detalhe continuam sem regressão

🤖 Generated with [Claude Code](https://claude.com/claude-code)