### PR TITLE
feat(ui): add Divider between project metadata and content in ProjectDetail

### DIFF
--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -3,7 +3,7 @@
 import { FC, useMemo } from 'react';
 
 import { Icon } from '@repo/ui/Imagery';
-import { TextRich } from '@repo/ui/View';
+import { Divider, TextRich } from '@repo/ui/View';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
@@ -113,6 +113,8 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
             </div>
           </dl>
         )}
+
+        <Divider />
 
         {content && <TextRich content={content} className={styles.editorial} />}
 


### PR DESCRIPTION
## Summary

- Adds a `Divider` component between the project metadata section (role `<dl>`) and the editorial content (`TextRich`) in `ProjectDetail`

## Test plan

- [ ] Visual check: open any project detail page and verify the divider renders between the metadata and content sections

Refs #

🤖 Generated with [Claude Code](https://claude.com/claude-code)