### PR TITLE
feat(content): add Technologies section to Buyr project content

### DIFF
--- a/packages/infra/prisma/seeders.ts
+++ b/packages/infra/prisma/seeders.ts
@@ -524,6 +524,18 @@ On the merchant side, I built three screens using **Shopify Polaris**:
 
 *Custom pricing models — merchants define thresholds and discount rules per product.*
 
+## Technologies
+
+- [React](https://react.dev) — storefront widget and merchant admin UI
+- [Framer Motion](https://www.framer.com/motion/) — animation system for the offer lifecycle states
+- [Vite](https://vite.dev) — storefront app bundler
+- [Tailwind CSS](https://tailwindcss.com) — utility-first styling for the storefront widget
+- [Shopify Polaris](https://polaris.shopify.com) — design system for the merchant admin screens
+- [Shopify App Bridge](https://shopify.dev/docs/api/app-bridge) — SDK for embedding the app inside the Shopify admin
+- [Theme App Extensions](https://shopify.dev/docs/apps/build/online-store/theme-app-extensions) — mechanism for injecting the storefront widget into merchant themes
+- [Storefront API](https://shopify.dev/docs/api/storefront) — Shopify GraphQL API used on the buyer-facing side
+- [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM) — CSS isolation layer between the widget and the host storefront theme
+
 ## Technical Highlights
 
 - **Monorepo with npm workspaces** — storefront (Vite + Tailwind) and merchant admin (Shopify Polaris) as fully separate apps


### PR DESCRIPTION
## Summary

- Add `## Technologies` section to Buyr seed content with 9 technologies, each linked to official documentation
- Section is placed before `## Technical Highlights` — from most central to most peripheral
- Establishes the pattern for all future project content: technologies are cited inline throughout the text and then consolidated with docs links in a dedicated section

## Technologies added

React, Framer Motion, Vite, Tailwind CSS, Shopify Polaris, Shopify App Bridge, Theme App Extensions, Storefront API, Shadow DOM (MDN)

## Test plan

- [ ] Navigate to `/projects/buyr-shopify-app` and verify the Technologies section renders with clickable links
- [ ] Verify links open the correct official documentation pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)