### PR TITLE
feat(skills): add project-content skill and writing instructions

### DIFF
--- a/.claude/skills/project-content/SKILL.md
+++ b/.claude/skills/project-content/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: project-content
+description: Write or edit project content for the portfolio — narrative structure, Technologies section, highlight syntax, and tone. Use when writing the content field of a project seed entry.
+---
+
+# Project Content Writing
+
+## Use when
+
+- User asks to write, edit, or review the `content` field of a project in `packages/infra/prisma/seeders.ts`
+- User mentions **project narrative**, **content writing**, **project description**, **escrever projeto**, or **conteúdo do projeto**
+- User wants to add a new project to the portfolio and needs to draft the prose
+
+## Reference (single source of truth)
+
+- [project_content.instructions.md](../../../.github/instructions/project_content.instructions.md) — narrative structure, required sections (including Technologies), standard questions, and tone guidelines
+
+Do not duplicate content here; the instructions file is the authoritative source.
+
+## Workflow
+
+1. **Collect context** — if the project is new, work through the standard questions from the instructions file conversationally. The user may answer freely; map answers to the question framework.
+2. **Draft** — follow the narrative structure: opening → Constraints → Contribution sections → Technologies → Technical Highlights
+3. **Apply markdown features** — use `==text==` for 3–5 key highlights, `**Label** —` for bullet items, `*caption*` after images
+4. **Write to seeder** — the final content goes in `packages/infra/prisma/seeders.ts` as the `content` field of the project entry
+5. **Run seed** — always run `pnpm run seed` after editing the seeder to apply changes

--- a/.github/instructions/project_content.instructions.md
+++ b/.github/instructions/project_content.instructions.md
@@ -1,0 +1,107 @@
+---
+description: Standards for writing project content in the portfolio — narrative structure, required sections, questions to answer, and tone guidelines.
+applyTo: "packages/infra/prisma/seeders.ts"
+---
+
+# Project Content Writing Standards
+
+These instructions apply whenever writing or editing the `content` field of a project in the seed file (`packages/infra/prisma/seeders.ts`).
+
+---
+
+## Narrative Structure
+
+Every project follows this order: **Constraints first → Context → Contribution → Result**
+
+This structure works because it answers, in order, the questions a recruiter or senior dev actually asks:
+1. *Was this hard?* (Constraints)
+2. *What did you do?* (Contribution)
+3. *Did it work?* (Result)
+
+---
+
+## Required Sections
+
+### Opening paragraph (no heading)
+- 1–2 sentences establishing what the product does and who it serves
+- Mention the central constraint or unusual aspect of the project
+- Sets tone: credibility over marketing
+
+### `## The Constraints`
+- What made this project difficult or non-obvious
+- Technical constraints, environment, timeline, team distribution
+- **Do not list technologies here** — this block is about context and tension
+
+### `## [Area of Contribution]` (e.g. `## Storefront`, `## Merchant Admin`)
+- What you specifically built, owned, or solved
+- Use ownership verbs: *built*, *designed*, *owned*, *architected*, *led*, *solved*, *investigated*
+- Sub-sections with `###` for distinct workstreams within the same area
+
+### `## Technologies`
+- List the main technologies with links to official documentation
+- One sentence per item describing the role it played in this specific project
+- **Order**: most central to most peripheral
+- Include only what helps the reader understand the project — not every tool touched
+
+```markdown
+## Technologies
+
+- [React](https://react.dev) — storefront widget and merchant admin UI
+- [Framer Motion](https://www.framer.com/motion/) — animation system for the offer lifecycle states
+```
+
+### `## Technical Highlights`
+- Architecture and technical decisions that are non-obvious
+- Each bullet answers "why does this matter", not just "what was done"
+- Format: `**Decision** — justification or impact`
+
+---
+
+## Standard Questions
+
+Answer these before writing the first draft. Mark `n/a` for anything confidential or not applicable.
+
+**Context**
+- [ ] What did the product do for the end user? (one sentence)
+- [ ] Who used it? (user type, scale — e.g. "800+ operators", "internal team of 10")
+- [ ] What was the state when you joined? (greenfield, legacy, in production)
+
+**Constraints**
+- [ ] Was there a fixed deadline?
+- [ ] Were there technical constraints from the environment?
+- [ ] Was the team distributed? How many people, which countries?
+- [ ] Any business rules or compliance that complicated technical decisions?
+
+**Your contribution**
+- [ ] What was your specific responsibility? (feature, module, layer, full product)
+- [ ] Did you have full ownership or were you part of a larger team?
+- [ ] What was the most important technical decision you made?
+- [ ] What did you build from scratch vs. what did you evolve?
+
+**Technical**
+- [ ] What was the main stack?
+- [ ] Any non-obvious architecture decision worth mentioning?
+- [ ] Was there a hard technical problem you solved? How?
+- [ ] Which technologies deserve a link to documentation?
+
+**Result**
+- [ ] Did it ship to production? Is it in use?
+- [ ] Any impact metric? (users, volume, time saved, error reduction)
+- [ ] If no numbers: what was the state before vs. after?
+
+**Visibility**
+- [ ] Can the company/product name be cited?
+- [ ] Are there screenshots, links, or visual material available?
+- [ ] Any information that cannot appear publicly?
+
+---
+
+## Tone Guidelines
+
+- Write from the perspective of someone who solved a problem, not someone listing skills
+- Avoid: *"I used React to build..."* → prefer: *"Built with React, the widget..."*
+- Keep technical English — no marketing jargon
+- Target length: 250–400 words in the rendered `content` field
+- Use `==text==` to highlight 3–5 key phrases the reader will scan for
+- Use `**Label** — description` format for bullet items (label gets accent color)
+- Use `*italic caption*` as the only content in a paragraph after an image (renders as caption)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,7 @@ Choose which skill to follow based on the user's intent. Then read the correspon
 | Plan refactor, refactoring RFC, tiny commits refactor, safe incremental refactor | **request-refactor-plan** | Follow [.claude/skills/request-refactor-plan/SKILL.md](.claude/skills/request-refactor-plan/SKILL.md); file as GitHub issue |
 | Git guardrails, block dangerous git, block push/reset/clean, git safety hooks | **git-guardrails-claude-code** | Follow [.claude/skills/git-guardrails-claude-code/SKILL.md](.claude/skills/git-guardrails-claude-code/SKILL.md); PreToolUse hook |
 | Ubiquitous language, domain glossary, DDD terms, domain model terminology | **ubiquitous-language** | Follow [.claude/skills/ubiquitous-language/SKILL.md](.claude/skills/ubiquitous-language/SKILL.md); output UBIQUITOUS_LANGUAGE.md |
+| Project content, write project, project narrative, escrever projeto, conteúdo do projeto, Technologies section, project description | **project-content** | Follow [.claude/skills/project-content/SKILL.md](.claude/skills/project-content/SKILL.md); use project_content.instructions.md |
 | Implementation, DDD, Clean Architecture, Either, Validator, Entity, VO, use case, repository, or no other skill matches | **engineering-standards** | Follow [.claude/skills/engineering-standards/SKILL.md](.claude/skills/engineering-standards/SKILL.md); use CLAUDE.md (this file), docs/INDEX.md, 02/06/08/09-*.md |
 
 Default to **engineering-standards** when the request is about writing or refactoring code and no other skill context is clear.


### PR DESCRIPTION
## Summary

- Add `.github/instructions/project_content.instructions.md` — single source of truth for how to write project content: narrative structure, required sections (opening, Constraints, Contribution, Technologies, Technical Highlights), standard questions checklist, and tone guidelines
- Add `.claude/skills/project-content/SKILL.md` — skill entrypoint with workflow steps (collect context → draft → apply markdown → write to seeder → run seed)
- Register `project-content` in the CLAUDE.md skill router with keywords: *project content, write project, project narrative, escrever projeto, conteúdo do projeto, Technologies section*

## Why

The writing template and questions were living in `tmp/content/` which is gitignored — lost on clean clones and invisible to the AI without being explicitly pointed to. This moves them to versioned, auto-discoverable locations so both the user and the AI have a consistent standard to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)