### PR TITLE
feat(projects): replace portfolio thumbnail with SVG for lossless quality

### DIFF
--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -3,7 +3,7 @@
 import { FC } from 'react';
 
 import { screens } from '@repo/tailwind-config/screens';
-import { buttonVariants, Button } from '@repo/ui/Control';
+import { Button } from '@repo/ui/Control';
 import { Icon } from '@repo/ui/Imagery';
 import classNames from 'classnames';
 import { useTranslations, useLocale } from 'next-intl';

--- a/packages/infra/prisma/seeders.ts
+++ b/packages/infra/prisma/seeders.ts
@@ -373,7 +373,7 @@ export async function seedProjects(db: PrismaClient): Promise<void> {
         'Repositorio del Portafolio Personal en GitHub',
       ),
       thumbnailImageUrl:
-        'https://wozibwvcepmelpstznic.supabase.co/storage/v1/object/public/portfolio-dev-images/site/projects/portfolio/portfolio-thumbnail2.webp',
+        'https://wozibwvcepmelpstznic.supabase.co/storage/v1/object/public/portfolio-dev-images/site/projects/portfolio/portfolio-w-symbol.svg',
       thumbnailImageAlt: loc(
         'Personal Portfolio thumbnail',
         'Thumbnail do Portfólio Pessoal',


### PR DESCRIPTION
## Summary

- Replace portfolio project thumbnail from WebP raster to SVG vector format
- Upload `portfolio-w-symbol.svg` to Supabase Storage with the brand W mark
- Update thumbnail URL in `seeders.ts` and database record directly
- Remove unused `buttonVariants` import from `ProjectCard.tsx`

## Why SVG

The portfolio thumbnail is a pure vector graphic (brand W mark on dark background). WebP introduced visible compression artifacts compared to the crisp SVG original. Since `dangerouslyAllowSVG: true` and the Supabase domain are already configured in `next.config.mjs`, serving SVG directly is the correct approach — lossless, resolution-independent, and smaller file size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)