### PR TITLE
feat(ui): improve TextRich typography for blog-like reading experience

### DIFF
--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -22,6 +22,7 @@ const nextConfig = {
       { protocol: 'https', hostname: 'github.com' },
       { protocol: 'https', hostname: 'opengraph.githubassets.com' },
       { protocol: 'https', hostname: '*.supabase.co' },
+      { protocol: 'https', hostname: 'cdn.shopify.com' },
     ],
   },
 };

--- a/packages/infra/prisma/seeders.ts
+++ b/packages/infra/prisma/seeders.ts
@@ -41,6 +41,7 @@ export const ID = {
     b2bEcommerce: '30000000-0000-4000-8000-000000000002',
     gamePlatform: '30000000-0000-4000-8000-000000000003',
     mqttClient: '30000000-0000-4000-8000-000000000004',
+    buyrShopifyApp: '30000000-0000-4000-8000-000000000005',
   },
   experiences: {
     fdte_current: '40000000-0000-4000-8000-000000000001',
@@ -449,6 +450,97 @@ Built the entire frontend with **React.js**, **Material UI**, and **GraphQL**, i
       periodStart: new Date('2023-10-01'),
       periodEnd: new Date('2023-12-31'),
       skillIds: [ID.skills.typescript, ID.skills.react, ID.skills.graphql],
+      relatedProjectSlugs: [],
+    },
+    {
+      id: ID.projects.buyrShopifyApp,
+      slug: 'buyr-shopify-app',
+      coverImageUrl:
+        'https://cdn.shopify.com/app-store/listing_images/6537909634eb9e249e1de55ca0ba2f65/promotional_image/CMfgkeeMwI4DEAE=.png',
+      coverImageAlt: loc(
+        'Buyr Shopify app — interactive pricing and AI offer negotiation',
+        'App Buyr para Shopify — precificação interativa e negociação de ofertas por IA',
+        'App Buyr para Shopify — precios interactivos y negociación de ofertas por IA',
+      ),
+      title: loc('Buyr — Shopify App', 'Buyr — App para Shopify', 'Buyr — App para Shopify'),
+      caption: loc(
+        'A public Shopify app with AI-powered offer negotiation — built across storefront and merchant admin with a focus on performance, isolation, and polish.',
+        'App público da Shopify com negociação de ofertas por IA — construído no storefront e no admin do merchant com foco em performance, isolamento e polimento.',
+        'App público de Shopify con negociación de ofertas por IA — construido en el storefront y el admin del merchant con foco en performance, aislamiento y polish.',
+      ),
+      content: `[Buyr](https://apps.shopify.com/buyr) is a public Shopify app that lets shoppers set their own price or negotiate with an AI agent — ==capturing orders that would otherwise be lost at full price==. Merchants configure profitability thresholds; Buyr handles the negotiation automatically.
+
+I was brought in to solve an animation problem no one on the team had tackled before, and ended up contributing across both sides of the product: the storefront experience buyers see and the merchant admin dashboard. Working with a distributed team across Brazil and the United States, we delivered the MVP against a fixed deadline, followed by a post-MVP improvement phase.
+
+## The Constraints
+
+The app runs embedded inside any Shopify storefront theme — with no control over the host's CSS, JavaScript environment, or component structure. A merchant running a minimalist theme and another running a custom brand theme would silently break the same widget in different ways.
+
+On top of that, ==Shopify's own acceptance criteria imposed strict performance thresholds the app had to meet to stay listed in the App Store==. Performance wasn't optional — it was a gate.
+
+![Interactive price input and AI negotiation chat interface](https://cdn.shopify.com/app-store/listing_images/6537909634eb9e249e1de55ca0ba2f65/desktop_screenshot/CIX6nOeMwI4DEAE=.png)
+
+*The storefront widget — interactive price input with AI negotiation chat.*
+
+## Storefront
+
+### Rebuilding the animation system
+
+The storefront widget had an animation system — but only as compiled vanilla JavaScript with no readable source. ==I reverse-engineered the behavior visually and rebuilt it from scratch using **Framer Motion**==, making it a proper state-driven system connected to the offer lifecycle:
+
+- **Idle** — ambient animated circles while the shopper browses
+- **In progress** — active animation while the offer is being created
+- **Success** — confetti burst with a yellow checkmark circle
+- **Existing offer** — distinct animation state for returning shoppers
+
+State was managed via React Context API, flowing through the entire storefront component tree.
+
+### Solving CSS isolation with Shadow DOM
+
+While testing across different Shopify themes, I found that merchant CSS would leak into the widget and break the layout in unpredictable ways. ==I investigated the root cause, identified Shadow DOM as the right boundary, and implemented it to fully isolate the app's styles== from whatever the host storefront was doing. This wasn't a requirement — it was a decision I made after diagnosing the problem.
+
+### Performance improvements
+
+Meeting Shopify's App Store performance requirements meant treating performance as a deliverable, not an afterthought. I studied comparable apps in the store, tracked metrics in a spreadsheet, and drove the following improvements:
+
+- **On-demand rendering** — only mount the widget when it's actually needed
+- **Dead code removal** — stripped unused dependencies and unreachable branches
+- **Offer flow simplification** — reduced steps and component depth in the critical path
+- **Refactoring** — replaced inefficient loops, over-engineered hooks, and global state misuse
+
+## Merchant Admin
+
+![Real-time offer management dashboard for merchants](https://cdn.shopify.com/app-store/listing_images/6537909634eb9e249e1de55ca0ba2f65/desktop_screenshot/CIP0xLL234wDEAE=.png)
+
+*Real-time offer management — merchants see and act on incoming offers as they arrive.*
+
+On the merchant side, I built three screens using **Shopify Polaris**:
+
+- **Offer acceptance flow** — pixel-perfect implementation of how merchants review and accept incoming offers
+- **Analytics screen** — dashboard giving merchants visibility into received vs. accepted offers over time
+- **Onboarding / welcome screen** — guided setup experience for merchants installing the app for the first time
+
+![Custom pricing models configuration screen](https://cdn.shopify.com/app-store/listing_images/6537909634eb9e249e1de55ca0ba2f65/desktop_screenshot/CK35r7L234wDEAE=.png)
+
+*Custom pricing models — merchants define thresholds and discount rules per product.*
+
+## Technical Highlights
+
+- **Monorepo with npm workspaces** — storefront (Vite + Tailwind) and merchant admin (Shopify Polaris) as fully separate apps
+- **Framer Motion** — multi-state, choreographed animation system driven by React Context API
+- **Shadow DOM** — CSS isolation across unpredictable storefront host environments
+- **Shopify App Bridge**, **Theme App Extensions**, and **Storefront API** — learned and applied in full across both contexts
+- **Fixed deadline** delivery with a structured post-MVP improvement phase`,
+      featured: false,
+      status: 'PUBLISHED' as const,
+      periodStart: new Date('2024-10-01'),
+      periodEnd: new Date('2025-02-28'),
+      skillIds: [
+        ID.skills.typescript,
+        ID.skills.react,
+        ID.skills.tailwindcss,
+        ID.skills.shopify,
+      ],
       relatedProjectSlugs: [],
     },
     {

--- a/packages/ui/globals.css
+++ b/packages/ui/globals.css
@@ -7,3 +7,125 @@
   font-family: inherit;
   font-size: inherit;
 }
+
+.markdown-body ul {
+  list-style-type: disc;
+}
+
+.markdown-body ol {
+  list-style-type: decimal;
+}
+
+.markdown-body h2 {
+  color: rgb(var(--tw-brand-accent));
+}
+
+.markdown-body h3 {
+  color: rgb(var(--tw-brand-primary));
+}
+
+.markdown-body a {
+  color: rgb(var(--tw-brand-accent));
+  text-decoration: underline;
+  text-decoration-color: rgb(var(--tw-brand-accent) / 0.4);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.2s;
+}
+
+.markdown-body a:hover {
+  text-decoration-color: rgb(var(--tw-brand-accent));
+}
+
+.markdown-body strong {
+  color: rgb(var(--tw-content-primary));
+  font-weight: 700;
+}
+
+/* Light mode overrides */
+.light .markdown-body h2 {
+  color: rgb(var(--tw-brand-primary));
+}
+
+.light .markdown-body h3 {
+  color: rgb(var(--tw-brand-primary));
+}
+
+.light .markdown-body a {
+  color: rgb(var(--tw-brand-primary));
+  text-decoration-color: rgb(var(--tw-brand-primary) / 0.4);
+}
+
+.light .markdown-body a:hover {
+  text-decoration-color: rgb(var(--tw-brand-primary));
+}
+
+/* Lede — first paragraph reads like a newspaper lead */
+.markdown-body > p:first-of-type {
+  font-size: 1.125rem;
+  color: rgb(var(--tw-content-secondary));
+  line-height: 1.8;
+}
+
+/* Drop cap — first letter floats large, editorial feel */
+.markdown-body > p:first-of-type::first-letter {
+  float: left;
+  font-size: 3.75rem;
+  font-weight: 700;
+  line-height: 0.82;
+  margin-right: 0.08em;
+  margin-top: 0.06em;
+  color: rgb(var(--tw-brand-accent));
+}
+
+/* Blockquote as pull quote */
+.markdown-body blockquote {
+  border-left: 3px solid rgb(var(--tw-brand-accent));
+  background: transparent;
+  padding: 0.5rem 1.25rem;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: rgb(var(--tw-content-secondary));
+}
+
+.markdown-body blockquote p {
+  margin: 0;
+}
+
+/* hr as editorial gradient separator */
+.markdown-body hr {
+  border: none;
+  height: 1px;
+  background: linear-gradient(to right, transparent, rgb(var(--tw-brand-accent) / 0.5), transparent);
+  margin: 2rem 0;
+}
+
+/* Bullet labels — first bold in each list item gets accent color */
+.markdown-body li > strong:first-child,
+.markdown-body li > p > strong:first-child {
+  color: rgb(var(--tw-brand-accent));
+}
+
+.light .markdown-body li > strong:first-child,
+.light .markdown-body li > p > strong:first-child {
+  color: rgb(var(--tw-brand-primary));
+}
+
+/* Highlight — marca-texto para partes-chave */
+.markdown-body mark {
+  background-color: rgba(251, 191, 36, 0.18);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0.05em 0.25em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+/* Image caption — em as only child of p that follows an img-containing p */
+.markdown-body p:has(img) + p > em:only-child {
+  display: block;
+  text-align: center;
+  font-size: 0.8125rem;
+  color: rgb(var(--tw-content-muted));
+  margin-top: -0.75rem;
+  font-style: italic;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,13 +54,16 @@
     "@repo/utils": "workspace:*",
     "classnames": "^2.5.1",
     "github-markdown-css": "^5.9.0",
+    "hast-util-sanitize": "^5.0.2",
     "mermaid": "^11.15.0",
     "react-markdown": "^9.0.1",
     "react-tooltip": "^5.28.0",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",
+    "remark-mark-highlight": "^0.1.1",
     "tiny-invariant": "^1.3.3",
+    "unified": "^11.0.5",
     "usehooks-ts": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/ui/src/View/TextRich/constants.ts
+++ b/packages/ui/src/View/TextRich/constants.ts
@@ -1,6 +1,18 @@
-import rehypeRaw from 'rehype-raw';
-import rehypeSanitize from 'rehype-sanitize';
-import remarkGfm from 'remark-gfm';
+import type { Schema } from 'hast-util-sanitize';
+import type { PluggableList } from 'unified';
 
-export const REMARK_PLUGINS = [remarkGfm];
-export const REHYPE_PLUGINS = [rehypeRaw, rehypeSanitize];
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import remarkGfm from 'remark-gfm';
+import { remarkMark } from 'remark-mark-highlight';
+
+const sanitizeSchema: Schema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'mark'],
+};
+
+export const REMARK_PLUGINS: PluggableList = [remarkGfm, remarkMark];
+export const REHYPE_PLUGINS: PluggableList = [
+  rehypeRaw,
+  [rehypeSanitize, sanitizeSchema],
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,9 @@ importers:
       github-markdown-css:
         specifier: ^5.9.0
         version: 5.9.0
+      hast-util-sanitize:
+        specifier: ^5.0.2
+        version: 5.0.2
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -477,9 +480,15 @@ importers:
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
+      remark-mark-highlight:
+        specifier: ^0.1.1
+        version: 0.1.1
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       usehooks-ts:
         specifier: ^3.1.1
         version: 3.1.1(react@19.2.7)
@@ -9071,6 +9080,10 @@ packages:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /remark-mark-highlight@0.1.1:
+    resolution: {integrity: sha512-ot2AE37OKO2YQTcqyZ8VatEGJV/7CXk/RPJHk2TEVm04pT+JLCnoQb4Yj1vdOv2y4ZK45cDylj19gYVHqHz7Tw==}
     dev: false
 
   /remark-parse@11.0.0:


### PR DESCRIPTION
## Summary

- Add blog-inspired CSS to `.markdown-body`: lede paragraph, drop cap, pull quote blockquote, editorial hr gradient, and image captions
- Add accent/primary colors to `h2`, `h3`, links, and `li strong:first-child` (bullet labels)
- Fix `list-style-type` reset caused by Tailwind Preflight (bullets weren't rendering)
- Add `remark-mark-highlight` plugin to support `==highlight==` syntax → `<mark>` element
- Allow `<mark>` tag in `rehype-sanitize` schema
- Add Buyr Shopify app to seed with rich markdown content: inline images, captions, `==highlights==`, and structured headings
- Add `cdn.shopify.com` to `next.config.mjs` remotePatterns

## Test plan

- [ ] Navigate to `/projects/buyr-shopify-app` and verify: drop cap on first paragraph, green h2/h3 headings, colored bullet labels, amber highlights, image captions, bullets visible
- [ ] Verify `==text==` syntax renders as highlighted text in any project content
- [ ] Verify `> blockquote` renders with green left border
- [ ] Verify light mode colors are correct (primary blue instead of accent green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)