### PR TITLE
feat(seo): dynamic OG image generation with internationalized content

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -144,15 +144,24 @@
     "Layout": {
       "description": "Frontend Software Engineer with 6+ years of experience building scalable, performant, and accessible web products with React, Next.js, and TypeScript."
     },
+    "OgCard": {
+      "jobTitle": "Front-end Software Engineer"
+    },
     "HomePage": {
-      "title": "Home"
+      "title": "Home",
+      "ogSubtitle": "Frontend Engineer building scalable, performant, and accessible web experiences.",
+      "ogPage": "HOME"
     },
     "AboutPage": {
-      "title": "About"
+      "title": "About",
+      "ogSubtitle": "6+ years building modern web products with React, Next.js, and TypeScript.",
+      "ogPage": "ABOUT"
     },
     "ProjectsPage": {
       "title": "Projects",
-      "description": "Software projects developed by Wallace Ferreira — scalable web applications built with React, Next.js, and TypeScript."
+      "description": "Software projects developed by Wallace Ferreira — scalable web applications built with React, Next.js, and TypeScript.",
+      "ogSubtitle": "Scalable web applications built with modern frontend technologies.",
+      "ogPage": "PROJECTS"
     }
   },
   "Feed": {

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -144,15 +144,24 @@
     "Layout": {
       "description": "Ingeniero de Software Frontend con más de 6 años de experiencia construyendo productos web escalables, eficientes y accesibles con React, Next.js y TypeScript."
     },
+    "OgCard": {
+      "jobTitle": "Ingeniero de Software Frontend"
+    },
     "HomePage": {
-      "title": "Inicio"
+      "title": "Inicio",
+      "ogSubtitle": "Ingeniero Frontend creando experiencias web escalables, eficientes y accesibles.",
+      "ogPage": "INICIO"
     },
     "AboutPage": {
-      "title": "Sobre"
+      "title": "Sobre",
+      "ogSubtitle": "Más de 6 años construyendo productos web modernos con React, Next.js y TypeScript.",
+      "ogPage": "SOBRE"
     },
     "ProjectsPage": {
       "title": "Proyectos",
-      "description": "Proyectos de software desarrollados por Wallace Ferreira — aplicaciones web escalables con React, Next.js y TypeScript."
+      "description": "Proyectos de software desarrollados por Wallace Ferreira — aplicaciones web escalables con React, Next.js y TypeScript.",
+      "ogSubtitle": "Aplicaciones web escalables construidas con tecnologías frontend modernas.",
+      "ogPage": "PROYECTOS"
     }
   },
   "Feed": {

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -144,15 +144,24 @@
     "Layout": {
       "description": "Engenheiro de Software Frontend com mais de 6 anos de experiência construindo produtos web escaláveis, performáticos e acessíveis com React, Next.js e TypeScript."
     },
+    "OgCard": {
+      "jobTitle": "Engenheiro de Software Frontend"
+    },
     "HomePage": {
-      "title": "Início"
+      "title": "Início",
+      "ogSubtitle": "Engenheiro Frontend criando experiências web escaláveis, performáticas e acessíveis.",
+      "ogPage": "INÍCIO"
     },
     "AboutPage": {
-      "title": "Sobre"
+      "title": "Sobre",
+      "ogSubtitle": "6+ anos construindo produtos web modernos com React, Next.js e TypeScript.",
+      "ogPage": "SOBRE"
     },
     "ProjectsPage": {
       "title": "Projetos",
-      "description": "Projetos de software desenvolvidos por Wallace Ferreira — aplicações web escaláveis com React, Next.js e TypeScript."
+      "description": "Projetos de software desenvolvidos por Wallace Ferreira — aplicações web escaláveis com React, Next.js e TypeScript.",
+      "ogSubtitle": "Aplicações web escaláveis construídas com tecnologias frontend modernas.",
+      "ogPage": "PROJETOS"
     }
   },
   "Feed": {

--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -47,9 +47,10 @@ export async function generateMetadata({
         {
           url: buildOgImageUrl({
             title,
-            subtitle: bio,
+            subtitle: t('AboutPage.ogSubtitle'),
             locale,
-            page: 'ABOUT',
+            page: t('AboutPage.ogPage'),
+            jobTitle: t('OgCard.jobTitle'),
           }),
           width: 1200,
           height: 630,

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -44,9 +44,10 @@ export async function generateMetadata({
         {
           url: buildOgImageUrl({
             title: name,
-            subtitle: t('Layout.description'),
+            subtitle: t('HomePage.ogSubtitle'),
             locale,
-            page: 'HOME',
+            page: t('HomePage.ogPage'),
+            jobTitle: t('OgCard.jobTitle'),
           }),
           width: 1200,
           height: 630,

--- a/apps/site/src/app/[locale]/projects/page.tsx
+++ b/apps/site/src/app/[locale]/projects/page.tsx
@@ -37,9 +37,10 @@ export async function generateMetadata({
         {
           url: buildOgImageUrl({
             title,
-            subtitle: description,
+            subtitle: t('ProjectsPage.ogSubtitle'),
             locale,
-            page: 'PROJECTS',
+            page: t('ProjectsPage.ogPage'),
+            jobTitle: t('OgCard.jobTitle'),
           }),
           width: 1200,
           height: 630,

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -15,6 +15,8 @@ export async function GET(req: NextRequest) {
   const subtitle = searchParams.get('subtitle') ?? '';
   const locale = searchParams.get('locale') ?? DEFAULT_LOCALE;
   const page = searchParams.get('page') ?? '';
+  const jobTitle =
+    searchParams.get('jobTitle') ?? 'Front-end Software Engineer';
 
   return new ImageResponse(
     <div
@@ -35,9 +37,7 @@ export async function GET(req: NextRequest) {
           <div tw="flex text-[54px] font-extrabold text-[#5CD66E]">W</div>
           <div tw="flex flex-col">
             <div tw="flex text-[28px] font-semibold">Wallace Ferreira</div>
-            <div tw="flex text-[22px] text-[#94A3B8]">
-              Front-end Software Engineer
-            </div>
+            <div tw="flex text-[22px] text-[#94A3B8]">{jobTitle}</div>
           </div>
         </div>
         {locale && (

--- a/apps/site/src/lib/og.ts
+++ b/apps/site/src/lib/og.ts
@@ -5,6 +5,7 @@ interface OgImageParams {
   subtitle?: string;
   locale?: string;
   page?: string;
+  jobTitle?: string;
 }
 
 export function buildOgImageUrl({
@@ -12,12 +13,14 @@ export function buildOgImageUrl({
   subtitle,
   locale,
   page,
+  jobTitle,
 }: OgImageParams): string {
   const url = new URL('/og', SITE_URL);
   url.searchParams.set('title', title);
   if (subtitle) url.searchParams.set('subtitle', subtitle);
   if (locale) url.searchParams.set('locale', locale);
   if (page) url.searchParams.set('page', page);
+  if (jobTitle) url.searchParams.set('jobTitle', jobTitle);
   return url.toString();
 }
 


### PR DESCRIPTION
## Summary

- Adds a `/og` Edge route that generates Open Graph images via `next/og` (Satori) with a branded dark-gradient card design
- Extracts `SITE_URL` and `buildOgImageUrl()` helper into `~/lib/og` to centralize OG URL construction
- Refactors all inline styles to Satori's `tw` prop; keeps only the gradient background as an inline `style` (Satori limitation — multi-stop linear gradients are not supported via `tw`)
- Adds OG color tokens to `apps/site/tailwind.config.ts` as design reference (with comment explaining Satori does not read this config)
- Adds `eslint-plugin-tailwindcss@^3` with `classAttributes: ["class", "className", "tw"]` so ESLint recognizes the `tw` prop
- Internationalizes all OG card content — fixed per-page subtitles, localized page labels, and localized job title — across `en-US`, `pt-BR`, and `es`

## Test plan

- [ ] Visit `/og?title=Wallace+Ferreira&locale=en-US&page=HOME&subtitle=...&jobTitle=Front-end+Software+Engineer` and confirm the card renders correctly
- [ ] Verify Home, About, and Projects pages produce valid OG image URLs with locale-specific content
- [ ] Confirm `pt-BR` and `es` locales render translated job title and page labels on the OG card
- [ ] Confirm no TypeScript errors (`tsc --noEmit`)
- [ ] Confirm build passes (`turbo build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)