### PR TITLE
feat(ui): extract OpenSourceBadge as shared component and add to ProjectCard

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -32,6 +32,9 @@
     "hero_caption": "Software Engineer",
     "hero_image_alt": "Professional Picture 1 of Wallace Ferreira"
   },
+  "Common": {
+    "open_source_label": "Open Source"
+  },
   "ProjectCard": {
     "view_project": "View Project",
     "share_tooltip": "Copy link",
@@ -135,8 +138,7 @@
     "breadcrumb_projects": "Projects",
     "back": "Back",
     "related_title": "Other projects",
-    "role_label": "Role",
-    "open_source_label": "Open Source"
+    "role_label": "Role"
   },
   "Metadata": {
     "Layout": {

--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -32,9 +32,6 @@
     "hero_caption": "Software Engineer",
     "hero_image_alt": "Professional Picture 1 of Wallace Ferreira"
   },
-  "Common": {
-    "open_source_label": "Open Source"
-  },
   "ProjectCard": {
     "view_project": "View Project",
     "share_tooltip": "Copy link",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -32,9 +32,6 @@
     "hero_caption": "Ingeniero de Software",
     "hero_image_alt": "Foto profesional 1 de Wallace Ferreira"
   },
-  "Common": {
-    "open_source_label": "Open Source"
-  },
   "ProjectCard": {
     "view_project": "Ver proyecto",
     "share_tooltip": "Copiar enlace",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -32,6 +32,9 @@
     "hero_caption": "Ingeniero de Software",
     "hero_image_alt": "Foto profesional 1 de Wallace Ferreira"
   },
+  "Common": {
+    "open_source_label": "Open Source"
+  },
   "ProjectCard": {
     "view_project": "Ver proyecto",
     "share_tooltip": "Copiar enlace",
@@ -135,8 +138,7 @@
     "breadcrumb_projects": "Proyectos",
     "back": "Volver",
     "related_title": "Otros proyectos",
-    "role_label": "Rol",
-    "open_source_label": "Open Source"
+    "role_label": "Rol"
   },
   "Metadata": {
     "Layout": {

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -32,6 +32,9 @@
     "hero_caption": "Engenheiro de Software",
     "hero_image_alt": "Foto profissional 1 de Wallace Ferreira"
   },
+  "Common": {
+    "open_source_label": "Open Source"
+  },
   "ProjectCard": {
     "view_project": "Ver projeto",
     "share_tooltip": "Copiar link",
@@ -135,8 +138,7 @@
     "breadcrumb_projects": "Projetos",
     "back": "Voltar",
     "related_title": "Outros projetos",
-    "role_label": "Função",
-    "open_source_label": "Open Source"
+    "role_label": "Função"
   },
   "Metadata": {
     "Layout": {

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -32,9 +32,6 @@
     "hero_caption": "Engenheiro de Software",
     "hero_image_alt": "Foto profissional 1 de Wallace Ferreira"
   },
-  "Common": {
-    "open_source_label": "Open Source"
-  },
   "ProjectCard": {
     "view_project": "Ver projeto",
     "share_tooltip": "Copiar link",

--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -10,6 +10,7 @@ import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
 
 import { useBreakpoint } from '~/hooks';
+import { OpenSourceBadge } from '~features/shared/OpenSourceBadge';
 import { ShareButton } from '~features/shared/ShareButton';
 import { SkillGroup } from '~features/shared/SkillGroup';
 
@@ -20,6 +21,7 @@ export interface IProjectCardProps {
   thumbnailImage: { url: string; alt: string };
   theme?: string;
   skills: { name: string; icon: string }[];
+  repositoryUrl?: string;
   compact?: boolean;
 }
 
@@ -31,6 +33,7 @@ export const ProjectCard: FC<IProjectCardProps> = ({
   theme,
   compact = false,
   skills,
+  repositoryUrl,
 }) => {
   const t = useTranslations('ProjectCard');
   const locale = useLocale();
@@ -85,7 +88,10 @@ export const ProjectCard: FC<IProjectCardProps> = ({
             </span>
           )}
 
-          <h3 className="text-2xl font-bold text-content-primary">{title}</h3>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <h3 className="text-2xl font-bold text-content-primary">{title}</h3>
+            {repositoryUrl && <OpenSourceBadge repositoryUrl={repositoryUrl} />}
+          </div>
 
           <p
             className={classNames(

--- a/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectList.tsx
@@ -14,6 +14,7 @@ export interface ProjectSummary {
   thumbnailImage: { url: string; alt: string };
   theme?: string;
   skills: { name: string; icon: string }[];
+  repositoryUrl?: string;
 }
 
 interface IProjectListProps {
@@ -37,6 +38,7 @@ export const ProjectList: FC<IProjectListProps> = ({
           thumbnailImage={project.thumbnailImage}
           theme={project.theme}
           skills={project.skills}
+          repositoryUrl={project.repositoryUrl}
           compact={compact}
         />
       </li>

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -12,6 +12,7 @@ import {
   ProjectSummary,
 } from '~features/home/ProjectsSection/ProjectList';
 import { Breadcrumb } from '~features/shared/Breadcrumb';
+import { OpenSourceBadge } from '~features/shared/OpenSourceBadge';
 import { SkillGroup } from '~features/shared/SkillGroup';
 import { Link } from '~i18n/routing';
 
@@ -86,15 +87,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
                 {title}
               </h1>
               {repositoryUrl && (
-                <a
-                  href={repositoryUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-x-1.5 rounded-full border border-content-muted/30 px-3 py-1 text-sm text-content-muted transition-colors hover:border-content-muted hover:text-content-primary"
-                >
-                  <Icon icon="mdi:github" className="text-base" />
-                  {t('open_source_label')}
-                </a>
+                <OpenSourceBadge repositoryUrl={repositoryUrl} />
               )}
             </div>
             <p className="text-xl text-content-primary">{caption}</p>

--- a/apps/site/src/features/shared/OpenSourceBadge/index.tsx
+++ b/apps/site/src/features/shared/OpenSourceBadge/index.tsx
@@ -1,9 +1,6 @@
-'use client';
-
 import { FC } from 'react';
 
 import { Icon } from '@repo/ui/Imagery';
-import { useTranslations } from 'next-intl';
 
 interface IOpenSourceBadgeProps {
   repositoryUrl: string;
@@ -11,18 +8,14 @@ interface IOpenSourceBadgeProps {
 
 export const OpenSourceBadge: FC<IOpenSourceBadgeProps> = ({
   repositoryUrl,
-}) => {
-  const t = useTranslations('Common');
-
-  return (
-    <a
-      href={repositoryUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex items-center gap-x-1.5 rounded-full border border-content-muted/30 px-3 py-1 text-sm text-content-muted transition-colors hover:border-content-muted hover:text-content-primary"
-    >
-      <Icon icon="mdi:github" className="text-base" />
-      {t('open_source_label')}
-    </a>
-  );
-};
+}) => (
+  <a
+    href={repositoryUrl}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-x-1.5 rounded-full border border-content-muted/30 px-3 py-1 text-sm text-content-muted transition-colors hover:border-content-muted hover:text-content-primary"
+  >
+    <Icon icon="mdi:github" className="text-base" />
+    Open Source
+  </a>
+);

--- a/apps/site/src/features/shared/OpenSourceBadge/index.tsx
+++ b/apps/site/src/features/shared/OpenSourceBadge/index.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { FC } from 'react';
+
+import { Icon } from '@repo/ui/Imagery';
+import { useTranslations } from 'next-intl';
+
+interface IOpenSourceBadgeProps {
+  repositoryUrl: string;
+}
+
+export const OpenSourceBadge: FC<IOpenSourceBadgeProps> = ({
+  repositoryUrl,
+}) => {
+  const t = useTranslations('Common');
+
+  return (
+    <a
+      href={repositoryUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-x-1.5 rounded-full border border-content-muted/30 px-3 py-1 text-sm text-content-muted transition-colors hover:border-content-muted hover:text-content-primary"
+    >
+      <Icon icon="mdi:github" className="text-base" />
+      {t('open_source_label')}
+    </a>
+  );
+};

--- a/apps/site/tests/components/shared/OpenSourceBadge/OpenSourceBadge.test.tsx
+++ b/apps/site/tests/components/shared/OpenSourceBadge/OpenSourceBadge.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+
+import { OpenSourceBadge } from '~/features/shared/OpenSourceBadge';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) =>
+    key === 'open_source_label' ? 'Open Source' : key,
+}));
+
+describe('OpenSourceBadge', () => {
+  it('should render a link pointing to the repository', () => {
+    render(<OpenSourceBadge repositoryUrl="https://github.com/user/repo" />);
+
+    const link = screen.getByRole('link', { name: /open source/i });
+    expect(link).toHaveAttribute('href', 'https://github.com/user/repo');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should display the open source label', () => {
+    render(<OpenSourceBadge repositoryUrl="https://github.com/user/repo" />);
+    expect(screen.getByText('Open Source')).toBeInTheDocument();
+  });
+});

--- a/apps/site/tests/components/shared/OpenSourceBadge/OpenSourceBadge.test.tsx
+++ b/apps/site/tests/components/shared/OpenSourceBadge/OpenSourceBadge.test.tsx
@@ -2,11 +2,6 @@ import { render, screen } from '@testing-library/react';
 
 import { OpenSourceBadge } from '~/features/shared/OpenSourceBadge';
 
-vi.mock('next-intl', () => ({
-  useTranslations: () => (key: string) =>
-    key === 'open_source_label' ? 'Open Source' : key,
-}));
-
 describe('OpenSourceBadge', () => {
   it('should render a link pointing to the repository', () => {
     render(<OpenSourceBadge repositoryUrl="https://github.com/user/repo" />);

--- a/packages/application/src/portfolio/dtos/ProjectSummaryDTO.ts
+++ b/packages/application/src/portfolio/dtos/ProjectSummaryDTO.ts
@@ -10,4 +10,5 @@ export type ProjectSummaryDTO = {
   theme?: string;
   skills: SkillSummary[];
   publishedAt: string;
+  repositoryUrl?: string;
 };

--- a/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
+++ b/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
@@ -140,6 +140,7 @@ export class GetProjectBySlug extends UseCase<
         (id) => skillNames.get(id.value) ?? { name: id.value, icon: '' },
       ),
       publishedAt: project.period.startAt.value,
+      repositoryUrl: project.repositoryUrl?.value,
     };
   }
 }

--- a/packages/application/src/portfolio/use-cases/GetPublishedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetPublishedProjects.ts
@@ -71,6 +71,7 @@ export class GetPublishedProjects extends UseCase<
         (id) => skillNames.get(id.value) ?? { name: id.value, icon: '' },
       ),
       publishedAt: project.period.startAt.value,
+      repositoryUrl: project.repositoryUrl?.value,
     };
   }
 }

--- a/packages/application/test/portfolio/GetProjectBySlug.test.ts
+++ b/packages/application/test/portfolio/GetProjectBySlug.test.ts
@@ -233,6 +233,25 @@ describe('GetProjectBySlug', () => {
       expect((result.value as DomainError).code).toBe('FETCH_FAILED');
     });
 
+    it('should map repositoryUrl in related projects when they are public', async () => {
+      const project = makeProject();
+      const related = makeProject({
+        slug: 'related-project',
+        repositoryUrl: 'https://github.com/user/related',
+      });
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(project),
+        findRelated: vi.fn().mockResolvedValue([related]),
+      });
+      const useCase = new GetProjectBySlug(repo, makeSkillRepository());
+
+      const result = await useCase.execute({ slug: 'my-project', locale: 'en-US' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = result.value as ProjectDetailDTO;
+      expect(dto.relatedProjects[0]!.repositoryUrl).toBe('https://github.com/user/related');
+    });
+
     it('should return Right with empty relatedProjects when findRelated throws', async () => {
       const project = makeProject();
       const repo = makeRepository({

--- a/packages/application/test/portfolio/GetPublishedProjects.test.ts
+++ b/packages/application/test/portfolio/GetPublishedProjects.test.ts
@@ -236,6 +236,36 @@ describe('GetPublishedProjects', () => {
       expect((result.value as DomainError).code).toBe('FETCH_FAILED');
     });
 
+    it('should map repositoryUrl when project is public', async () => {
+      const project = makeProject({
+        repositoryUrl: 'https://github.com/user/repo',
+      });
+      const repo = makeRepository({
+        findPublished: vi.fn().mockResolvedValue([project]),
+      });
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
+
+      const result = await useCase.execute({ locale: 'en-US' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = (result.value as ProjectSummaryDTO[])[0]!;
+      expect(dto.repositoryUrl).toBe('https://github.com/user/repo');
+    });
+
+    it('should omit repositoryUrl when project has no repository', async () => {
+      const project = makeProject();
+      const repo = makeRepository({
+        findPublished: vi.fn().mockResolvedValue([project]),
+      });
+      const useCase = new GetPublishedProjects(repo, makeSkillRepository());
+
+      const result = await useCase.execute({ locale: 'en-US' });
+
+      expect(result.isRight()).toBe(true);
+      const dto = (result.value as ProjectSummaryDTO[])[0]!;
+      expect(dto.repositoryUrl).toBeUndefined();
+    });
+
     it('should call findPublished() on the repository', async () => {
       const findPublished = vi.fn().mockResolvedValue([]);
       const repo = makeRepository({ findPublished });


### PR DESCRIPTION
## Summary

- Extracts the open source badge (GitHub icon + \"Open Source\" label) into `features/shared/OpenSourceBadge` — reused by `ProjectDetail` and `ProjectCard`
- Moves `open_source_label` i18n key from `ProjectDetail` to the `Common` namespace
- Adds `repositoryUrl?: string` to `ProjectSummaryDTO` and maps it in `GetPublishedProjects` and `GetProjectBySlug.toSummaryDTO` so cards receive the field
- `ProjectList` and `ProjectCard` pass `repositoryUrl` through to the badge

## Test plan

- [ ] Projects with `repositoryUrl` show the badge on both the card and the detail page
- [ ] Projects without `repositoryUrl` show no badge on either surface
- [ ] Unit tests: `pnpm --filter site test -- OpenSourceBadge`
- [ ] Unit tests: `pnpm --filter @repo/application test -- GetPublishedProjects GetProjectBySlug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)