### PR TITLE
fix(ProjectDetail): use object-contain on cover image to prevent side cropping

### DIFF
--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -71,12 +71,12 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
         </div>
 
         <div className="flex flex-col gap-y-6">
-          <div className="relative h-60 w-full overflow-hidden rounded-lg shadow-drop-sm lg:h-[485px]">
+          <div className="relative h-60 w-full overflow-hidden rounded-lg bg-surface shadow-drop-sm lg:h-[485px]">
             <Image
               src={coverImage.url}
               fill
               alt={coverImage.alt}
-              className="object-cover"
+              className="object-contain"
               priority
             />
           </div>


### PR DESCRIPTION
## Summary

- Troca `object-cover` por `object-contain` na imagem de capa do `ProjectDetail`
- Adiciona `bg-surface` ao container para que o espaço vazio ao redor da imagem se misture com o fundo da página

## Context

Em mobile, imagens de capa com proporção mais larga que o container (`h-60` / 240 px) eram cortadas nas laterais pelo `object-cover`. Como a imagem de capa é um artefato de apresentação do projeto, o conteúdo completo deve estar visível. O espaço vazio resultante do `object-contain` é preenchido pela cor `bg-surface`, que é idêntica ao fundo da página.

## Test plan

- [ ] Abrir a página de detalhe do projeto **Personal Portfolio** em mobile e confirmar que a imagem aparece completa, sem corte lateral
- [ ] Conferir que outros projetos com imagens em proporção diferente também exibem a imagem inteira
- [ ] Confirmar que o fundo do container (`bg-surface`) não destoa visualmente em light e dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)