### PR TITLE
feat(i18n): update projects page hero title and caption

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -77,8 +77,8 @@
     "email": "Enter a valid e-mail address."
   },
   "Projects": {
-    "hero_title": "Portfolio",
-    "hero_caption": "Discover some of my projects",
+    "hero_title": "Projects",
+    "hero_caption": "A selection of products I've designed, built, and shipped — from solo greenfield architecture to commercial apps delivered with distributed teams.",
     "hero_image_alt": "Professional Picture 1 of Wallace Ferreira"
   },
   "About": {

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -77,8 +77,8 @@
     "email": "Introduce un correo electrónico válido."
   },
   "Projects": {
-    "hero_title": "Portafolio",
-    "hero_caption": "Conoce algunos de mis proyectos",
+    "hero_title": "Proyectos",
+    "hero_caption": "Una selección de productos que diseñé, construí y entregué — desde arquitecturas solo desde cero hasta apps comerciales entregadas con equipos distribuidos.",
     "hero_image_alt": "Foto profesional 1 de Wallace Ferreira"
   },
   "About": {

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -77,8 +77,8 @@
     "email": "Informe um e-mail válido."
   },
   "Projects": {
-    "hero_title": "Portfólio",
-    "hero_caption": "Conheça alguns dos meus projetos",
+    "hero_title": "Projetos",
+    "hero_caption": "Uma seleção de produtos que projetei, construí e entreguei — de arquiteturas solo do zero a apps comerciais entregues com times distribuídos.",
     "hero_image_alt": "Foto profissional 1 de Wallace Ferreira"
   },
   "About": {

--- a/apps/site/src/features/projects/HeroSection/index.tsx
+++ b/apps/site/src/features/projects/HeroSection/index.tsx
@@ -16,6 +16,7 @@ export async function HeroSection({ locale }: { locale: Locale }) {
       titleAs="h1"
       imageClassName="object-contain p-6 lg:py-8"
       className="shadow-drop-sm"
+      textColumnClassName="md:w-1/2"
     />
   );
 }


### PR DESCRIPTION
## Summary

- Title: "Portfolio / Portfólio / Portafolio" → "Projects / Projetos / Proyectos" — matches the URL and removes ambiguity with the site name
- Caption: replaced the generic one-liner with a description that communicates ownership verbs (designed, built, shipped) and scope (solo greenfield → commercial apps with distributed teams) across all three locales (EN, PT-BR, ES)

## Test plan

- [x] Build passes pre-push hook
- [ ] Visual check on `/projects` page in all three locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)