### PR TITLE
feat(seo): add dynamic OG image generation via /og route

### DIFF
--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata({
 
   if (profileResult.isLeft()) return { title };
 
-  const { bio, photo } = profileResult.value;
+  const { bio } = profileResult.value;
 
   return {
     title,
@@ -45,7 +45,12 @@ export async function generateMetadata({
       description: bio,
       images: [
         {
-          url: buildOgImageUrl({ title, description: bio, image: photo?.url }),
+          url: buildOgImageUrl({
+            title,
+            subtitle: bio,
+            locale,
+            page: 'ABOUT',
+          }),
           width: 1200,
           height: 630,
           alt: title,

--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -5,13 +5,12 @@ import type { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { DEFAULT_LOCALE } from '~/i18n/routing';
+import { buildOgImageUrl } from '~/lib/og';
 import { getServerContainer } from '~/lib/server/container';
 import { CurriculumCTA } from '~features/about/CurriculumCTA';
 import { ExperiencesSection } from '~features/about/ExperiencesSection';
 import { HeroSection } from '~features/about/HeroSection';
 import { ValuesSection } from '~features/about/ValuesSection';
-
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
 export function generateStaticParams() {
   return LOCALES.map((locale) => ({ locale }));
@@ -38,18 +37,20 @@ export async function generateMetadata({
 
   const { bio, photo } = profileResult.value;
 
-  const ogUrl = new URL('/og', SITE_URL);
-  ogUrl.searchParams.set('title', title);
-  if (bio) ogUrl.searchParams.set('description', bio);
-  if (photo?.url) ogUrl.searchParams.set('image', photo.url);
-
   return {
     title,
     description: bio,
     openGraph: {
       title,
       description: bio,
-      images: [{ url: ogUrl.toString(), width: 1200, height: 630, alt: title }],
+      images: [
+        {
+          url: buildOgImageUrl({ title, description: bio, image: photo?.url }),
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
     },
   };
 }

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -10,14 +10,13 @@ import {
 import { Inter } from 'next/font/google';
 
 import { AppLayout } from '~components';
+import { SITE_URL } from '~/lib/og';
 
 import '@repo/tailwind-config/tailwind.css';
 import '@repo/ui/globals.css';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'], display: 'swap' });
-
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
 export async function generateMetadata({
   params,

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -9,8 +9,8 @@ import {
 } from 'next-intl/server';
 import { Inter } from 'next/font/google';
 
-import { AppLayout } from '~components';
 import { SITE_URL } from '~/lib/og';
+import { AppLayout } from '~components';
 
 import '@repo/tailwind-config/tailwind.css';
 import '@repo/ui/globals.css';

--- a/apps/site/src/app/[locale]/not-found.tsx
+++ b/apps/site/src/app/[locale]/not-found.tsx
@@ -8,15 +8,15 @@ export default function NotFound() {
   const t = useTranslations('NotFound');
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-y-4 text-content-primary">
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-y-4 text-content-primary">
       <h1 className="text-6xl font-bold">404</h1>
       <h2 className="text-2xl font-semibold">{t('title')}</h2>
-      <p className="text-content-secondary text-center max-w-sm">
+      <p className="max-w-sm text-center text-content-secondary">
         {t('description')}
       </p>
       <Link
         href="/"
-        className="px-6 py-2 bg-surface text-content-primary rounded-lg font-medium hover:bg-surface-interactive transition-colors"
+        className="rounded-lg bg-surface px-6 py-2 font-medium text-content-primary transition-colors hover:bg-surface-interactive"
       >
         {t('backToHome')}
       </Link>

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({
   if (profileResult.isLeft())
     return { title: { absolute: `${t('HomePage.title')} | Wallace Ferreira` } };
 
-  const { name, headline, photo } = profileResult.value;
+  const { name, headline } = profileResult.value;
 
   return {
     title: { absolute: `${t('HomePage.title')} | Wallace Ferreira` },
@@ -44,8 +44,9 @@ export async function generateMetadata({
         {
           url: buildOgImageUrl({
             title: name,
-            description: headline,
-            image: photo?.url,
+            subtitle: t('Layout.description'),
+            locale,
+            page: 'HOME',
           }),
           width: 1200,
           height: 630,

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -4,11 +4,10 @@ import type { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { DEFAULT_LOCALE } from '~/i18n/routing';
+import { buildOgImageUrl } from '~/lib/og';
 import { getServerContainer } from '~/lib/server/container';
 import { HeroSection } from '~features/home/HeroSection';
 import { ProjectsSection } from '~features/home/ProjectsSection';
-
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
 export function generateStaticParams() {
   return LOCALES.map((locale) => ({ locale }));
@@ -35,18 +34,24 @@ export async function generateMetadata({
 
   const { name, headline, photo } = profileResult.value;
 
-  const ogUrl = new URL('/og', SITE_URL);
-  ogUrl.searchParams.set('title', name);
-  if (headline) ogUrl.searchParams.set('description', headline);
-  if (photo?.url) ogUrl.searchParams.set('image', photo.url);
-
   return {
     title: { absolute: `${t('HomePage.title')} | Wallace Ferreira` },
     description: headline,
     openGraph: {
       title: name,
       description: headline,
-      images: [{ url: ogUrl.toString(), width: 1200, height: 630, alt: name }],
+      images: [
+        {
+          url: buildOgImageUrl({
+            title: name,
+            description: headline,
+            image: photo?.url,
+          }),
+          width: 1200,
+          height: 630,
+          alt: name,
+        },
+      ],
     },
   };
 }

--- a/apps/site/src/app/[locale]/projects/page.tsx
+++ b/apps/site/src/app/[locale]/projects/page.tsx
@@ -38,7 +38,6 @@ export async function generateMetadata({
           url: buildOgImageUrl({
             title,
             subtitle: description,
-            tag: 'Portfolio Projects',
             locale,
             page: 'PROJECTS',
           }),

--- a/apps/site/src/app/[locale]/projects/page.tsx
+++ b/apps/site/src/app/[locale]/projects/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { DEFAULT_LOCALE } from '~/i18n/routing';
+import { buildOgImageUrl } from '~/lib/og';
 import { getServerContainer } from '~/lib/server/container';
 import { HeroSection } from '~features/projects/HeroSection';
 import { ProjectsSection } from '~features/projects/ProjectsSection';
@@ -26,7 +27,28 @@ export async function generateMetadata({
   const title = t('ProjectsPage.title');
   const description = t('ProjectsPage.description');
 
-  return { title, description, openGraph: { title, description } };
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [
+        {
+          url: buildOgImageUrl({
+            title,
+            subtitle: description,
+            tag: 'Portfolio Projects',
+            locale,
+            page: 'PROJECTS',
+          }),
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+  };
 }
 
 export default async function Projects({ params }: ProjectsPageProps) {

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCALE } from '@repo/core';
 import { ImageResponse } from 'next/og';
 import { type NextRequest } from 'next/server';
 
@@ -12,13 +13,16 @@ export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const title = searchParams.get('title') ?? 'Wallace Ferreira';
   const subtitle = searchParams.get('subtitle') ?? '';
-  const locale = searchParams.get('locale') ?? 'en-US';
+  const locale = searchParams.get('locale') ?? DEFAULT_LOCALE;
   const page = searchParams.get('page') ?? '';
 
   return new ImageResponse(
     <div
       tw="flex flex-col justify-between w-full h-full relative p-[72px] text-[#F8FAFC] font-[Arial]"
-      style={{ background: 'linear-gradient(135deg, #070B12 0%, #0E1622 60%, #10251C 100%)' }}
+      style={{
+        background:
+          'linear-gradient(135deg, #070B12 0%, #0E1622 60%, #10251C 100%)',
+      }}
     >
       {/* Watermark W */}
       <div tw="absolute flex -right-[60px] top-[80px] text-[420px] font-extrabold leading-none text-[#5CD66E]/10">
@@ -31,7 +35,9 @@ export async function GET(req: NextRequest) {
           <div tw="flex text-[54px] font-extrabold text-[#5CD66E]">W</div>
           <div tw="flex flex-col">
             <div tw="flex text-[28px] font-semibold">Wallace Ferreira</div>
-            <div tw="flex text-[22px] text-[#94A3B8]">Front-end Software Engineer</div>
+            <div tw="flex text-[22px] text-[#94A3B8]">
+              Front-end Software Engineer
+            </div>
           </div>
         </div>
         {locale && (

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -9,7 +9,6 @@ export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const title = searchParams.get('title') ?? 'Wallace Ferreira';
   const subtitle = searchParams.get('subtitle') ?? '';
-  const tag = searchParams.get('tag') ?? 'React • Next.js • TypeScript';
   const locale = searchParams.get('locale') ?? 'en-US';
   const page = searchParams.get('page') ?? '';
 
@@ -139,19 +138,6 @@ export async function GET(req: NextRequest) {
         }}
       >
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          <div
-            style={{
-              border: '1px solid rgba(92, 214, 110, 0.7)',
-              color: '#5CD66E',
-              borderRadius: 999,
-              padding: '12px 24px',
-              fontSize: 24,
-              fontWeight: 700,
-              display: 'flex',
-            }}
-          >
-            {tag}
-          </div>
           <div style={{ fontSize: 18, color: '#475569', display: 'flex' }}>
             portfolio-web-kohl-two.vercel.app
           </div>

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -17,143 +17,59 @@ export async function GET(req: NextRequest) {
 
   return new ImageResponse(
     <div
+      tw="flex flex-col justify-between w-full h-full relative p-[72px] text-[#F8FAFC]"
       style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'space-between',
-        background:
-          'linear-gradient(135deg, #070B12 0%, #0E1622 60%, #10251C 100%)',
-        color: '#F8FAFC',
-        padding: 72,
+        background: 'linear-gradient(135deg, #070B12 0%, #0E1622 60%, #10251C 100%)',
         fontFamily: 'Arial',
-        position: 'relative',
       }}
     >
       {/* Watermark W */}
       <div
-        style={{
-          position: 'absolute',
-          right: -60,
-          top: 80,
-          fontSize: 420,
-          fontWeight: 800,
-          color: 'rgba(92, 214, 110, 0.10)',
-          lineHeight: 1,
-          display: 'flex',
-        }}
+        tw="absolute flex text-[420px] font-extrabold leading-none text-[rgba(92,214,110,0.10)]"
+        style={{ right: -60, top: 80 }}
       >
         W
       </div>
 
       {/* Header */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
-          <div
-            style={{
-              fontSize: 54,
-              fontWeight: 800,
-              color: '#5CD66E',
-              display: 'flex',
-            }}
-          >
-            W
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div style={{ fontSize: 28, fontWeight: 600, display: 'flex' }}>
-              Wallace Ferreira
-            </div>
-            <div style={{ fontSize: 22, color: '#94A3B8', display: 'flex' }}>
-              Front-end Software Engineer
-            </div>
+      <div tw="flex items-center justify-between">
+        <div tw="flex items-center gap-6">
+          <div tw="flex text-[54px] font-extrabold text-[#5CD66E]">W</div>
+          <div tw="flex flex-col">
+            <div tw="flex text-[28px] font-semibold">Wallace Ferreira</div>
+            <div tw="flex text-[22px] text-[#94A3B8]">Front-end Software Engineer</div>
           </div>
         </div>
         {locale && (
-          <div
-            style={{
-              background: '#5CD66E',
-              color: '#070B12',
-              borderRadius: 999,
-              padding: '10px 22px',
-              fontSize: 22,
-              fontWeight: 800,
-              display: 'flex',
-            }}
-          >
+          <div tw="flex rounded-full px-[22px] py-[10px] text-[22px] font-extrabold bg-[#5CD66E] text-[#070B12]">
             {locale}
           </div>
         )}
       </div>
 
       {/* Main content */}
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div tw="flex flex-col">
         <div
-          style={{
-            fontSize: title.length > 20 ? 64 : 76,
-            fontWeight: 800,
-            letterSpacing: '-0.04em',
-            maxWidth: 760,
-            lineHeight: 1.05,
-            display: 'flex',
-          }}
+          tw="flex font-extrabold max-w-[760px] leading-[1.05] tracking-[-0.04em]"
+          style={{ fontSize: title.length > 20 ? 64 : 76 }}
         >
           {title}
         </div>
-        <div
-          style={{
-            width: 150,
-            height: 6,
-            background: '#5CD66E',
-            borderRadius: 999,
-            marginTop: 24,
-            marginBottom: 32,
-            display: 'flex',
-          }}
-        />
+        <div tw="flex w-[150px] h-[6px] bg-[#5CD66E] rounded-full mt-6 mb-8" />
         {subtitle && (
-          <div
-            style={{
-              fontSize: 30,
-              color: '#CBD5E1',
-              maxWidth: 760,
-              lineHeight: 1.3,
-              display: 'flex',
-            }}
-          >
+          <div tw="flex text-[30px] text-[#CBD5E1] max-w-[760px] leading-[1.3]">
             {subtitle}
           </div>
         )}
       </div>
 
       {/* Footer */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        }}
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          <div style={{ fontSize: 18, color: '#475569', display: 'flex' }}>
-            {siteHost}
-          </div>
-        </div>
+      <div tw="flex items-center justify-between">
+        <div tw="flex text-[18px] text-[#475569]">{siteHost}</div>
         {page && (
           <div
-            style={{
-              fontSize: 28,
-              fontWeight: 800,
-              color: 'rgba(92, 214, 110, 0.5)',
-              letterSpacing: '0.1em',
-              display: 'flex',
-            }}
+            tw="flex text-[28px] font-extrabold tracking-[0.1em]"
+            style={{ color: 'rgba(92, 214, 110, 0.5)' }}
           >
             {page}
           </div>

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -17,17 +17,11 @@ export async function GET(req: NextRequest) {
 
   return new ImageResponse(
     <div
-      tw="flex flex-col justify-between w-full h-full relative p-[72px] text-[#F8FAFC]"
-      style={{
-        background: 'linear-gradient(135deg, #070B12 0%, #0E1622 60%, #10251C 100%)',
-        fontFamily: 'Arial',
-      }}
+      tw="flex flex-col justify-between w-full h-full relative p-[72px] text-[#F8FAFC] font-[Arial]"
+      style={{ background: 'linear-gradient(135deg, #070B12 0%, #0E1622 60%, #10251C 100%)' }}
     >
       {/* Watermark W */}
-      <div
-        tw="absolute flex text-[420px] font-extrabold leading-none text-[rgba(92,214,110,0.10)]"
-        style={{ right: -60, top: 80 }}
-      >
+      <div tw="absolute flex -right-[60px] top-[80px] text-[420px] font-extrabold leading-none text-[#5CD66E]/10">
         W
       </div>
 
@@ -67,10 +61,7 @@ export async function GET(req: NextRequest) {
       <div tw="flex items-center justify-between">
         <div tw="flex text-[18px] text-[#475569]">{siteHost}</div>
         {page && (
-          <div
-            tw="flex text-[28px] font-extrabold tracking-[0.1em]"
-            style={{ color: 'rgba(92, 214, 110, 0.5)' }}
-          >
+          <div tw="flex text-[28px] font-extrabold tracking-[0.1em] text-[#5CD66E]/50">
             {page}
           </div>
         )}

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -49,10 +49,7 @@ export async function GET(req: NextRequest) {
 
       {/* Main content */}
       <div tw="flex flex-col">
-        <div
-          tw="flex font-extrabold max-w-[760px] leading-[1.05] tracking-[-0.04em]"
-          style={{ fontSize: title.length > 20 ? 64 : 76 }}
-        >
+        <div tw="flex text-[64px] font-extrabold max-w-[760px] leading-[1.05] tracking-[-0.04em]">
           {title}
         </div>
         <div tw="flex w-[150px] h-[6px] bg-[#5CD66E] rounded-full mt-6 mb-8" />

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -5,11 +5,25 @@ export const runtime = 'edge';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
+async function fetchImageAsPngDataUrl(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const buffer = await res.arrayBuffer();
+    const base64 = Buffer.from(buffer).toString('base64');
+    return `data:image/png;base64,${base64}`;
+  } catch {
+    return null;
+  }
+}
+
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const title = searchParams.get('title') ?? 'Wallace Ferreira';
   const description = searchParams.get('description') ?? '';
   const imageUrl = searchParams.get('image') ?? '';
+
+  const imageSrc = imageUrl ? await fetchImageAsPngDataUrl(imageUrl) : null;
 
   return new ImageResponse(
     <div
@@ -36,7 +50,7 @@ export async function GET(req: NextRequest) {
       />
 
       {/* Decorative circle — top-right (only when no image) */}
-      {!imageUrl && (
+      {!imageSrc && (
         <div
           style={{
             position: 'absolute',
@@ -52,7 +66,7 @@ export async function GET(req: NextRequest) {
       )}
 
       {/* Profile image — right side */}
-      {imageUrl && (
+      {imageSrc && (
         <div
           style={{
             position: 'absolute',
@@ -78,7 +92,7 @@ export async function GET(req: NextRequest) {
           />
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={imageUrl}
+            src={imageSrc}
             alt=""
             style={{
               width: '100%',
@@ -97,7 +111,7 @@ export async function GET(req: NextRequest) {
           flexDirection: 'column',
           justifyContent: 'space-between',
           padding: '64px 80px',
-          width: imageUrl ? 780 : '100%',
+          width: imageSrc ? 780 : '100%',
           height: '100%',
         }}
       >
@@ -133,7 +147,7 @@ export async function GET(req: NextRequest) {
               fontWeight: 700,
               lineHeight: 1.1,
               letterSpacing: '-0.02em',
-              maxWidth: imageUrl ? 680 : 900,
+              maxWidth: imageSrc ? 680 : 900,
             }}
           >
             {title}
@@ -145,7 +159,7 @@ export async function GET(req: NextRequest) {
                 fontSize: 26,
                 fontWeight: 400,
                 lineHeight: 1.5,
-                maxWidth: imageUrl ? 640 : 820,
+                maxWidth: imageSrc ? 640 : 820,
               }}
             >
               {description}

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -3,200 +3,174 @@ import { type NextRequest } from 'next/server';
 
 export const runtime = 'edge';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
-
-async function fetchImageAsPngDataUrl(url: string): Promise<string | null> {
-  try {
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    const buffer = await res.arrayBuffer();
-    const base64 = Buffer.from(buffer).toString('base64');
-    return `data:image/png;base64,${base64}`;
-  } catch {
-    return null;
-  }
-}
+const SIZE = { width: 1200, height: 630 };
 
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const title = searchParams.get('title') ?? 'Wallace Ferreira';
-  const description = searchParams.get('description') ?? '';
-  const imageUrl = searchParams.get('image') ?? '';
-
-  const imageSrc = imageUrl ? await fetchImageAsPngDataUrl(imageUrl) : null;
+  const subtitle = searchParams.get('subtitle') ?? '';
+  const tag = searchParams.get('tag') ?? 'React • Next.js • TypeScript';
+  const locale = searchParams.get('locale') ?? 'en-US';
+  const page = searchParams.get('page') ?? '';
 
   return new ImageResponse(
     <div
       style={{
-        display: 'flex',
         width: '100%',
         height: '100%',
-        backgroundColor: '#1C1C1C',
-        fontFamily: 'Inter, sans-serif',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        background:
+          'linear-gradient(135deg, #070B12 0%, #0E1622 60%, #10251C 100%)',
+        color: '#F8FAFC',
+        padding: 72,
+        fontFamily: 'Arial',
         position: 'relative',
-        overflow: 'hidden',
       }}
     >
-      {/* Accent stripe */}
+      {/* Watermark W */}
       <div
         style={{
           position: 'absolute',
-          top: 0,
-          left: 0,
-          width: 8,
-          height: '100%',
-          backgroundColor: '#8efb9d',
+          right: -60,
+          top: 80,
+          fontSize: 420,
+          fontWeight: 800,
+          color: 'rgba(92, 214, 110, 0.10)',
+          lineHeight: 1,
+          display: 'flex',
         }}
-      />
+      >
+        W
+      </div>
 
-      {/* Decorative circle — top-right (only when no image) */}
-      {!imageSrc && (
-        <div
-          style={{
-            position: 'absolute',
-            top: -120,
-            right: -120,
-            width: 420,
-            height: 420,
-            borderRadius: '50%',
-            backgroundColor: '#4452ff',
-            opacity: 0.12,
-          }}
-        />
-      )}
-
-      {/* Profile image — right side */}
-      {imageSrc && (
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            right: 0,
-            width: 420,
-            height: '100%',
-            display: 'flex',
-          }}
-        >
-          {/* Gradient overlay so text stays readable */}
-          <div
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: 160,
-              height: '100%',
-              background:
-                'linear-gradient(to right, #1C1C1C 0%, transparent 100%)',
-              zIndex: 1,
-            }}
-          />
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={imageSrc}
-            alt=""
-            style={{
-              width: '100%',
-              height: '100%',
-              objectFit: 'cover',
-              objectPosition: 'center top',
-            }}
-          />
-        </div>
-      )}
-
-      {/* Content */}
+      {/* Header */}
       <div
         style={{
           display: 'flex',
-          flexDirection: 'column',
+          alignItems: 'center',
           justifyContent: 'space-between',
-          padding: '64px 80px',
-          width: imageSrc ? 780 : '100%',
-          height: '100%',
         }}
       >
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
           <div
             style={{
-              width: 10,
-              height: 10,
-              borderRadius: '50%',
-              backgroundColor: '#8efb9d',
-            }}
-          />
-          <span
-            style={{
-              color: '#8efb9d',
-              fontSize: 18,
-              fontWeight: 600,
-              letterSpacing: '0.05em',
-              textTransform: 'uppercase',
+              fontSize: 54,
+              fontWeight: 800,
+              color: '#5CD66E',
+              display: 'flex',
             }}
           >
-            Wallace Ferreira
-          </span>
-        </div>
-
-        {/* Main content */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
-          <div
-            style={{
-              color: '#d9d9d9',
-              fontSize: title.length > 40 ? 52 : 64,
-              fontWeight: 700,
-              lineHeight: 1.1,
-              letterSpacing: '-0.02em',
-              maxWidth: imageSrc ? 680 : 900,
-            }}
-          >
-            {title}
+            W
           </div>
-          {description && (
-            <div
-              style={{
-                color: '#8d8d8d',
-                fontSize: 26,
-                fontWeight: 400,
-                lineHeight: 1.5,
-                maxWidth: imageSrc ? 640 : 820,
-              }}
-            >
-              {description}
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ fontSize: 28, fontWeight: 600, display: 'flex' }}>
+              Wallace Ferreira
             </div>
-          )}
+            <div style={{ fontSize: 22, color: '#94A3B8', display: 'flex' }}>
+              Front-end Software Engineer
+            </div>
+          </div>
         </div>
+        {locale && (
+          <div
+            style={{
+              background: '#5CD66E',
+              color: '#070B12',
+              borderRadius: 999,
+              padding: '10px 22px',
+              fontSize: 22,
+              fontWeight: 800,
+              display: 'flex',
+            }}
+          >
+            {locale}
+          </div>
+        )}
+      </div>
 
-        {/* Footer */}
+      {/* Main content */}
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
         <div
           style={{
+            fontSize: title.length > 20 ? 64 : 76,
+            fontWeight: 800,
+            letterSpacing: '-0.04em',
+            maxWidth: 760,
+            lineHeight: 1.05,
             display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
           }}
         >
-          <span style={{ color: '#494949', fontSize: 18 }}>
-            {SITE_URL.replace(/^https?:\/\//, '')}
-          </span>
+          {title}
+        </div>
+        <div
+          style={{
+            width: 150,
+            height: 6,
+            background: '#5CD66E',
+            borderRadius: 999,
+            marginTop: 24,
+            marginBottom: 32,
+            display: 'flex',
+          }}
+        />
+        {subtitle && (
           <div
             style={{
+              fontSize: 30,
+              color: '#CBD5E1',
+              maxWidth: 760,
+              lineHeight: 1.3,
               display: 'flex',
-              alignItems: 'center',
-              backgroundColor: '#282828',
-              borderRadius: 12,
-              padding: '10px 20px',
             }}
           >
-            <span style={{ color: '#a4a4a4', fontSize: 16 }}>
-              Software Engineer
-            </span>
+            {subtitle}
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div
+            style={{
+              border: '1px solid rgba(92, 214, 110, 0.7)',
+              color: '#5CD66E',
+              borderRadius: 999,
+              padding: '12px 24px',
+              fontSize: 24,
+              fontWeight: 700,
+              display: 'flex',
+            }}
+          >
+            {tag}
+          </div>
+          <div style={{ fontSize: 18, color: '#475569', display: 'flex' }}>
+            portfolio-web-kohl-two.vercel.app
           </div>
         </div>
+        {page && (
+          <div
+            style={{
+              fontSize: 28,
+              fontWeight: 800,
+              color: 'rgba(92, 214, 110, 0.5)',
+              letterSpacing: '0.1em',
+              display: 'flex',
+            }}
+          >
+            {page}
+          </div>
+        )}
       </div>
     </div>,
-    {
-      width: 1200,
-      height: 630,
-    },
+    SIZE,
   );
 }

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -1,9 +1,12 @@
 import { ImageResponse } from 'next/og';
 import { type NextRequest } from 'next/server';
 
+import { SITE_URL } from '~/lib/og';
+
 export const runtime = 'edge';
 
 const SIZE = { width: 1200, height: 630 };
+const siteHost = new URL(SITE_URL).host;
 
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
@@ -139,7 +142,7 @@ export async function GET(req: NextRequest) {
       >
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           <div style={{ fontSize: 18, color: '#475569', display: 'flex' }}>
-            portfolio-web-kohl-two.vercel.app
+            {siteHost}
           </div>
         </div>
         {page && (

--- a/apps/site/src/components/Layout/AppLayout/index.tsx
+++ b/apps/site/src/components/Layout/AppLayout/index.tsx
@@ -8,11 +8,11 @@ export const AppLayout: FC<PropsWithChildren> = ({ children }) => {
   return (
     <>
       <SideNavigation />
-      <div className="flex h-full flex-col ml-0 lg:ml-60 mt-header-mobile lg:mt-0">
-        <main className="w-full max-w-237.5 mx-auto h-auto flex flex-col flex-1 pt-6 lg:pt-16 xl:pt-20 px-4 xl:px-0">
+      <div className="ml-0 mt-header-mobile flex h-full flex-col lg:ml-60 lg:mt-0">
+        <main className="mx-auto flex h-auto w-full max-w-237.5 flex-1 flex-col px-4 pt-6 lg:pt-16 xl:px-0 xl:pt-20">
           {children}
         </main>
-        <footer className="w-full max-w-237.5 mx-auto shadow-drop-up">
+        <footer className="mx-auto w-full max-w-237.5 shadow-drop-up">
           <ContactSection />
         </footer>
       </div>

--- a/apps/site/src/components/Layout/Header/index.tsx
+++ b/apps/site/src/components/Layout/Header/index.tsx
@@ -2,12 +2,12 @@
 
 import { FC } from 'react';
 
+import { screens } from '@repo/tailwind-config/screens';
 import { Button } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
 import { useTranslations } from 'next-intl';
 import NextLink from 'next/link';
 
-import { screens } from '@repo/tailwind-config/screens';
 import logo from '~assets/images/logo.svg';
 
 interface HeaderProps {
@@ -19,7 +19,7 @@ export const Header: FC<HeaderProps> = ({ open, toggle }) => {
   const t = useTranslations('Header');
 
   return (
-    <header className="w-full lg:w-60 flex items-center lg:items-end justify-between lg:justify-center bg-surface lg:bg-surface-sunken px-4 py-3 lg:px-0 lg:py-0 transition-all duration-300 ease-linear h-header-mobile lg:h-header-desktop shadow-drop-md lg:shadow-none">
+    <header className="flex h-header-mobile w-full items-center justify-between bg-surface px-4 py-3 shadow-drop-md transition-all duration-300 ease-linear lg:h-header-desktop lg:w-60 lg:items-end lg:justify-center lg:bg-surface-sunken lg:p-0 lg:shadow-none">
       <NextLink href="/" aria-label={t('logo_alt')}>
         <picture>
           <source
@@ -38,7 +38,7 @@ export const Header: FC<HeaderProps> = ({ open, toggle }) => {
         </picture>
       </NextLink>
       <Button.Base
-        className="flex items-center justify-center h-10 w-10 !bg-surface-raised hover:!bg-surface !rounded !p-0 lg:hidden"
+        className="flex size-10 items-center justify-center !rounded !bg-surface-raised !p-0 hover:!bg-surface lg:hidden"
         onClick={toggle}
         aria-label={open ? t('closeMenu') : t('openMenu')}
         aria-expanded={open}

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -24,7 +24,7 @@ export const SideNavigation: FC = () => {
   useScrollLock({ autoLock: isOpen });
 
   return (
-    <div className="fixed top-0 left-0 shadow-1 w-full lg:w-auto z-50">
+    <div className="fixed left-0 top-0 z-50 w-full shadow-1 lg:w-auto">
       <Header open={isOpen} toggle={toggle} />
       <nav
         id="side-navigation"
@@ -34,7 +34,7 @@ export const SideNavigation: FC = () => {
           isOpen ? 'translate-x-0' : 'translate-x-full',
         )}
       >
-        <ul className="flex flex-col gap-y-3 px-6 pt-10 lg:pt-15 lg:px-0">
+        <ul className="flex flex-col gap-y-3 px-6 pt-10 lg:px-0 lg:pt-15">
           <li>
             <MenuItem.Item1 href="/" icon="material-symbols:home">
               {t('home')}
@@ -64,7 +64,7 @@ export const SideNavigation: FC = () => {
           </li>
         </ul>
         <Divider className="mx-6 lg:mx-0" />
-        <ul className="flex flex-col gap-y-3 px-6 pb-8 lg:px-0 lg:justify-end">
+        <ul className="flex flex-col gap-y-3 px-6 pb-8 lg:justify-end lg:px-0">
           <li>
             <MenuItem.Item2.Link
               href={process.env.NEXT_PUBLIC_LINKEDIN_URL}

--- a/apps/site/src/features/about/CurriculumCTA/index.tsx
+++ b/apps/site/src/features/about/CurriculumCTA/index.tsx
@@ -28,7 +28,7 @@ export async function CurriculumCTA({
         className,
       )}
     >
-      <div className="relative w-full h-[220px] lg:w-[320px] lg:h-[317px] shrink-0">
+      <div className="relative h-[220px] w-full shrink-0 lg:h-[317px] lg:w-[320px]">
         <Image
           src={illustrationSrc}
           alt={t('illustration_alt')}
@@ -37,7 +37,7 @@ export async function CurriculumCTA({
         />
       </div>
 
-      <div className="flex flex-col gap-y-8 w-full lg:w-auto">
+      <div className="flex w-full flex-col gap-y-8 lg:w-auto">
         <p className="text-2xl font-normal text-content-primary">
           {t('description')}
         </p>
@@ -45,7 +45,7 @@ export async function CurriculumCTA({
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-x-2 w-full lg:w-[292px] justify-center"
+          className="inline-flex w-full items-center justify-center gap-x-2 lg:w-[292px]"
         >
           {t('button')}
           <Icon icon="material-symbols:open-in-new" className="text-2xl" />

--- a/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
@@ -101,15 +101,15 @@ export const ExperienceCard: FC<IExperienceCardProps> = ({
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-base text-content-disabled">
         <span className="flex items-center gap-x-1">
-          <Icon icon={LOCATION_ICON} className="text-base shrink-0" />
+          <Icon icon={LOCATION_ICON} className="shrink-0 text-base" />
           {location}
         </span>
         <span className="flex items-center gap-x-1">
-          <Icon icon={employmentIcon} className="text-base shrink-0" />
+          <Icon icon={employmentIcon} className="shrink-0 text-base" />
           {employmentLabel}
         </span>
         <span className="flex items-center gap-x-1">
-          <Icon icon={locationTypeIcon} className="text-base shrink-0" />
+          <Icon icon={locationTypeIcon} className="shrink-0 text-base" />
           {locationLabel}
         </span>
       </div>

--- a/apps/site/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperiencesSkeleton.tsx
@@ -1,17 +1,17 @@
 export function ExperiencesSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="h-px bg-surface-raised my-6" />
+      <div className="my-6 h-px bg-surface-raised" />
       <ul className="flex flex-col gap-y-3">
         {(['exp-1', 'exp-2', 'exp-3'] as const).map((key) => (
           <li
             key={key}
-            className="flex flex-col py-6 px-3 bg-surface-sunken rounded-xl gap-y-3"
+            className="flex flex-col gap-y-3 rounded-xl bg-surface-sunken px-3 py-6"
           >
-            <div className="h-5 w-3/5 bg-surface-raised rounded" />
-            <div className="h-4 w-2/5 bg-surface-raised rounded" />
-            <div className="h-4 bg-surface-raised rounded w-full" />
-            <div className="h-4 bg-surface-raised rounded w-5/6" />
+            <div className="h-5 w-3/5 rounded bg-surface-raised" />
+            <div className="h-4 w-2/5 rounded bg-surface-raised" />
+            <div className="h-4 w-full rounded bg-surface-raised" />
+            <div className="h-4 w-5/6 rounded bg-surface-raised" />
           </li>
         ))}
       </ul>

--- a/apps/site/src/features/about/ExperiencesSection/SkillAccordion.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/SkillAccordion.tsx
@@ -26,11 +26,11 @@ export const SkillAccordion: FC<ISkillAccordionProps> = ({ skills }) => {
             </span>
             <Icon
               icon="ic:round-keyboard-arrow-down"
-              className={`text-content-muted text-xl transition-transform duration-300 ${expanded ? 'rotate-180' : ''}`}
+              className={`text-xl text-content-muted transition-transform duration-300 ${expanded ? 'rotate-180' : ''}`}
             />
           </Accordion.Header>
           <Accordion.Body>
-            <ul className="flex flex-row gap-2 flex-wrap pt-2">
+            <ul className="flex flex-row flex-wrap gap-2 pt-2">
               {skills.map((skill) => (
                 <li key={skill.name}>
                   {skill.icon ? (

--- a/apps/site/src/features/about/ValuesSection/ProfessionalValueCard.tsx
+++ b/apps/site/src/features/about/ValuesSection/ProfessionalValueCard.tsx
@@ -16,13 +16,13 @@ export const ProfessionalValueCard: FC<IProfessionalValueCardProps> = ({
   content,
 }) => {
   return (
-    <article className="w-full h-full border border-border-subtle bg-surface/20 rounded-xl px-4 py-6 flex flex-col gap-y-4 shadow-drop-sm">
+    <article className="flex size-full flex-col gap-y-4 rounded-xl border border-border-subtle bg-surface/20 px-4 py-6 shadow-drop-sm">
       <Icon
         icon={icon}
-        className="!text-[48px] text-brand-accent flex-shrink-0"
+        className="flex-shrink-0 !text-[48px] text-brand-accent"
       />
       <TextRich
-        className="text-base text-content-primary flex-1 [&_p]:text-base [&_p]:leading-[1.4] [&_p]:text-content-primary [&_p]:m-0 [&_strong]:text-brand-accent [&_strong]:font-bold [&_p]:line-clamp-4"
+        className="flex-1 text-base text-content-primary [&_p]:m-0 [&_p]:line-clamp-4 [&_p]:text-base [&_p]:leading-[1.4] [&_p]:text-content-primary [&_strong]:font-bold [&_strong]:text-brand-accent"
         content={content}
       />
     </article>

--- a/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
@@ -21,11 +21,11 @@ export async function ValuesSection({ locale }: { locale: Locale }) {
     valuesResult.isRight() ? valuesResult.value : [];
 
   return (
-    <section className="flex flex-col gap-y-4 mt-10 xl:mt-16 2xl:mt-20">
-      <h2 className="text-[32px] font-bold text-content-primary text-left">
+    <section className="mt-10 flex flex-col gap-y-4 xl:mt-16 2xl:mt-20">
+      <h2 className="text-left text-[32px] font-bold text-content-primary">
         {t('values_title')}
       </h2>
-      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 items-stretch">
+      <ul className="grid grid-cols-2 items-stretch gap-4 sm:grid-cols-3 lg:grid-cols-4">
         {professionalValues.map((professionalValue) => (
           <li key={professionalValue.id}>
             <ProfessionalValueCard {...professionalValue} />

--- a/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSkeleton.tsx
@@ -1,17 +1,17 @@
 export function ValuesSkeleton() {
   return (
-    <div className="animate-pulse flex flex-col gap-y-6">
-      <div className="h-8 w-64 bg-surface-raised rounded" />
-      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+    <div className="flex animate-pulse flex-col gap-y-6">
+      <div className="h-8 w-64 rounded bg-surface-raised" />
+      <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
         {(['val-1', 'val-2', 'val-3', 'val-4'] as const).map((key) => (
           <li
             key={key}
-            className="w-full border border-border-subtle px-4 py-6 rounded-xl bg-surface/20 flex flex-col gap-y-3"
+            className="flex w-full flex-col gap-y-3 rounded-xl border border-border-subtle bg-surface/20 px-4 py-6"
           >
-            <div className="h-12 w-12 bg-surface-raised rounded" />
-            <div className="h-4 bg-surface-raised rounded w-full" />
-            <div className="h-4 bg-surface-raised rounded w-4/5" />
-            <div className="h-4 bg-surface-raised rounded w-3/5" />
+            <div className="size-12 rounded bg-surface-raised" />
+            <div className="h-4 w-full rounded bg-surface-raised" />
+            <div className="h-4 w-4/5 rounded bg-surface-raised" />
+            <div className="h-4 w-3/5 rounded bg-surface-raised" />
           </li>
         ))}
       </ul>

--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -35,7 +35,7 @@ export const ContactForm: FC = () => {
   if (submitted) {
     return (
       <div className="w-full">
-        <h2 className="text-2xl font-bold text-content-primary mb-6">
+        <h2 className="mb-6 text-2xl font-bold text-content-primary">
           {tForm('title')}
         </h2>
         <p className="text-accent">{tForm('success')}</p>
@@ -47,7 +47,7 @@ export const ContactForm: FC = () => {
     <>
       <h2
         id="contact-form-title"
-        className="text-2xl font-bold text-content-primary mb-6"
+        className="mb-6 text-2xl font-bold text-content-primary"
       >
         {tForm('title')}
       </h2>
@@ -55,10 +55,10 @@ export const ContactForm: FC = () => {
       <form onSubmit={handleSubmit(onSubmit)} className="w-full" noValidate>
         <fieldset
           aria-labelledby="contact-form-title"
-          className="border-0 p-0 m-0 min-w-0"
+          className="m-0 min-w-0 border-0 p-0"
         >
           <div className="flex flex-col gap-y-6">
-            <div className="flex flex-col xl:flex-row gap-y-6 xl:gap-x-4">
+            <div className="flex flex-col gap-y-6 xl:flex-row xl:gap-x-4">
               <div className="flex flex-col gap-y-1 xl:flex-1">
                 <Label htmlFor="name">{tForm('nameLabel')}</Label>
                 <Text.Base
@@ -75,7 +75,7 @@ export const ContactForm: FC = () => {
                   <span
                     id="name-error"
                     role="alert"
-                    className="text-error text-xs"
+                    className="text-xs text-error"
                   >
                     {tV(errors.name.message as Parameters<typeof tV>[0])}
                   </span>
@@ -98,7 +98,7 @@ export const ContactForm: FC = () => {
                   <span
                     id="email-error"
                     role="alert"
-                    className="text-error text-xs"
+                    className="text-xs text-error"
                   >
                     {tV(errors.email.message as Parameters<typeof tV>[0])}
                   </span>
@@ -123,7 +123,7 @@ export const ContactForm: FC = () => {
                 <span
                   id="message-error"
                   role="alert"
-                  className="text-error text-xs"
+                  className="text-xs text-error"
                 >
                   {tV(errors.message.message as Parameters<typeof tV>[0])}
                 </span>
@@ -134,7 +134,7 @@ export const ContactForm: FC = () => {
 
         <Button.Base
           type="submit"
-          className="w-full xl:w-[216px] h-[46px] mt-6"
+          className="mt-6 h-[46px] w-full xl:w-[216px]"
           disabled={isSubmitting}
         >
           {tForm('submit')}

--- a/apps/site/src/features/contact/ContactInfo/index.tsx
+++ b/apps/site/src/features/contact/ContactInfo/index.tsx
@@ -25,7 +25,7 @@ export const ContactInfo: FC = () => {
           <div className="flex items-center gap-x-2">
             <Icon
               icon="ic:baseline-email"
-              className="text-content-secondary text-2xl"
+              className="text-2xl text-content-secondary"
             />
             <strong className="text-base font-bold text-content-primary">
               {t('email')}
@@ -43,7 +43,7 @@ export const ContactInfo: FC = () => {
             >
               <Icon
                 icon="material-symbols:content-copy"
-                className="text-content-secondary text-2xl"
+                className="text-2xl text-content-secondary"
               />
             </Button.Clipboard>
           </div>
@@ -53,7 +53,7 @@ export const ContactInfo: FC = () => {
           <div className="flex items-center gap-x-2">
             <Icon
               icon="ic:baseline-whatsapp"
-              className="text-content-secondary text-2xl"
+              className="text-2xl text-content-secondary"
             />
             <strong className="text-base font-bold text-content-primary">
               WhatsApp
@@ -71,7 +71,7 @@ export const ContactInfo: FC = () => {
             >
               <Icon
                 icon="material-symbols:content-copy"
-                className="text-content-secondary text-2xl"
+                className="text-2xl text-content-secondary"
               />
             </Button.Clipboard>
           </div>

--- a/apps/site/src/features/contact/ContactSection/index.tsx
+++ b/apps/site/src/features/contact/ContactSection/index.tsx
@@ -11,8 +11,8 @@ const ContactForm = dynamic(
 
 export function ContactSection() {
   return (
-    <section className="bg-surface-overlay xl:border-2 xl:border-b-0 xl:border-border-subtle py-10 2xl:-mx-[161px] 2xl:px-[161px]">
-      <div className="mx-4 xl:mx-8 flex flex-col gap-y-6 xl:flex-row xl:gap-x-8 2xl:gap-x-16">
+    <section className="bg-surface-overlay py-10 xl:border-2 xl:border-b-0 xl:border-border-subtle 2xl:mx-[-161px] 2xl:px-[161px]">
+      <div className="mx-4 flex flex-col gap-y-6 xl:mx-8 xl:flex-row xl:gap-x-8 2xl:gap-x-16">
         <div className="xl:w-[560px] xl:shrink-0">
           <ContactForm />
         </div>

--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -1,8 +1,7 @@
 import { type ProfileDTO } from '@repo/application/portfolio';
 import { type Locale } from '@repo/core/shared';
-import { getTranslations } from 'next-intl/server';
-
 import { screens } from '@repo/tailwind-config/screens';
+import { getTranslations } from 'next-intl/server';
 
 import HeroLandingPage from '~assets/images/hero-landing-page.webp';
 import { HeroBanner } from '~features/shared/HeroBanner';

--- a/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -1,5 +1,6 @@
 import { type Locale } from '@repo/core/shared';
 import { getTranslations } from 'next-intl/server';
+
 import { Link } from '~/i18n/routing';
 
 import { ProjectList, ProjectSummary } from './ProjectList';
@@ -17,7 +18,7 @@ export async function ProjectsSection({
 
   return (
     <>
-      <h2 className="text-content-primary my-6 !text-xl lg:block lg:mx-auto lg:my-8 lg:w-full lg:!text-[32px] lg:max-w-237.5">
+      <h2 className="my-6 !text-xl text-content-primary lg:mx-auto lg:my-8 lg:block lg:w-full lg:max-w-237.5 lg:!text-[32px]">
         {t('projects_title')}
       </h2>
       <ProjectList projects={projects} compact className="pb-6" />

--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -2,10 +2,9 @@
 
 import { FC } from 'react';
 
-import { buttonVariants } from '@repo/ui/Control';
-import { Button } from '@repo/ui/Control';
-import { Icon } from '@repo/ui/Imagery';
 import { screens } from '@repo/tailwind-config/screens';
+import { buttonVariants, Button } from '@repo/ui/Control';
+import { Icon } from '@repo/ui/Imagery';
 import classNames from 'classnames';
 import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
@@ -74,7 +73,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
           !compact && 'lg:p-6 lg:gap-5',
         )}
       >
-        <div className="flex flex-col gap-4 flex-1">
+        <div className="flex flex-1 flex-col gap-4">
           {theme && (
             <span
               className={classNames(
@@ -108,7 +107,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
 
           <Button.Link
             href={`/${locale}/projects/${slug}`}
-            className="flex flex-row justify-center items-center gap-2"
+            className="flex flex-row items-center justify-center gap-2"
           >
             {t('view_project')}
             <Icon icon="ic:round-arrow-forward" className="text-xl" />

--- a/apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectsSkeleton.tsx
@@ -1,17 +1,17 @@
 export function ProjectsSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="w-full flex justify-start my-6 lg:mx-auto lg:max-w-237.5">
-        <div className="h-8 w-32 bg-surface-raised rounded" />
+      <div className="my-6 flex w-full justify-start lg:mx-auto lg:max-w-237.5">
+        <div className="h-8 w-32 rounded bg-surface-raised" />
       </div>
-      <ul className="lg:mx-auto grid grid-cols-1 lg:grid-cols-2 max-w-237.5 gap-4 lg:gap-6 pb-8 lg:pb-20">
+      <ul className="grid max-w-237.5 grid-cols-1 gap-4 pb-8 lg:mx-auto lg:grid-cols-2 lg:gap-6 lg:pb-20">
         {(['card-1', 'card-2', 'card-3', 'card-4'] as const).map((key) => (
-          <li key={key} className="bg-surface p-3 rounded-5">
-            <div className="h-45 lg:h-61 bg-surface-raised rounded-lg mb-4" />
-            <div className="h-5 w-3/4 bg-surface-raised rounded mb-2" />
-            <div className="h-4 bg-surface-raised rounded mb-1" />
-            <div className="h-4 w-5/6 bg-surface-raised rounded mb-5" />
-            <div className="h-10 bg-surface-raised rounded" />
+          <li key={key} className="rounded-5 bg-surface p-3">
+            <div className="mb-4 h-45 rounded-lg bg-surface-raised lg:h-61" />
+            <div className="mb-2 h-5 w-3/4 rounded bg-surface-raised" />
+            <div className="mb-1 h-4 rounded bg-surface-raised" />
+            <div className="mb-5 h-4 w-5/6 rounded bg-surface-raised" />
+            <div className="h-10 rounded bg-surface-raised" />
           </li>
         ))}
       </ul>

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -66,12 +66,12 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
   );
 
   return (
-    <article className="flex flex-col gap-y-10 pb-12 mt-6 lg:mt-0">
-      <div className="lg:mx-auto lg:w-full lg:max-w-237.5 flex flex-col gap-y-10">
-        <div className="flex flex-col justify-center items-start gap-y-1 lg:flex-row lg:items-center lg:justify-between">
+    <article className="mt-6 flex flex-col gap-y-10 pb-12 lg:mt-0">
+      <div className="flex flex-col gap-y-10 lg:mx-auto lg:w-full lg:max-w-237.5">
+        <div className="flex flex-col items-start justify-center gap-y-1 lg:flex-row lg:items-center lg:justify-between">
           <Breadcrumb
             items={breadcrumbItems}
-            className="flex items-center min-h-12 lg:order-2"
+            className="flex min-h-12 items-center lg:order-2"
           />
           <Link
             href="/projects"
@@ -83,7 +83,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
         </div>
 
         <div className="flex flex-col gap-y-6">
-          <div className="relative w-full lg:h-[485px] h-60 rounded-lg overflow-hidden shadow-drop-sm">
+          <div className="relative h-60 w-full overflow-hidden rounded-lg shadow-drop-sm lg:h-[485px]">
             <Image
               src={coverImage.url}
               fill

--- a/apps/site/src/features/projects/ProjectDetail/ProjectMetaGrid.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectMetaGrid.tsx
@@ -37,9 +37,9 @@ export const ProjectMetaGrid: FC<IProjectMetaGridProps> = ({
   return (
     <div className="flex flex-col gap-y-6">
       {hasCards && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
           {summary && (
-            <div className="bg-surface rounded-xl p-6 flex flex-col gap-y-2 sm:h-[150px]">
+            <div className="flex flex-col gap-y-2 rounded-xl bg-surface p-6 sm:h-[150px]">
               <dt className="text-xl font-bold text-content-muted">
                 {labels.summary}
               </dt>
@@ -47,7 +47,7 @@ export const ProjectMetaGrid: FC<IProjectMetaGridProps> = ({
             </div>
           )}
           {objectives && (
-            <div className="bg-surface rounded-xl p-6 flex flex-col gap-y-2 sm:h-[150px]">
+            <div className="flex flex-col gap-y-2 rounded-xl bg-surface p-6 sm:h-[150px]">
               <dt className="text-xl font-bold text-content-muted">
                 {labels.objectives}
               </dt>

--- a/apps/site/src/features/shared/Breadcrumb/index.tsx
+++ b/apps/site/src/features/shared/Breadcrumb/index.tsx
@@ -31,7 +31,7 @@ export const Breadcrumb: FC<IBreadcrumbProps> = ({ items, className }) => (
               />
             )}
             {isLast ? (
-              <span className="px-3 py-1.5 rounded-lg text-sm text-content-primary bg-surface-selected [.light_&]:!text-content-secondary">
+              <span className="rounded-lg bg-surface-selected px-3 py-1.5 text-sm text-content-primary [.light_&]:!text-content-secondary">
                 {item.label}
               </span>
             ) : (

--- a/apps/site/src/features/shared/ErrorView/index.tsx
+++ b/apps/site/src/features/shared/ErrorView/index.tsx
@@ -12,14 +12,14 @@ export const ErrorView: FC<ErrorViewProps> = ({ reset }) => {
   const t = useTranslations('Error');
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-y-4 text-content-primary">
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-y-4 text-content-primary">
       <h2 className="text-2xl font-semibold">{t('title')}</h2>
-      <p className="text-content-muted text-center max-w-sm">
+      <p className="max-w-sm text-center text-content-muted">
         {t('description')}
       </p>
       <button
         onClick={reset}
-        className="px-6 py-2 bg-surface text-content-primary rounded-lg font-medium hover:bg-surface-interactive transition-colors"
+        className="rounded-lg bg-surface px-6 py-2 font-medium text-content-primary transition-colors hover:bg-surface-interactive"
       >
         {t('retry')}
       </button>

--- a/apps/site/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
+++ b/apps/site/src/features/shared/HeroBanner/HeroBannerSkeleton.tsx
@@ -1,16 +1,16 @@
 export function HeroBannerSkeleton() {
   return (
-    <section className="animate-pulse flex flex-col bg-surface gap-y-6 lg:flex-row lg:rounded-xl lg:h-106">
-      <div className="flex flex-col px-6 pb-6 lg:py-20 lg:pl-20 lg:w-1/2 gap-y-4">
-        <div className="h-8 w-48 bg-surface-raised rounded" />
-        <div className="h-8 w-64 bg-surface-raised rounded" />
+    <section className="flex animate-pulse flex-col gap-y-6 bg-surface lg:h-106 lg:flex-row lg:rounded-xl">
+      <div className="flex flex-col gap-y-4 px-6 pb-6 lg:w-1/2 lg:py-20 lg:pl-20">
+        <div className="h-8 w-48 rounded bg-surface-raised" />
+        <div className="h-8 w-64 rounded bg-surface-raised" />
         <div className="flex flex-col gap-y-2 pt-4">
-          <div className="h-4 bg-surface-raised rounded w-full" />
-          <div className="h-4 bg-surface-raised rounded w-5/6" />
-          <div className="h-4 bg-surface-raised rounded w-4/6" />
+          <div className="h-4 w-full rounded bg-surface-raised" />
+          <div className="h-4 w-5/6 rounded bg-surface-raised" />
+          <div className="h-4 w-4/6 rounded bg-surface-raised" />
         </div>
       </div>
-      <div className="lg:order-1 lg:w-1/2 bg-surface-raised lg:rounded-r-xl min-h-50" />
+      <div className="min-h-50 bg-surface-raised lg:order-1 lg:w-1/2 lg:rounded-r-xl" />
     </section>
   );
 }

--- a/apps/site/src/features/shared/HeroBanner/index.tsx
+++ b/apps/site/src/features/shared/HeroBanner/index.tsx
@@ -34,7 +34,7 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
         className,
       )}
     >
-      <div className="relative h-64 flex flex-row justify-center lg:order-1 lg:h-full lg:w-1/2">
+      <div className="relative flex h-64 flex-row justify-center lg:order-1 lg:h-full lg:w-1/2">
         <Image
           src={src}
           alt={alt}
@@ -64,7 +64,7 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
         >
           {title}
         </TitleTag>
-        <p className="text-sm md:text-base lg:text-lg 2xl:text-2xl 2xl:leading-[33.6px] text-content-secondary">
+        <p className="text-sm text-content-secondary md:text-base lg:text-lg 2xl:text-2xl 2xl:leading-[33.6px]">
           {caption}
         </p>
       </div>

--- a/apps/site/src/features/shared/SkillGroup/Skill.tsx
+++ b/apps/site/src/features/shared/SkillGroup/Skill.tsx
@@ -8,10 +8,10 @@ import { Icon } from '@repo/ui/Imagery';
 export const Skill: FC<ISkillProps> = ({ icon, description }) => {
   return (
     <li
-      className="flex flex-row items-center bg-surface-raised py-1 px-3 gap-x-2 rounded-3.75"
+      className="flex flex-row items-center gap-x-2 rounded-3.75 bg-surface-raised px-3 py-1"
       title={description}
     >
-      <Icon icon={icon} className="text-xl min-w-fit" />
+      <Icon icon={icon} className="min-w-fit text-xl" />
       <span className="text-body-xs !text-content-primary">{description}</span>
     </li>
   );

--- a/apps/site/src/features/shared/SkillGroup/index.tsx
+++ b/apps/site/src/features/shared/SkillGroup/index.tsx
@@ -53,7 +53,7 @@ export const SkillGroup: FC<ISkillGroupProps> = ({
 
   return (
     <>
-      <ul className="flex flex-row gap-2 flex-wrap">
+      <ul className="flex flex-row flex-wrap gap-2">
         {renderedSkills}
         {skills.length > storedMax ? (
           <li>
@@ -63,7 +63,7 @@ export const SkillGroup: FC<ISkillGroupProps> = ({
               <button
                 type="button"
                 aria-label={t('show_more', { count: total - storedMax })}
-                className="hover:opacity-80 transition-opacity"
+                className="transition-opacity hover:opacity-80"
                 onClick={openModal}
               >
                 <Badge.Count count={total - storedMax} />

--- a/apps/site/src/features/shared/StatCard/index.tsx
+++ b/apps/site/src/features/shared/StatCard/index.tsx
@@ -10,13 +10,13 @@ interface IStatCardProps {
 
 export const StatCard: FC<IStatCardProps> = ({ label, value, icon }) => {
   return (
-    <article className="flex items-center gap-x-3 border border-border-subtle px-4 py-4 rounded-xl bg-surface/20 shadow-drop-sm">
-      <Icon icon={icon} className="text-4xl text-accent shrink-0" />
+    <article className="flex items-center gap-x-3 rounded-xl border border-border-subtle bg-surface/20 p-4 shadow-drop-sm">
+      <Icon icon={icon} className="shrink-0 text-4xl text-accent" />
       <div className="flex flex-col">
-        <span className="text-content-primary font-semibold text-lg leading-tight">
+        <span className="text-lg font-semibold leading-tight text-content-primary">
           {value}
         </span>
-        <span className="text-content-muted text-sm">{label}</span>
+        <span className="text-sm text-content-muted">{label}</span>
       </div>
     </article>
   );

--- a/apps/site/src/features/shared/TechnologiesModal/index.tsx
+++ b/apps/site/src/features/shared/TechnologiesModal/index.tsx
@@ -42,7 +42,7 @@ export const TechnologiesModal: FC<ITechnologiesModalProps> = ({
       title={t('title')}
     >
       {(company || position || hasDescriptions) && (
-        <div className="flex items-center gap-3 mb-6">
+        <div className="mb-6 flex items-center gap-3">
           {company && (
             <span className="text-xl font-bold text-content-primary">
               {company}
@@ -57,7 +57,7 @@ export const TechnologiesModal: FC<ITechnologiesModalProps> = ({
             <button
               type="button"
               onClick={() => setView(isDetailed ? 'basic' : 'detailed')}
-              className="ml-auto text-body-xs text-brand-primary hover:opacity-80 transition-opacity"
+              className="text-body-xs ml-auto text-brand-primary transition-opacity hover:opacity-80"
             >
               {isDetailed ? t('compactView') : t('viewDetails')}
             </button>
@@ -65,7 +65,7 @@ export const TechnologiesModal: FC<ITechnologiesModalProps> = ({
         </div>
       )}
 
-      {isDetailed && <hr className="border-t border-border-muted mb-6" />}
+      {isDetailed && <hr className="mb-6 border-t border-border-muted" />}
 
       {isDetailed ? (
         <ul className="flex flex-col gap-3">
@@ -79,7 +79,7 @@ export const TechnologiesModal: FC<ITechnologiesModalProps> = ({
                         {tech.icon && (
                           <Icon
                             icon={tech.icon}
-                            className="text-2xl min-w-fit"
+                            className="min-w-fit text-2xl"
                           />
                         )}
                         <span className="text-base font-bold text-content-primary">
@@ -88,11 +88,11 @@ export const TechnologiesModal: FC<ITechnologiesModalProps> = ({
                       </div>
                       <Icon
                         icon="ic:round-keyboard-arrow-down"
-                        className={`text-content-muted text-xl transition-transform duration-300 ${expanded ? 'rotate-180' : ''}`}
+                        className={`text-xl text-content-muted transition-transform duration-300 ${expanded ? 'rotate-180' : ''}`}
                       />
                     </Accordion.Header>
                     <Accordion.Body>
-                      <p className="text-sm font-normal text-content-secondary leading-[1.4] pb-3">
+                      <p className="pb-3 text-sm font-normal leading-[1.4] text-content-secondary">
                         {tech.description}
                       </p>
                     </Accordion.Body>
@@ -106,7 +106,7 @@ export const TechnologiesModal: FC<ITechnologiesModalProps> = ({
           ))}
         </ul>
       ) : (
-        <ul className="flex flex-row gap-3 flex-wrap">
+        <ul className="flex flex-row flex-wrap gap-3">
           {technologies.map((tech) => (
             <li key={tech.name}>
               {tech.icon ? (

--- a/apps/site/src/lib/og.ts
+++ b/apps/site/src/lib/og.ts
@@ -3,7 +3,6 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 interface OgImageParams {
   title: string;
   subtitle?: string;
-  tag?: string;
   locale?: string;
   page?: string;
 }
@@ -11,14 +10,12 @@ interface OgImageParams {
 export function buildOgImageUrl({
   title,
   subtitle,
-  tag,
   locale,
   page,
 }: OgImageParams): string {
   const url = new URL('/og', SITE_URL);
   url.searchParams.set('title', title);
   if (subtitle) url.searchParams.set('subtitle', subtitle);
-  if (tag) url.searchParams.set('tag', tag);
   if (locale) url.searchParams.set('locale', locale);
   if (page) url.searchParams.set('page', page);
   return url.toString();

--- a/apps/site/src/lib/og.ts
+++ b/apps/site/src/lib/og.ts
@@ -2,19 +2,25 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
 interface OgImageParams {
   title: string;
-  description?: string;
-  image?: string;
+  subtitle?: string;
+  tag?: string;
+  locale?: string;
+  page?: string;
 }
 
 export function buildOgImageUrl({
   title,
-  description,
-  image,
+  subtitle,
+  tag,
+  locale,
+  page,
 }: OgImageParams): string {
   const url = new URL('/og', SITE_URL);
   url.searchParams.set('title', title);
-  if (description) url.searchParams.set('description', description);
-  if (image) url.searchParams.set('image', image);
+  if (subtitle) url.searchParams.set('subtitle', subtitle);
+  if (tag) url.searchParams.set('tag', tag);
+  if (locale) url.searchParams.set('locale', locale);
+  if (page) url.searchParams.set('page', page);
   return url.toString();
 }
 

--- a/apps/site/src/lib/og.ts
+++ b/apps/site/src/lib/og.ts
@@ -1,0 +1,21 @@
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
+interface OgImageParams {
+  title: string;
+  description?: string;
+  image?: string;
+}
+
+export function buildOgImageUrl({
+  title,
+  description,
+  image,
+}: OgImageParams): string {
+  const url = new URL('/og', SITE_URL);
+  url.searchParams.set('title', title);
+  if (description) url.searchParams.set('description', description);
+  if (image) url.searchParams.set('image', image);
+  return url.toString();
+}
+
+export { SITE_URL };

--- a/apps/site/tailwind.config.ts
+++ b/apps/site/tailwind.config.ts
@@ -11,6 +11,18 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        // OG card palette — design reference only.
+        // next/og (Satori) uses its own Tailwind interpreter and does not
+        // read this config, so these tokens cannot be used via the tw prop
+        // in apps/site/src/app/og/route.tsx.
+        og: {
+          accent: '#5CD66E',
+          dark: '#070B12',
+          'canvas-mid': '#0E1622',
+          'canvas-end': '#10251C',
+        },
+      },
       height: {
         'sidenav-desktop': 'calc(100vh - var(--header-height-desktop))',
         'sidenav-mobile': 'calc(100vh - var(--header-height-mobile))',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-perf": "^3.3.2",
     "eslint-plugin-react-refresh": "^0.4.12",
+    "eslint-plugin-tailwindcss": "^3.18.3",
     "typescript": "^5.3.3"
   }
 }

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -17,6 +17,7 @@ module.exports = {
     "plugin:react-hooks/recommended",
     "plugin:react-perf/recommended",
     "plugin:jsx-a11y/recommended",
+    "plugin:tailwindcss/recommended",
   ],
   globals: {
     React: true,
@@ -36,6 +37,7 @@ module.exports = {
     "react-hooks",
     "react-perf",
     "jsx-a11y",
+    "tailwindcss",
   ],
   rules: {
     "prettier/prettier": ["error"],
@@ -135,6 +137,9 @@ module.exports = {
     },
     react: {
       version: "detect",
+    },
+    tailwindcss: {
+      classAttributes: ["class", "className", "tw"],
     },
   },
   ignorePatterns: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.12
         version: 0.4.26(eslint@8.57.1)
+      eslint-plugin-tailwindcss:
+        specifier: ^3.18.3
+        version: 3.18.3(tailwindcss@3.4.19)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -5391,6 +5394,19 @@ packages:
       string.prototype.repeat: 1.0.0
     dev: true
 
+  /eslint-plugin-tailwindcss@3.18.3(tailwindcss@3.4.19):
+    resolution: {integrity: sha512-lqjNX7mt1Ip2qR236hvhbZ9ff2TFLUWou+tBHz82SA1nWFzOZSoEOI+9UBZmuf2977r2MMp9/y3/broyz8AYig==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      tailwindcss: ^3.4.0 || ^4.0.0
+    dependencies:
+      fast-glob: 3.3.3
+      postcss: 8.5.15
+      synckit: 0.11.13
+      tailwind-api-utils: 1.0.3(tailwindcss@3.4.19)
+      tailwindcss: 3.4.19
+    dev: true
+
   /eslint-plugin-testing-library@6.5.0(eslint@8.57.1)(typescript@5.9.3):
     resolution: {integrity: sha512-Ls5TUfLm5/snocMAOlofSOJxNN0aKqwTlco7CrNtMjkTdQlkpSMaeTCDHCuXfzrI97xcx2rSCNeKeJjtpkNC1w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
@@ -6934,6 +6950,15 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
+  /local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
+    dev: true
+
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -8183,6 +8208,10 @@ packages:
   /pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  /quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+    dev: true
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
@@ -9047,6 +9076,17 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/core': 0.3.6
+    dev: true
+
+  /tailwind-api-utils@1.0.3(tailwindcss@3.4.19):
+    resolution: {integrity: sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==}
+    peerDependencies:
+      tailwindcss: ^3.3.0 || ^4.0.0 || ^4.0.0-beta
+    dependencies:
+      enhanced-resolve: 5.24.0
+      jiti: 2.7.0
+      local-pkg: 1.2.1
+      tailwindcss: 3.4.19
     dev: true
 
   /tailwindcss@3.4.19:


### PR DESCRIPTION
## Summary

- Adds Edge route `/og` that generates 1200×630 PNG cards via `next/og` (Satori) for Home, About, and Projects pages
- Dark gradient card template with "W" watermark, locale badge, title, green underline, subtitle, and page label in footer
- Extracts `SITE_URL` and `buildOgImageUrl()` helper to `lib/og.ts` to avoid duplication across page metadata
- Wires OG image to Home, About, and Projects `generateMetadata()`; project detail pages continue using `coverImage.url` directly
- Fixes next-intl middleware matcher to exclude `/og` from locale redirect
- Migrates inline styles to `tw` prop (Satori's Tailwind interpreter); only the `linear-gradient` background remains as `style` — Satori does not support `bg-[linear-gradient()]` via `tw`
- Footer URL derived from `NEXT_PUBLIC_SITE_URL` env var instead of hardcoded string
- Adds `eslint-plugin-tailwindcss@^3` to `@repo/eslint-config` with `classAttributes: ["class", "className", "tw"]` so the `tw` prop is lint-checked
- Adds OG color palette tokens to `apps/site/tailwind.config.ts` as design reference (`og.accent`, `og.dark`, `og.canvas-mid`, `og.canvas-end`)

## Test plan

- [ ] Hit `/og?title=Wallace+Ferreira&locale=en-US&page=HOME` locally and verify PNG renders correctly
- [ ] Verify Home, About, and Projects pages return correct `og:image` meta tag
- [ ] Deploy to Vercel preview and confirm `/og` route returns a valid PNG (not 0 bytes)
- [ ] Share a page URL on a social debugger (e.g. LinkedIn Post Inspector) and confirm card renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)