### PR TITLE
fix(utils): remove react eslint config from pure TypeScript package

### DIFF
--- a/packages/utils/.eslintrc.js
+++ b/packages/utils/.eslintrc.js
@@ -3,7 +3,6 @@ module.exports = {
   root: true,
   extends: [
     '@repo/eslint-config/library.js',
-    '@repo/eslint-config/react.js',
     'plugin:@typescript-eslint/recommended',
   ],
   parser: '@typescript-eslint/parser',


### PR DESCRIPTION
## Summary

- Removes `@repo/eslint-config/react.js` from `packages/utils/.eslintrc.js`
- `@repo/utils` is a framework-agnostic utility library (no JSX, no Tailwind) — the react config was incorrectly included, pulling in `plugin:tailwindcss/recommended` which failed to resolve `tailwindcss` in this package context
- This was causing the entire monorepo lint to fail on every pre-commit hook

## Test plan

- [ ] Run `pnpm lint:check` and verify no errors from `@repo/utils`

🤖 Generated with [Claude Code](https://claude.com/claude-code)