### PR TITLE
feat(seo): dynamic OG image generation via /og route

### DIFF
--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -11,6 +11,8 @@ import { ExperiencesSection } from '~features/about/ExperiencesSection';
 import { HeroSection } from '~features/about/HeroSection';
 import { ValuesSection } from '~features/about/ValuesSection';
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
 export function generateStaticParams() {
   return LOCALES.map((locale) => ({ locale }));
 }
@@ -36,13 +38,18 @@ export async function generateMetadata({
 
   const { bio, photo } = profileResult.value;
 
+  const ogUrl = new URL('/og', SITE_URL);
+  ogUrl.searchParams.set('title', title);
+  if (bio) ogUrl.searchParams.set('description', bio);
+  if (photo?.url) ogUrl.searchParams.set('image', photo.url);
+
   return {
     title,
     description: bio,
     openGraph: {
       title,
       description: bio,
-      images: [{ url: photo.url, alt: photo.alt }],
+      images: [{ url: ogUrl.toString(), width: 1200, height: 630, alt: title }],
     },
   };
 }

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -37,7 +37,12 @@ export async function generateMetadata({
       type: 'website',
       siteName: 'Wallace Ferreira',
       images: [
-        { url: 'https://github.com/wallace-sf.png', alt: 'Wallace Ferreira' },
+        {
+          url: '/og',
+          width: 1200,
+          height: 630,
+          alt: 'Wallace Ferreira',
+        },
       ],
     },
     twitter: {

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -8,6 +8,8 @@ import { getServerContainer } from '~/lib/server/container';
 import { HeroSection } from '~features/home/HeroSection';
 import { ProjectsSection } from '~features/home/ProjectsSection';
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
 export function generateStaticParams() {
   return LOCALES.map((locale) => ({ locale }));
 }
@@ -33,13 +35,18 @@ export async function generateMetadata({
 
   const { name, headline, photo } = profileResult.value;
 
+  const ogUrl = new URL('/og', SITE_URL);
+  ogUrl.searchParams.set('title', name);
+  if (headline) ogUrl.searchParams.set('description', headline);
+  if (photo?.url) ogUrl.searchParams.set('image', photo.url);
+
   return {
     title: { absolute: `${t('HomePage.title')} | Wallace Ferreira` },
     description: headline,
     openGraph: {
       title: name,
       description: headline,
-      images: [{ url: photo.url, alt: photo.alt }],
+      images: [{ url: ogUrl.toString(), width: 1200, height: 630, alt: name }],
     },
   };
 }

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -1,0 +1,188 @@
+import { ImageResponse } from 'next/og';
+import { type NextRequest } from 'next/server';
+
+export const runtime = 'edge';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const title = searchParams.get('title') ?? 'Wallace Ferreira';
+  const description = searchParams.get('description') ?? '';
+  const imageUrl = searchParams.get('image') ?? '';
+
+  return new ImageResponse(
+    <div
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#1C1C1C',
+        fontFamily: 'Inter, sans-serif',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Accent stripe */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: 8,
+          height: '100%',
+          backgroundColor: '#8efb9d',
+        }}
+      />
+
+      {/* Decorative circle — top-right (only when no image) */}
+      {!imageUrl && (
+        <div
+          style={{
+            position: 'absolute',
+            top: -120,
+            right: -120,
+            width: 420,
+            height: 420,
+            borderRadius: '50%',
+            backgroundColor: '#4452ff',
+            opacity: 0.12,
+          }}
+        />
+      )}
+
+      {/* Profile image — right side */}
+      {imageUrl && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            width: 420,
+            height: '100%',
+            display: 'flex',
+          }}
+        >
+          {/* Gradient overlay so text stays readable */}
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: 160,
+              height: '100%',
+              background:
+                'linear-gradient(to right, #1C1C1C 0%, transparent 100%)',
+              zIndex: 1,
+            }}
+          />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt=""
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              objectPosition: 'center top',
+            }}
+          />
+        </div>
+      )}
+
+      {/* Content */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '64px 80px',
+          width: imageUrl ? 780 : '100%',
+          height: '100%',
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              backgroundColor: '#8efb9d',
+            }}
+          />
+          <span
+            style={{
+              color: '#8efb9d',
+              fontSize: 18,
+              fontWeight: 600,
+              letterSpacing: '0.05em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Wallace Ferreira
+          </span>
+        </div>
+
+        {/* Main content */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+          <div
+            style={{
+              color: '#d9d9d9',
+              fontSize: title.length > 40 ? 52 : 64,
+              fontWeight: 700,
+              lineHeight: 1.1,
+              letterSpacing: '-0.02em',
+              maxWidth: imageUrl ? 680 : 900,
+            }}
+          >
+            {title}
+          </div>
+          {description && (
+            <div
+              style={{
+                color: '#8d8d8d',
+                fontSize: 26,
+                fontWeight: 400,
+                lineHeight: 1.5,
+                maxWidth: imageUrl ? 640 : 820,
+              }}
+            >
+              {description}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <span style={{ color: '#494949', fontSize: 18 }}>
+            {SITE_URL.replace(/^https?:\/\//, '')}
+          </span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              backgroundColor: '#282828',
+              borderRadius: 12,
+              padding: '10px 20px',
+            }}
+          >
+            <span style={{ color: '#a4a4a4', fontSize: 16 }}>
+              Software Engineer
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>,
+    {
+      width: 1200,
+      height: 630,
+    },
+  );
+}

--- a/apps/site/src/proxy.ts
+++ b/apps/site/src/proxy.ts
@@ -12,7 +12,7 @@ export default function middleware(request: NextRequest): NextResponse {
 export const config = {
   matcher: [
     '/',
-    '/((?!api|_next|_vercel|.*\\..*).*)',
+    '/((?!api|og|_next|_vercel|.*\\..*).*)',
     '/(en-US|es|pt-BR)/:path*',
   ],
 };


### PR DESCRIPTION
## Summary

- Add Edge route `/og` that generates 1200×630 PNG cards using `next/og` (`ImageResponse`)
- Accepts `?title`, `?description`, and `?image` query params
- Renders the provided image in the right column with a dark gradient overlay when `?image` is present; falls back to a decorative circle when omitted
- Exclude `/og` from the `next-intl` middleware matcher to prevent locale redirect
- Wire **home page** OG image to `/og` with `name`, `headline`, and `photo.url` from profile
- Wire **about page** OG image to `/og` with `title`, `bio`, and `photo.url` from profile
- Layout fallback OG image points to `/og` (text-only card)
- **Project detail pages** keep `coverImage.url` directly — no `/og` route needed

## Test plan

- [ ] `GET /og` returns `image/png` with status 200
- [ ] `GET /og?title=...&description=...&image=<url>` renders image on the right column
- [ ] `GET /og` (no params) renders text-only card with decorative circle
- [ ] Home and About page `<meta property="og:image">` point to the `/og` route
- [ ] Project detail `<meta property="og:image">` points directly to `coverImage.url`
- [ ] `/og` is not intercepted by the locale middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)