### PR TITLE
feat(seo): add og:site_name to all page metadata

### DIFF
--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -44,6 +44,7 @@ export async function generateMetadata({
     openGraph: {
       title,
       description: bio,
+      siteName: 'Wallace Ferreira',
       images: [
         {
           url: buildOgImageUrl({

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -40,6 +40,7 @@ export async function generateMetadata({
     openGraph: {
       title: name,
       description: headline,
+      siteName: 'Wallace Ferreira',
       images: [
         {
           url: buildOgImageUrl({

--- a/apps/site/src/app/[locale]/projects/[slug]/page.tsx
+++ b/apps/site/src/app/[locale]/projects/[slug]/page.tsx
@@ -48,6 +48,7 @@ export async function generateMetadata({
     openGraph: {
       title,
       description: caption,
+      siteName: 'Wallace Ferreira',
       images: [{ url: coverImage.url, alt: coverImage.alt }],
     },
   };

--- a/apps/site/src/app/[locale]/projects/page.tsx
+++ b/apps/site/src/app/[locale]/projects/page.tsx
@@ -33,6 +33,7 @@ export async function generateMetadata({
     openGraph: {
       title,
       description,
+      siteName: 'Wallace Ferreira',
       images: [
         {
           url: buildOgImageUrl({


### PR DESCRIPTION
## Summary

- Adds `siteName: 'Wallace Ferreira'` ao objeto `openGraph` de todas as páginas que definem `generateMetadata` próprio: Home, About, Projects e Project Detail

## Context

O layout raiz já declarava `openGraph.siteName`, mas o Next.js App Router não faz deep merge automático de `openGraph` entre layout e page — a page-level metadata substitui o objeto inteiro. Como resultado, o `siteName` estava ausente em qualquer página que definisse seu próprio `openGraph`. A correção adiciona o campo explicitamente em cada `generateMetadata`.

## Test plan

- [ ] Inspecionar o HTML de cada página (`/`, `/about`, `/projects`, `/projects/[slug]`) e confirmar a presença de `<meta property="og:site_name" content="Wallace Ferreira" />`
- [ ] Validar via [opengraph.xyz](https://www.opengraph.xyz) ou similar após deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)