### PR TITLE
fix(ui): scope editorial styles to ProjectDetail and fix locale-aware duration formatting

### DIFF
--- a/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
@@ -10,6 +10,7 @@ import { useBoolean } from 'usehooks-ts';
 
 import { SkillGroup } from '~features/shared/SkillGroup';
 import { useBreakpoint } from '~hooks';
+import { formatDuration } from '~utils';
 
 import {
   EMPLOYMENT_TYPE_ICONS,
@@ -37,23 +38,6 @@ export interface IExperienceCardProps {
   skills: IExperienceCardSkill[];
 }
 
-export function calculateDuration(
-  startAt: string,
-  endAt?: string | null,
-): string {
-  const start = new Date(startAt);
-  const end = endAt ? new Date(endAt) : new Date();
-  const totalMonths =
-    (end.getFullYear() - start.getFullYear()) * 12 +
-    (end.getMonth() - start.getMonth());
-  const years = Math.floor(totalMonths / 12);
-  const months = totalMonths % 12;
-  const parts: string[] = [];
-  if (years > 0) parts.push(`${years}a`);
-  if (months > 0) parts.push(`${months}m`);
-  return parts.join(' ') || '1m';
-}
-
 function formatDate(dateStr: string, locale: string): string {
   return new Intl.DateTimeFormat(locale, {
     month: 'short',
@@ -78,7 +62,7 @@ export const ExperienceCard: FC<IExperienceCardProps> = ({
   const isXL = useBreakpoint('xl');
 
   const period = `${formatDate(startAt, locale)} - ${endAt ? formatDate(endAt, locale) : t('present')}`;
-  const duration = calculateDuration(startAt, endAt);
+  const duration = formatDuration(startAt, locale, endAt);
   const employmentLabel = t(`employment_type.${employmentType}`);
   const locationLabel = t(`location_type.${locationType}`);
   const employmentIcon =

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.module.css
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.module.css
@@ -1,0 +1,15 @@
+.editorial:global(.markdown-body) > p:first-of-type {
+  font-size: 1.125rem;
+  color: rgb(var(--tw-content-secondary));
+  line-height: 1.8;
+}
+
+.editorial:global(.markdown-body) > p:first-of-type::first-letter {
+  float: left;
+  font-size: 3.75rem;
+  font-weight: 700;
+  line-height: 0.82;
+  margin-right: 0.08em;
+  margin-top: 0.06em;
+  color: rgb(var(--tw-brand-accent));
+}

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -15,6 +15,7 @@ import { Breadcrumb } from '~features/shared/Breadcrumb';
 import { SkillGroup } from '~features/shared/SkillGroup';
 import { Link } from '~i18n/routing';
 
+import styles from './ProjectDetail.module.css';
 import { ProjectMetaGrid } from './ProjectMetaGrid';
 
 export interface IProjectDetailProps {
@@ -118,7 +119,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
           labels={metaLabels}
         />
 
-        {content && <TextRich content={content} />}
+        {content && <TextRich content={content} className={styles.editorial} />}
 
         {relatedProjects.length > 0 && (
           <section className="flex flex-col gap-y-6">

--- a/apps/site/src/utils/formatters/formatDuration.ts
+++ b/apps/site/src/utils/formatters/formatDuration.ts
@@ -15,7 +15,7 @@ export function formatDuration(
     new Intl.NumberFormat(locale, {
       style: 'unit',
       unit,
-      unitDisplay: 'short',
+      unitDisplay: 'long',
     }).format(value);
 
   const parts: string[] = [];

--- a/apps/site/src/utils/formatters/formatDuration.ts
+++ b/apps/site/src/utils/formatters/formatDuration.ts
@@ -1,0 +1,25 @@
+export function formatDuration(
+  startAt: string,
+  locale: string,
+  endAt?: string | null,
+): string {
+  const start = new Date(startAt);
+  const end = endAt ? new Date(endAt) : new Date();
+  const totalMonths =
+    (end.getFullYear() - start.getFullYear()) * 12 +
+    (end.getMonth() - start.getMonth());
+  const years = Math.floor(totalMonths / 12);
+  const months = totalMonths % 12;
+
+  const fmt = (value: number, unit: 'year' | 'month') =>
+    new Intl.NumberFormat(locale, {
+      style: 'unit',
+      unit,
+      unitDisplay: 'short',
+    }).format(value);
+
+  const parts: string[] = [];
+  if (years > 0) parts.push(fmt(years, 'year'));
+  if (months > 0) parts.push(fmt(months, 'month'));
+  return parts.join(' ') || fmt(1, 'month');
+}

--- a/apps/site/src/utils/formatters/index.ts
+++ b/apps/site/src/utils/formatters/index.ts
@@ -1,0 +1,1 @@
+export * from './formatDuration';

--- a/apps/site/src/utils/index.ts
+++ b/apps/site/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './constants';
+export * from './formatters';

--- a/apps/site/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
+++ b/apps/site/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
@@ -54,35 +54,43 @@ vi.mock('~/features/shared/TechnologiesModal', () => ({
   }) => (open ? <div data-testid="technologies-modal">{company}</div> : null),
 }));
 
-import {
-  ExperienceCard,
-  calculateDuration,
-} from '~/features/about/ExperiencesSection';
+import { ExperienceCard } from '~/features/about/ExperiencesSection';
+import { formatDuration } from '~/utils';
 
 // ---------------------------------------------------------------------------
-// calculateDuration unit tests
+// formatDuration unit tests
 // ---------------------------------------------------------------------------
 
-describe('calculateDuration', () => {
-  it('should return years and months for multi-year range', () => {
-    expect(calculateDuration('2022-01-01', '2023-04-01')).toBe('1a 3m');
+const YEAR_PATTERN = /yr|year/;
+const MONTH_PATTERN = /mo|mth|month/;
+
+describe('formatDuration', () => {
+  it('should include years and months for multi-year range', () => {
+    const result = formatDuration('2022-01-01', 'en-US', '2023-04-01');
+    expect(result).toMatch(YEAR_PATTERN);
+    expect(result).toMatch(MONTH_PATTERN);
   });
 
   it('should return only years when months is zero', () => {
-    expect(calculateDuration('2021-03-01', '2023-03-01')).toBe('2a');
+    const result = formatDuration('2021-03-01', 'en-US', '2023-03-01');
+    expect(result).toMatch(YEAR_PATTERN);
+    expect(result).not.toMatch(MONTH_PATTERN);
   });
 
   it('should return only months for sub-year range', () => {
-    expect(calculateDuration('2023-06-01', '2023-09-01')).toBe('3m');
+    const result = formatDuration('2023-06-01', 'en-US', '2023-09-01');
+    expect(result).not.toMatch(YEAR_PATTERN);
+    expect(result).toMatch(MONTH_PATTERN);
   });
 
   it('should use today when endAt is not provided', () => {
-    const result = calculateDuration('2020-01-01');
-    expect(result).toMatch(/^\d+a(\s\d+m)?$|^\d+m$/);
+    const result = formatDuration('2020-01-01', 'en-US');
+    expect(result).toMatch(new RegExp(`${YEAR_PATTERN.source}|${MONTH_PATTERN.source}`));
   });
 
-  it('should return 1m as minimum when duration rounds to zero', () => {
-    expect(calculateDuration('2023-01-15', '2023-01-20')).toBe('1m');
+  it('should return minimum of 1 month when duration rounds to zero', () => {
+    const result = formatDuration('2023-01-15', 'en-US', '2023-01-20');
+    expect(result).toMatch(MONTH_PATTERN);
   });
 });
 

--- a/apps/site/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
+++ b/apps/site/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
@@ -61,8 +61,8 @@ import { formatDuration } from '~/utils';
 // formatDuration unit tests
 // ---------------------------------------------------------------------------
 
-const YEAR_PATTERN = /yr|year/;
-const MONTH_PATTERN = /mo|mth|month/;
+const YEAR_PATTERN = /years?/;
+const MONTH_PATTERN = /months?/;
 
 describe('formatDuration', () => {
   it('should include years and months for multi-year range', () => {

--- a/packages/ui/globals.css
+++ b/packages/ui/globals.css
@@ -59,24 +59,6 @@
   text-decoration-color: rgb(var(--tw-brand-primary));
 }
 
-/* Lede — first paragraph reads like a newspaper lead */
-.markdown-body > p:first-of-type {
-  font-size: 1.125rem;
-  color: rgb(var(--tw-content-secondary));
-  line-height: 1.8;
-}
-
-/* Drop cap — first letter floats large, editorial feel */
-.markdown-body > p:first-of-type::first-letter {
-  float: left;
-  font-size: 3.75rem;
-  font-weight: 700;
-  line-height: 0.82;
-  margin-right: 0.08em;
-  margin-top: 0.06em;
-  color: rgb(var(--tw-brand-accent));
-}
-
 /* Blockquote as pull quote */
 .markdown-body blockquote {
   border-left: 3px solid rgb(var(--tw-brand-accent));
@@ -91,7 +73,7 @@
   margin: 0;
 }
 
-/* hr as editorial gradient separator */
+/* hr as gradient separator */
 .markdown-body hr {
   border: none;
   height: 1px;


### PR DESCRIPTION
## Summary

- Move lede (first paragraph) and drop cap styles out of `packages/ui/globals.css` — where they were bleeding into `ExperienceCard` and `ProfessionalValueCard` — into a scoped CSS Module (`ProjectDetail.module.css`) applied only on the project detail page
- Replace hardcoded Portuguese abbreviations (`1a 9m`) in `ExperienceCard` with `formatDuration`, a shared formatter at `apps/site/src/utils/formatters/` that uses `Intl.NumberFormat` with `unitDisplay: 'long'` for consistent, locale-aware output across all environments

## Test plan

- [ ] Verify drop cap and lede paragraph appear on `/projects/[slug]` pages
- [ ] Verify drop cap and lede paragraph do NOT appear on the About page (ExperienceCard, ProfessionalValueCard)
- [ ] Verify duration shows "1 year 9 months" in en-US and "1 ano 9 meses" in pt-BR
- [ ] Run `pnpm test:ci` — 178 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)