### PR TITLE
chore(infra): allow portfolio-dev as safe target for destructive Prisma ops

### DIFF
--- a/packages/infra/.env.example
+++ b/packages/infra/.env.example
@@ -14,6 +14,13 @@ DIRECT_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler
 # Admin user created by prisma/seed.ts
 ADMIN_EMAIL="admin@portfolio.dev"
 
+# ── Migration safety (scripts/assert-safe-db.mjs) ─────────────────────────────
+# Optional. A substring of DIRECT_URL (e.g. your dev project's ref) that the
+# safety guard treats as safe for destructive Prisma operations, in addition
+# to localhost. Leave unset to require DB_ALLOW_DESTRUCTIVE=1 for any
+# non-local database.
+DB_SAFE_REMOTE_REF=""
+
 # ── Integration tests (SupabaseAuthenticationGateway) ─────────────────────────
 # Required to run integration tests against a real Supabase project.
 # Tests are skipped automatically when any of these variables is absent.

--- a/packages/infra/scripts/assert-safe-db.mjs
+++ b/packages/infra/scripts/assert-safe-db.mjs
@@ -2,12 +2,15 @@
  * Safety guard for destructive Prisma operations (migrate dev, db push).
  *
  * Reads DIRECT_URL from the local .env file and aborts if it points to a
- * non-local database, unless DB_ALLOW_DESTRUCTIVE=1 is explicitly set.
+ * database that is neither localhost nor DB_SAFE_REMOTE_REF (also read from
+ * .env — e.g. your dev project's ref), unless DB_ALLOW_DESTRUCTIVE=1 is
+ * explicitly set.
  *
  * Usage (called automatically by db:migrate and db:push scripts):
  *   node scripts/assert-safe-db.mjs
  *
- * To intentionally run a destructive operation against cloud:
+ * To intentionally run a destructive operation against another database
+ * (e.g. production):
  *   DB_ALLOW_DESTRUCTIVE=1 pnpm db:migrate
  */
 
@@ -37,13 +40,16 @@ function parseEnv(filePath) {
 const env = parseEnv(envPath);
 const directUrl = process.env.DIRECT_URL ?? env['DIRECT_URL'] ?? '';
 const allowDestructive = process.env.DB_ALLOW_DESTRUCTIVE === '1';
+const safeRemoteRef = process.env.DB_SAFE_REMOTE_REF ?? env['DB_SAFE_REMOTE_REF'] ?? '';
 
 const isLocal =
   directUrl.includes('localhost') ||
   directUrl.includes('127.0.0.1') ||
   directUrl.includes('0.0.0.0');
 
-if (!isLocal && !allowDestructive) {
+const isSafeRemote = safeRemoteRef !== '' && directUrl.includes(safeRemoteRef);
+
+if (!isLocal && !isSafeRemote && !allowDestructive) {
   console.error('');
   console.error('🚨  DESTRUCTIVE OPERATION BLOCKED');
   console.error('');
@@ -62,7 +68,13 @@ if (!isLocal && !allowDestructive) {
   process.exit(1);
 }
 
-if (!isLocal && allowDestructive) {
+if (!isLocal && isSafeRemote) {
+  console.log('');
+  console.log('ℹ️   DIRECT_URL matches DB_SAFE_REMOTE_REF — proceeding.');
+  console.log('');
+}
+
+if (!isLocal && !isSafeRemote && allowDestructive) {
   console.warn('');
   console.warn('⚠️   DB_ALLOW_DESTRUCTIVE=1 — proceeding against cloud database.');
   console.warn('    Make sure you have a recent backup (pnpm db:backup).');


### PR DESCRIPTION
## Summary
- `assert-safe-db.mjs` only treated `localhost` as a safe target for destructive Prisma operations (`migrate dev`, `db push`), but this project's dev database is a remote Supabase project (`portfolio-dev`), not local Postgres.
- Adds an optional `DB_SAFE_REMOTE_REF` env var (documented in `.env.example`, real value kept out of git in `.env`) that the guard also accepts as safe, so `pnpm db:migrate`/`db:push` work against `portfolio-dev` without requiring `DB_ALLOW_DESTRUCTIVE=1` on every run.
- Production remains blocked by default, since its ref isn't in `DB_SAFE_REMOTE_REF`.

## Test plan
- [x] `node scripts/assert-safe-db.mjs` run locally against `portfolio-dev` — passes with the new info message, no `DESTRUCTIVE OPERATION BLOCKED` error.
- [x] `pnpm build` (pre-push hook) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)