### PR TITLE
feat(site): close mobile side menu on menu item click

### DIFF
--- a/.taskmaster/docs/mobile-menu-close-on-item-click-prd.md
+++ b/.taskmaster/docs/mobile-menu-close-on-item-click-prd.md
@@ -1,4 +1,4 @@
-# Mobile side menu: close on item click
+# PRD: Close mobile side menu on menu item click
 
 ## Problem
 
@@ -12,7 +12,7 @@ Close the mobile menu whenever the user acts on any menu item:
 - `MenuItem.Item2.Link` / `MenuItem.Item2.ShortLink` (LinkedIn, GitHub, RSS)
 - Selecting a `Radio` option inside the `ThemeToggle` or `LanguageSelector` expandables (i.e. their `RadioGroup`'s `onChange`)
 
-Out of scope: any change to `Accordion` semantics. `ThemeToggle` and `LanguageSelector` remain two independent `Accordion.Root` instances — expanding one does not collapse the other. The "radio" behavior referenced in the request is the existing `Radio`/`RadioGroup` used for selecting a theme/language inside each expandable, not a radio relationship between the two accordions.
+Out of scope: any change to `Accordion` semantics. `ThemeToggle` and `LanguageSelector` remain two independent `Accordion.Root` instances — expanding one does not collapse the other. The "radio" behavior referenced in the original request is the existing `Radio`/`RadioGroup` used for selecting a theme/language inside each expandable, not a radio relationship between the two accordions.
 
 Desktop is unaffected: `isOpen` is already gated by `!isDesktop && open`, so calling close on desktop is a no-op in practice, but consumers don't need to know or care about breakpoint — they just declare "close on selection."
 
@@ -43,11 +43,11 @@ The context lives alongside `SideNavigation` (`apps/site/src/components/Layout/S
 
 ## Testing
 
-Behavior-focused tests (no implementation details):
+Behavior-focused tests (no implementation details), per `docs/08-TESTING.md`:
 
 - `Item1`, `Item2.Link`, `Item2.ShortLink`: clicking the link calls `closeMenu` from a mocked `SideNavigationContext`.
 - `ThemeToggle`, `LanguageSelector`: selecting a radio option calls `closeMenu` in addition to the existing `setTheme`/`replace` side effect.
-- `SideNavigation`: an integration-level test (or the existing test file for it, if any) confirming that clicking a nested `Item1` link transitions `open` back to `false`.
+- `SideNavigation`: an integration-level test confirming that clicking a nested `Item1` link transitions `open` back to `false`.
 
 ## Non-goals
 

--- a/.taskmaster/state.json
+++ b/.taskmaster/state.json
@@ -1,6 +1,6 @@
 {
-  "currentTag": "project-content",
-  "lastSwitched": "2026-07-01T02:14:46.415Z",
+  "currentTag": "mobile-menu-close-on-item-click",
+  "lastSwitched": "2026-07-01T14:48:31.289Z",
   "branchTagMapping": {},
   "migrationNoticeShown": true
 }

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6690,7 +6690,7 @@
   "lighthouse": {
     "tasks": [
       {
-        "id": "1",
+        "id": 1,
         "title": "Fix LCP: remover 'use client' do HeroBanner e adicionar preload hint",
         "description": "HeroBanner tinha 'use client' desnecessário impedindo Next.js de gerar link rel=preload fetchpriority=high. Removido 'use client' (PR #790) e adicionado preload manual com fetchPriority=high no HeroSection (PR #794). LCP caiu de 4.8s para 1.2s.",
         "details": "",
@@ -6702,7 +6702,7 @@
         "updatedAt": "2026-06-18T05:14:14.823Z"
       },
       {
-        "id": "2",
+        "id": 2,
         "title": "Otimizar imagens estáticas: converter PNG para WebP",
         "description": "Convertidos hero-landing-page, hero-about, hero-projects e curriculum-cta-illustration de PNG para WebP (qualidade 90). Imports atualizados nos HeroSections. Redução de até 91% no tamanho (803KB → 96KB no hero principal). PR #792.",
         "details": "",
@@ -6714,7 +6714,7 @@
         "updatedAt": "2026-06-18T05:14:17.893Z"
       },
       {
-        "id": "3",
+        "id": 3,
         "title": "Reduzir JS não utilizado: lazy load do ContactForm e remoção de use client",
         "description": "Causa raiz: AppLayout ('use client') importava ContactSection estaticamente, puxando ContactForm → Zod (73KB) para o bundle de todas as páginas. Corrigido com: remoção de 'use client' do AppLayout (PR #796) e next/dynamic com ssr:false no ContactForm dentro do ContactSection (PR #798). Unused JS caiu de 215KB para 193KB. Score Lighthouse: 80 → 98.",
         "details": "",
@@ -6733,13 +6733,15 @@
       "completedCount": 3,
       "tags": [
         "lighthouse"
-      ]
+      ],
+      "created": "2026-07-01T14:21:47.330Z",
+      "description": "Tasks for lighthouse context"
     }
   },
   "project-content": {
     "tasks": [
       {
-        "id": "1",
+        "id": 1,
         "title": "Rewrite all 6 project content entries to reduce AI-sounding prose",
         "description": "Comprehensive rewrite of all project narratives (EN/PT/ES) in seeders.ts to eliminate AI-writing tells: em-dash overuse, rule-of-three lists, \"not X, it's Y\" reframes, and listicle-only Technical Highlights sections",
         "details": "## Implementation Context\n\nThis task involved rewriting the `content` field for all 6 projects in `packages/infra/prisma/seeders.ts`, across all 3 languages (EN/PT/ES = 18 total rewrites), to remove recognizable AI-writing patterns that made the portfolio sound generic and overly polished.\n\n## Changes Made\n\n### Content Rewrites (seeders.ts)\n- **Em-dash reduction**: Cut em-dash usage from 454 occurrences to 7 (only in code comments and mermaid diagrams, not in narrative prose)\n- **Bullet separator change**: Switched from `**Label** — description` to `**Label**: description` format throughout all projects. This was safe because the accent-color styling in `packages/ui/globals.css` (lines 85-93) targets `li > strong:first-child`, not the separator character itself\n- **Structural changes**:\n  - Replaced rule-of-three lists with naturally-varying list lengths (2, 4, 5 items instead of forcing 3)\n  - Removed \"not X, it's Y\" reframe patterns (e.g., \"This wasn't optional — it was required\")\n  - Mixed prose paragraphs into Technical Highlights sections instead of pure bullet lists\n  - Added concrete, project-specific details to replace generic statements\n  - Varied sentence rhythm and length within sections\n  - Eliminated banned LLM vocabulary (leverage, seamless, robust, delve, etc.)\n\n### Bug Fix\n- **Buyr project**: Removed a duplicated `## Technologies` section that appeared twice in the English version\n- **Buyr title**: Changed from `Buyr — Shopify App` to `Buyr: Shopify App` (consistent with colon separator)\n\n### Documentation Update\n- Added comprehensive \"Avoiding AI-sounding prose\" section to `.github/instructions/project_content.instructions.md` (lines 111-123) documenting all the patterns to avoid in future content writing\n\n## Files Modified\n\n1. `packages/infra/prisma/seeders.ts` (839 lines changed)\n   - All 6 projects rewritten: Buyr, Seidor, Galaxies, Stattus4, Portfolio, and one other\n   - Each project had EN/PT/ES versions rewritten (18 total content blocks)\n   \n2. `.github/instructions/project_content.instructions.md` (17 lines added)\n   - New section: \"Avoiding AI-sounding prose\"\n   - Lists 8 specific anti-patterns with guidance on each\n\n## Technical Approach\n\nThe rewrite followed the existing narrative structure (Constraints → Context → Contribution → Result) but improved the prose quality by:\n- Reading each section aloud to catch unnatural rhythm\n- Checking for \"could this apply to any similar project?\" and adding concrete details when yes\n- Mixing short, blunt sentences with longer ones\n- Using periods and commas instead of defaulting to em-dashes\n- Preserving technical accuracy while improving readability\n\n## Deployment\n\n- PR #883 merged to `develop` branch on 2026-07-01\n- Subsequently promoted to `master`/production\n- Seed applied to both dev (`portfolio-dev`) and production Supabase databases\n- All 18 project detail pages (6 projects × 3 languages) verified returning 200 with updated content",
@@ -6758,7 +6760,112 @@
       "completedCount": 1,
       "tags": [
         "project-content"
-      ]
+      ],
+      "created": "2026-07-01T14:21:47.330Z",
+      "description": "Tasks for project-content context"
+    }
+  },
+  "mobile-menu-close-on-item-click": {
+    "tasks": [
+      {
+        "id": 1,
+        "title": "Create SideNavigation context and hook",
+        "description": "Create `SideNavigationContext` and `useSideNavigation` hook to expose closeMenu function",
+        "details": "Create `apps/site/src/components/Layout/SideNavigation/context.ts` with:\n\n1. Define `ISideNavigationContext` interface:\n   ```typescript\n   export interface ISideNavigationContext {\n     closeMenu: () => void;\n   }\n   ```\n\n2. Create context with `createContext<ISideNavigationContext | null>(null)`\n3. Export `SideNavigationProvider = SideNavigationContext.Provider`\n4. Set `displayName = 'SideNavigationContext'`\n5. Create `useSideNavigation` hook in same file:\n   - Use `useContext(SideNavigationContext)`\n   - Add invariant guard: `invariant(context, 'useSideNavigation must be used within a SideNavigationProvider.')`\n   - Return context\n\nFollow the exact pattern from `packages/ui/src/Control/Accordion/context.ts` and `packages/ui/src/Control/Accordion/useAccordion.ts`. Use `tiny-invariant` for the guard (already available as dependency in apps/site/package.json).",
+        "testStrategy": "Unit test for `useSideNavigation` hook:\n- Mock context provider with closeMenu function\n- Verify hook returns context when inside provider\n- Verify invariant throws when hook used outside provider (should throw error with message 'useSideNavigation must be used within a SideNavigationProvider.')\n\nCreate test file at `apps/site/tests/components/Layout/SideNavigation/useSideNavigation.test.tsx`",
+        "priority": "high",
+        "dependencies": [],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 2,
+        "title": "Update SideNavigation to provide context",
+        "description": "Modify SideNavigation component to extract setFalse from useBoolean and provide it via SideNavigationContext",
+        "details": "In `apps/site/src/components/Layout/SideNavigation/index.tsx`:\n\n1. Line 22: Update useBoolean destructure:\n   ```typescript\n   const { value: open, toggle, setFalse: closeMenu } = useBoolean(false);\n   ```\n\n2. Import SideNavigationProvider:\n   ```typescript\n   import { SideNavigationProvider } from './context';\n   ```\n\n3. Wrap the nav element (lines 30-105) with:\n   ```typescript\n   <SideNavigationProvider value={{ closeMenu }}>\n     <nav ... >\n       {/* existing nav content */}\n     </nav>\n   </SideNavigationProvider>\n   ```\n\nNo changes to open/toggle behavior or any other logic. Desktop behavior unchanged (isOpen still gated by !isDesktop && open).",
+        "testStrategy": "Integration test in existing `apps/site/tests/components/View/SideNavigation/SideNavigation.test.tsx`:\n- Render SideNavigation with mocked useBoolean returning open=true, toggle=mockToggle, setFalse=mockCloseMenu\n- Use Testing Library to find and click a MenuItem.Item1 link\n- Verify mockCloseMenu was called\n- Verify menu transitions from open to closed state\n\nBehavior-focused: test that clicking a link closes the menu, not implementation details of context.",
+        "priority": "high",
+        "dependencies": [
+          1
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 3,
+        "title": "Add closeMenu to MenuItem.Item1 onClick",
+        "description": "Call closeMenu() when Item1 link is clicked (Home, Projects, About, Resume)",
+        "details": "In `apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx`:\n\n1. Import the hook:\n   ```typescript\n   import { useSideNavigation } from '../../context';\n   ```\n\n2. Inside the Item1 component (line 14), extract closeMenu:\n   ```typescript\n   const { closeMenu } = useSideNavigation();\n   ```\n\n3. On the Link element (line 35), add onClick:\n   ```typescript\n   <Link\n     href={newHref}\n     onClick={closeMenu}\n     aria-current={isActive ? 'page' : undefined}\n     // ... rest of props\n   ```\n\nNo other changes. The onClick fires before navigation, closing the menu declaratively.",
+        "testStrategy": "Unit test at `apps/site/tests/components/Layout/SideNavigation/MenuItem/Item1.test.tsx`:\n- Mock useSideNavigation to return mockCloseMenu\n- Render Item1 with test props (href, icon, children)\n- Use Testing Library to click the link\n- Verify mockCloseMenu was called once\n- Verify link renders with correct href and aria attributes\n\nBehavior: clicking Item1 calls closeMenu from context.",
+        "priority": "medium",
+        "dependencies": [
+          1,
+          2
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 4,
+        "title": "Add closeMenu to MenuItem.Item2.Link onClick",
+        "description": "Call closeMenu() when Item2.Link is clicked (LinkedIn, GitHub, RSS)",
+        "details": "In `apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/Link/index.tsx`:\n\n1. Import the hook:\n   ```typescript\n   import { useSideNavigation } from '../../../context';\n   ```\n\n2. Inside the Link component (line 14), extract closeMenu:\n   ```typescript\n   const { closeMenu } = useSideNavigation();\n   ```\n\n3. On the NextLink element (line 23), add onClick:\n   ```typescript\n   <NextLink\n     href={href}\n     onClick={closeMenu}\n     className={classNames(ROOT_STYLE, className)}\n     // ... rest of props\n   ```\n\nNo other changes.",
+        "testStrategy": "Unit test at `apps/site/tests/components/Layout/SideNavigation/MenuItem/Item2/Link.test.tsx`:\n- Mock useSideNavigation to return mockCloseMenu\n- Render Item2.Link with test props (href, icon, children, newTab)\n- Use Testing Library to click the link\n- Verify mockCloseMenu was called once\n- Verify link renders with correct target and rel attributes for external links\n\nBehavior: clicking Item2.Link calls closeMenu from context.",
+        "priority": "medium",
+        "dependencies": [
+          1,
+          2
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 5,
+        "title": "Add closeMenu to MenuItem.Item2.ShortLink onClick",
+        "description": "Call closeMenu() when Item2.ShortLink is clicked",
+        "details": "In `apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/ShortLink/index.tsx`:\n\n1. Import the hook:\n   ```typescript\n   import { useSideNavigation } from '../../../context';\n   ```\n\n2. Inside the ShortLink component (line 13), extract closeMenu:\n   ```typescript\n   const { closeMenu } = useSideNavigation();\n   ```\n\n3. On the NextLink element (line 22), add onClick:\n   ```typescript\n   <NextLink\n     href={href}\n     onClick={closeMenu}\n     aria-label={ariaLabel}\n     className={classNames(ROOT_STYLE, className)}\n     // ... rest of props\n   ```\n\nNo other changes.",
+        "testStrategy": "Unit test at `apps/site/tests/components/Layout/SideNavigation/MenuItem/Item2/ShortLink.test.tsx`:\n- Mock useSideNavigation to return mockCloseMenu\n- Render Item2.ShortLink with test props (href, icon, aria-label, newTab)\n- Use Testing Library to click the link\n- Verify mockCloseMenu was called once\n- Verify link renders with correct aria-label and target\n\nBehavior: clicking Item2.ShortLink calls closeMenu from context.",
+        "priority": "medium",
+        "dependencies": [
+          1,
+          2
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 6,
+        "title": "Add closeMenu to ThemeToggle onChange",
+        "description": "Call closeMenu() inside onChangeTheme after setTheme when a theme radio option is selected",
+        "details": "In `apps/site/src/components/Layout/SideNavigation/ThemeToggle.tsx`:\n\n1. Import the hook:\n   ```typescript\n   import { useSideNavigation } from './context';\n   ```\n\n2. Inside the ThemeToggle component (line 18), extract closeMenu:\n   ```typescript\n   const { closeMenu } = useSideNavigation();\n   ```\n\n3. Update onChangeTheme callback (lines 23-28) to call closeMenu after setTheme:\n   ```typescript\n   const onChangeTheme = useCallback<RadioGroupProps['onChange']>(\n     (event) => {\n       setTheme(event.target.value as Theme);\n       closeMenu();\n     },\n     [setTheme, closeMenu],\n   );\n   ```\n\nNo other changes. The existing setTheme side effect is preserved, closeMenu is called immediately after.",
+        "testStrategy": "Update existing test at `apps/site/tests/components/View/SideNavigation/ThemeToggle.test.tsx`:\n- Mock useSideNavigation to return mockCloseMenu\n- Keep existing mockSetTheme mock\n- Existing tests verify setTheme is called for each theme option (light/dark/system)\n- Add new assertions to each test:\n  - Verify mockCloseMenu was called once\n  - Verify mockCloseMenu was called after setTheme (order matters)\n\nBehavior: selecting a theme radio calls both setTheme and closeMenu.",
+        "priority": "medium",
+        "dependencies": [
+          1,
+          2
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 7,
+        "title": "Add closeMenu to LanguageSelector onChange",
+        "description": "Call closeMenu() inside onChangeLanguage after replace when a language radio option is selected",
+        "details": "In `apps/site/src/components/Layout/SideNavigation/LanguageSelector.tsx`:\n\n1. Import the hook:\n   ```typescript\n   import { useSideNavigation } from './context';\n   ```\n\n2. Inside the LanguageSelector component (line 17), extract closeMenu:\n   ```typescript\n   const { closeMenu } = useSideNavigation();\n   ```\n\n3. Update onChangeLanguage callback (lines 24-30) to call closeMenu after replace:\n   ```typescript\n   const onChangeLanguage = useCallback<RadioGroupProps['onChange']>(\n     (event) => {\n       const { value } = event.target;\n       replace(pathname.replace(`/${locale}`, `/${value}`));\n       closeMenu();\n     },\n     [replace, pathname, locale, closeMenu],\n   );\n   ```\n\nNo other changes. The existing replace navigation is preserved, closeMenu is called immediately after.",
+        "testStrategy": "Update existing test at `apps/site/tests/components/View/SideNavigation/LanguageSelector.test.tsx`:\n- Mock useSideNavigation to return mockCloseMenu\n- Keep existing mockReplace mock\n- Existing tests verify replace is called with correct paths for each language (en-US/pt-BR/es)\n- Add new assertions to each navigation test:\n  - Verify mockCloseMenu was called once\n  - Verify mockCloseMenu was called after replace (order matters)\n\nBehavior: selecting a language radio calls both replace and closeMenu.",
+        "priority": "medium",
+        "dependencies": [
+          1,
+          2
+        ],
+        "status": "pending",
+        "subtasks": []
+      }
+    ],
+    "metadata": {
+      "created": "2026-07-01T14:21:47.335Z",
+      "updated": "2026-07-01T14:38:11.709Z",
+      "description": "Tasks for mobile-menu-close-on-item-click context"
     }
   }
 }

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6775,9 +6775,9 @@
         "testStrategy": "Unit test for `useSideNavigation` hook:\n- Mock context provider with closeMenu function\n- Verify hook returns context when inside provider\n- Verify invariant throws when hook used outside provider (should throw error with message 'useSideNavigation must be used within a SideNavigationProvider.')\n\nCreate test file at `apps/site/tests/components/Layout/SideNavigation/useSideNavigation.test.tsx`",
         "priority": "high",
         "dependencies": [],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-07-01T14:49:55.101Z"
+        "updatedAt": "2026-07-01T14:55:53.301Z"
       },
       {
         "id": 2,
@@ -6789,8 +6789,9 @@
         "dependencies": [
           1
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-07-01T14:59:12.812Z"
       },
       {
         "id": 3,
@@ -6803,8 +6804,9 @@
           1,
           2
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-07-01T15:03:54.026Z"
       },
       {
         "id": 4,
@@ -6817,8 +6819,9 @@
           1,
           2
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-07-01T15:08:07.231Z"
       },
       {
         "id": 5,
@@ -6831,8 +6834,9 @@
           1,
           2
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-07-01T15:11:41.572Z"
       },
       {
         "id": 6,
@@ -6845,8 +6849,9 @@
           1,
           2
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-07-01T15:13:50.657Z"
       },
       {
         "id": 7,
@@ -6859,15 +6864,16 @@
           1,
           2
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-07-01T15:14:53.855Z"
       }
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-07-01T14:49:55.102Z",
+      "lastModified": "2026-07-01T15:14:53.856Z",
       "taskCount": 7,
-      "completedCount": 0,
+      "completedCount": 7,
       "tags": [
         "mobile-menu-close-on-item-click"
       ]

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -6775,8 +6775,9 @@
         "testStrategy": "Unit test for `useSideNavigation` hook:\n- Mock context provider with closeMenu function\n- Verify hook returns context when inside provider\n- Verify invariant throws when hook used outside provider (should throw error with message 'useSideNavigation must be used within a SideNavigationProvider.')\n\nCreate test file at `apps/site/tests/components/Layout/SideNavigation/useSideNavigation.test.tsx`",
         "priority": "high",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "in-progress",
+        "subtasks": [],
+        "updatedAt": "2026-07-01T14:49:55.101Z"
       },
       {
         "id": 2,
@@ -6863,9 +6864,13 @@
       }
     ],
     "metadata": {
-      "created": "2026-07-01T14:21:47.335Z",
-      "updated": "2026-07-01T14:38:11.709Z",
-      "description": "Tasks for mobile-menu-close-on-item-click context"
+      "version": "1.0.0",
+      "lastModified": "2026-07-01T14:49:55.102Z",
+      "taskCount": 7,
+      "completedCount": 0,
+      "tags": [
+        "mobile-menu-close-on-item-click"
+      ]
     }
   }
 }

--- a/apps/site/src/components/Layout/SideNavigation/LanguageSelector.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/LanguageSelector.tsx
@@ -12,6 +12,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { LANGUAGES_OPTIONS } from './constants';
+import { useSideNavigation } from './context';
 import { MenuItem } from './MenuItem';
 
 export const LanguageSelector: FC = () => {
@@ -20,13 +21,15 @@ export const LanguageSelector: FC = () => {
   const locale = useLocale();
   const { replace } = useRouter();
   const pathname = usePathname();
+  const { closeMenu } = useSideNavigation();
 
   const onChangeLanguage = useCallback<RadioGroupProps['onChange']>(
     (event) => {
       const { value } = event.target;
       replace(pathname.replace(`/${locale}`, `/${value}`));
+      closeMenu();
     },
-    [replace, pathname, locale],
+    [replace, pathname, locale, closeMenu],
   );
 
   const renderLanguages = useCallback<RadioGroupChildrenFn>(

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item1/index.tsx
@@ -8,6 +8,7 @@ import { useLocale } from 'next-intl';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
+import { useSideNavigation } from '../../context';
 import { Text } from '../Text';
 import { IGhostLinkProps } from '../types';
 
@@ -21,6 +22,7 @@ export const Item1: FC<IGhostLinkProps> = ({
 }) => {
   const locale = useLocale();
   const pathname = usePathname();
+  const { closeMenu } = useSideNavigation();
   const localizedHref = href === '/' ? `/${locale}` : `/${locale}${href}`;
   const newHref = newTab ? href : localizedHref;
 
@@ -34,6 +36,7 @@ export const Item1: FC<IGhostLinkProps> = ({
   return (
     <Link
       href={newHref}
+      onClick={closeMenu}
       aria-current={isActive ? 'page' : undefined}
       className={classNames(
         'flex flex-row items-center justify-between transition-all px-4 py-3 rounded-lg',

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/Link/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/Link/index.tsx
@@ -6,6 +6,7 @@ import { Icon } from '@repo/ui/Imagery';
 import classNames from 'classnames';
 import NextLink from 'next/link';
 
+import { useSideNavigation } from '../../../context';
 import { Text } from '../../Text';
 import { IGhostLinkProps } from '../../types';
 import { ROOT_STYLE } from '../constants';
@@ -19,9 +20,12 @@ export const Link: FC<IGhostLinkProps> = ({
   iconClassName,
   newTab,
 }) => {
+  const { closeMenu } = useSideNavigation();
+
   return (
     <NextLink
       href={href}
+      onClick={closeMenu}
       className={classNames(ROOT_STYLE, className)}
       target={newTab ? '_blank' : '_self'}
       rel={newTab ? 'noopener noreferrer' : undefined}

--- a/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/ShortLink/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/MenuItem/Item2/ShortLink/index.tsx
@@ -6,6 +6,7 @@ import { Icon } from '@repo/ui/Imagery';
 import classNames from 'classnames';
 import NextLink from 'next/link';
 
+import { useSideNavigation } from '../../../context';
 import { IGhostLinkProps } from '../../types';
 import { ROOT_STYLE } from '../constants';
 import { Container } from '../Container';
@@ -18,9 +19,12 @@ export const ShortLink: FC<IGhostLinkProps> = ({
   newTab,
   'aria-label': ariaLabel,
 }) => {
+  const { closeMenu } = useSideNavigation();
+
   return (
     <NextLink
       href={href}
+      onClick={closeMenu}
       aria-label={ariaLabel}
       className={classNames(ROOT_STYLE, className)}
       target={newTab ? '_blank' : '_self'}

--- a/apps/site/src/components/Layout/SideNavigation/ThemeToggle.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/ThemeToggle.tsx
@@ -13,18 +13,21 @@ import { useTranslations } from 'next-intl';
 import { Theme, useTheme } from '~hooks';
 
 import { THEME_OPTIONS } from './constants';
+import { useSideNavigation } from './context';
 import { MenuItem } from './MenuItem';
 
 export const ThemeToggle: FC = () => {
   const t = useTranslations('SideNavigation');
   const tTheme = useTranslations('Theme');
   const { theme, setTheme } = useTheme();
+  const { closeMenu } = useSideNavigation();
 
   const onChangeTheme = useCallback<RadioGroupProps['onChange']>(
     (event) => {
       setTheme(event.target.value as Theme);
+      closeMenu();
     },
-    [setTheme],
+    [setTheme, closeMenu],
   );
 
   const renderThemes = useCallback<RadioGroupChildrenFn>(

--- a/apps/site/src/components/Layout/SideNavigation/context.ts
+++ b/apps/site/src/components/Layout/SideNavigation/context.ts
@@ -1,25 +1,17 @@
 import { createContext, useContext } from 'react';
 
-import invariant from 'tiny-invariant';
-
 export interface ISideNavigationContext {
   closeMenu: () => void;
 }
 
-export const SideNavigationContext =
-  createContext<ISideNavigationContext | null>(null);
+const noop = () => {};
+
+export const SideNavigationContext = createContext<ISideNavigationContext>({
+  closeMenu: noop,
+});
 
 export const SideNavigationProvider = SideNavigationContext.Provider;
 
 SideNavigationContext.displayName = 'SideNavigationContext';
 
-export const useSideNavigation = () => {
-  const context = useContext(SideNavigationContext);
-
-  invariant(
-    context,
-    'useSideNavigation must be used within a SideNavigationProvider.',
-  );
-
-  return context;
-};
+export const useSideNavigation = () => useContext(SideNavigationContext);

--- a/apps/site/src/components/Layout/SideNavigation/context.ts
+++ b/apps/site/src/components/Layout/SideNavigation/context.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react';
+
+import invariant from 'tiny-invariant';
+
+export interface ISideNavigationContext {
+  closeMenu: () => void;
+}
+
+export const SideNavigationContext =
+  createContext<ISideNavigationContext | null>(null);
+
+export const SideNavigationProvider = SideNavigationContext.Provider;
+
+SideNavigationContext.displayName = 'SideNavigationContext';
+
+export const useSideNavigation = () => {
+  const context = useContext(SideNavigationContext);
+
+  invariant(
+    context,
+    'useSideNavigation must be used within a SideNavigationProvider.',
+  );
+
+  return context;
+};

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -11,6 +11,7 @@ import { getResumeUrl } from '~/lib/resume';
 import { useBreakpoint } from '~hooks';
 
 import { Header } from '../Header';
+import { SideNavigationProvider } from './context';
 import { LanguageSelector } from './LanguageSelector';
 import { MenuItem } from './MenuItem';
 import { ThemeToggle } from './ThemeToggle';
@@ -19,7 +20,7 @@ export const SideNavigation: FC = () => {
   const t = useTranslations('SideNavigation');
   const locale = useLocale();
   const isDesktop = useBreakpoint('lg');
-  const { value: open, toggle } = useBoolean(false);
+  const { value: open, toggle, setFalse: closeMenu } = useBoolean(false);
   const isOpen = !isDesktop && open;
 
   useScrollLock({ autoLock: isOpen });
@@ -27,82 +28,86 @@ export const SideNavigation: FC = () => {
   return (
     <div className="fixed left-0 top-0 z-50 w-full shadow-1 lg:w-auto">
       <Header open={isOpen} toggle={toggle} />
-      <nav
-        id="side-navigation"
-        aria-label={t('mainNav')}
-        className={classNames(
-          'absolute top-full lg:relative lg:top-auto h-sidenav-mobile lg:h-sidenav-desktop right-0 w-full sm:w-[375px] lg:w-60 lg:px-4 bg-surface-sunken flex flex-col overflow-y-auto overscroll-y-contain border-0 duration-300 ease-linear lg:!translate-x-0 z-9999',
-          isOpen ? 'translate-x-0' : 'translate-x-full',
-        )}
-      >
-        <ul className="flex flex-col gap-y-3 px-6 pt-10 lg:px-0 lg:pt-15">
-          <li>
-            <MenuItem.Item1 href="/" icon="material-symbols:home">
-              {t('home')}
-            </MenuItem.Item1>
-          </li>
-          <li>
-            <MenuItem.Item1
-              href="/projects"
-              icon="material-symbols:deployed-code"
-            >
-              {t('projects')}
-            </MenuItem.Item1>
-          </li>
-          <li>
-            <MenuItem.Item1 href="/about" icon="material-symbols:person">
-              {t('about')}
-            </MenuItem.Item1>
-          </li>
-          <li>
-            <MenuItem.Item1
-              href={getResumeUrl(locale as Parameters<typeof getResumeUrl>[0])}
-              icon="material-symbols:description"
-              newTab
-            >
-              {t('resume')}
-            </MenuItem.Item1>
-          </li>
-        </ul>
-        <Divider className="mx-6 lg:mx-0" />
-        <ul className="flex flex-col gap-y-3 px-6 pb-8 lg:justify-end lg:px-0">
-          <li>
-            <MenuItem.Item2.Link
-              href={process.env.NEXT_PUBLIC_LINKEDIN_URL}
-              icon="devicon:linkedin"
-              newTab
-            >
-              {t('linkedin')}
-            </MenuItem.Item2.Link>
-          </li>
-          <li>
-            <MenuItem.Item2.Link
-              href={process.env.NEXT_PUBLIC_GITHUB_URL}
-              icon="mdi:github"
-              iconClassName="text-content-primary"
-              newTab
-            >
-              {t('github')}
-            </MenuItem.Item2.Link>
-          </li>
-          <li>
-            <MenuItem.Item2.Link
-              href={`/${locale}/feed.xml`}
-              icon="mdi:rss"
-              iconClassName="text-content-primary"
-              newTab
-            >
-              {t('rss')}
-            </MenuItem.Item2.Link>
-          </li>
-          <li>
-            <ThemeToggle />
-          </li>
-          <li>
-            <LanguageSelector />
-          </li>
-        </ul>
-      </nav>
+      <SideNavigationProvider value={{ closeMenu }}>
+        <nav
+          id="side-navigation"
+          aria-label={t('mainNav')}
+          className={classNames(
+            'absolute top-full lg:relative lg:top-auto h-sidenav-mobile lg:h-sidenav-desktop right-0 w-full sm:w-[375px] lg:w-60 lg:px-4 bg-surface-sunken flex flex-col overflow-y-auto overscroll-y-contain border-0 duration-300 ease-linear lg:!translate-x-0 z-9999',
+            isOpen ? 'translate-x-0' : 'translate-x-full',
+          )}
+        >
+          <ul className="flex flex-col gap-y-3 px-6 pt-10 lg:px-0 lg:pt-15">
+            <li>
+              <MenuItem.Item1 href="/" icon="material-symbols:home">
+                {t('home')}
+              </MenuItem.Item1>
+            </li>
+            <li>
+              <MenuItem.Item1
+                href="/projects"
+                icon="material-symbols:deployed-code"
+              >
+                {t('projects')}
+              </MenuItem.Item1>
+            </li>
+            <li>
+              <MenuItem.Item1 href="/about" icon="material-symbols:person">
+                {t('about')}
+              </MenuItem.Item1>
+            </li>
+            <li>
+              <MenuItem.Item1
+                href={getResumeUrl(
+                  locale as Parameters<typeof getResumeUrl>[0],
+                )}
+                icon="material-symbols:description"
+                newTab
+              >
+                {t('resume')}
+              </MenuItem.Item1>
+            </li>
+          </ul>
+          <Divider className="mx-6 lg:mx-0" />
+          <ul className="flex flex-col gap-y-3 px-6 pb-8 lg:justify-end lg:px-0">
+            <li>
+              <MenuItem.Item2.Link
+                href={process.env.NEXT_PUBLIC_LINKEDIN_URL}
+                icon="devicon:linkedin"
+                newTab
+              >
+                {t('linkedin')}
+              </MenuItem.Item2.Link>
+            </li>
+            <li>
+              <MenuItem.Item2.Link
+                href={process.env.NEXT_PUBLIC_GITHUB_URL}
+                icon="mdi:github"
+                iconClassName="text-content-primary"
+                newTab
+              >
+                {t('github')}
+              </MenuItem.Item2.Link>
+            </li>
+            <li>
+              <MenuItem.Item2.Link
+                href={`/${locale}/feed.xml`}
+                icon="mdi:rss"
+                iconClassName="text-content-primary"
+                newTab
+              >
+                {t('rss')}
+              </MenuItem.Item2.Link>
+            </li>
+            <li>
+              <ThemeToggle />
+            </li>
+            <li>
+              <LanguageSelector />
+            </li>
+          </ul>
+        </nav>
+      </SideNavigationProvider>
     </div>
   );
 };

--- a/apps/site/tests/components/View/SideNavigation/LanguageSelector.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/LanguageSelector.test.tsx
@@ -3,8 +3,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { LanguageSelector } from '~/components/Layout/SideNavigation/LanguageSelector';
 
 const mockReplace = vi.fn();
+const mockCloseMenu = vi.fn();
 let mockPathname = '/en-US/about';
 let mockLocale = 'en-US';
+
+vi.mock('~/components/Layout/SideNavigation/context', () => ({
+  useSideNavigation: () => ({ closeMenu: mockCloseMenu }),
+}));
 
 vi.mock('next/navigation', () => ({
   redirect: vi.fn(),
@@ -127,5 +132,13 @@ describe('LanguageSelector', () => {
     fireEvent.click(screen.getByTestId('radio-en-US'));
 
     expect(mockReplace).toHaveBeenCalledWith('/en-US/about');
+  });
+
+  it('should call closeMenu when a language option is selected', () => {
+    render(<LanguageSelector />);
+
+    fireEvent.click(screen.getByTestId('radio-pt-BR'));
+
+    expect(mockCloseMenu).toHaveBeenCalledOnce();
   });
 });

--- a/apps/site/tests/components/View/SideNavigation/MenuItem/Item1.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/MenuItem/Item1.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { Item1 } from '~/components/Layout/SideNavigation/MenuItem/Item1';
+
+const mockCloseMenu = vi.fn();
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en-US',
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/en-US/about',
+}));
+
+vi.mock('~/components/Layout/SideNavigation/context', () => ({
+  useSideNavigation: () => ({ closeMenu: mockCloseMenu }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Item1', () => {
+  it('should call closeMenu when the link is clicked', () => {
+    render(
+      <Item1 href="/projects" icon="material-symbols:deployed-code">
+        Projects
+      </Item1>,
+    );
+
+    fireEvent.click(screen.getByText('Projects'));
+
+    expect(mockCloseMenu).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/site/tests/components/View/SideNavigation/MenuItem/Item2/Link.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/MenuItem/Item2/Link.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { Link } from '~/components/Layout/SideNavigation/MenuItem/Item2/Link';
+
+const mockCloseMenu = vi.fn();
+
+vi.mock('~/components/Layout/SideNavigation/context', () => ({
+  useSideNavigation: () => ({ closeMenu: mockCloseMenu }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Item2.Link', () => {
+  it('should call closeMenu when the link is clicked', () => {
+    render(
+      <Link href="https://linkedin.com" icon="devicon:linkedin" newTab>
+        LinkedIn
+      </Link>,
+    );
+
+    fireEvent.click(screen.getByText('LinkedIn'));
+
+    expect(mockCloseMenu).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/site/tests/components/View/SideNavigation/MenuItem/Item2/ShortLink.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/MenuItem/Item2/ShortLink.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ShortLink } from '~/components/Layout/SideNavigation/MenuItem/Item2/ShortLink';
+
+const mockCloseMenu = vi.fn();
+
+vi.mock('~/components/Layout/SideNavigation/context', () => ({
+  useSideNavigation: () => ({ closeMenu: mockCloseMenu }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Item2.ShortLink', () => {
+  it('should call closeMenu when the link is clicked', () => {
+    render(
+      <ShortLink
+        href="https://github.com"
+        icon="mdi:github"
+        aria-label="GitHub"
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('GitHub'));
+
+    expect(mockCloseMenu).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/site/tests/components/View/SideNavigation/SideNavigation.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/SideNavigation.test.tsx
@@ -3,15 +3,17 @@
  */
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
   useLocale: () => 'en-US',
 }));
 
+const mockSetFalse = vi.fn();
+
 vi.mock('usehooks-ts', () => ({
-  useBoolean: () => ({ value: false, toggle: vi.fn() }),
+  useBoolean: () => ({ value: false, toggle: vi.fn(), setFalse: mockSetFalse }),
   useScrollLock: vi.fn(),
 }));
 
@@ -23,18 +25,41 @@ vi.mock('~/components/Layout/Header', () => ({
   Header: () => <div data-testid="header" />,
 }));
 
-vi.mock('~/components/Layout/SideNavigation/MenuItem', () => ({
-  MenuItem: {
-    Item1: ({ children, href }: { children: React.ReactNode; href: string }) => (
-      <a href={href}>{children}</a>
-    ),
-    Item2: {
-      Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
-        <a href={href}>{children}</a>
-      ),
+vi.mock('~/components/Layout/SideNavigation/MenuItem', async () => {
+  const { useSideNavigation } = await vi.importActual<
+    typeof import('~/components/Layout/SideNavigation/context')
+  >('~/components/Layout/SideNavigation/context');
+
+  const Item1 = ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => {
+    const { closeMenu } = useSideNavigation();
+    return (
+      <a href={href} onClick={closeMenu}>
+        {children}
+      </a>
+    );
+  };
+
+  return {
+    MenuItem: {
+      Item1,
+      Item2: {
+        Link: ({
+          children,
+          href,
+        }: {
+          children: React.ReactNode;
+          href: string;
+        }) => <a href={href}>{children}</a>,
+      },
     },
-  },
-}));
+  };
+});
 
 vi.mock('~/components/Layout/SideNavigation/ThemeToggle', () => ({
   ThemeToggle: () => <div data-testid="theme-toggle" />,
@@ -47,6 +72,10 @@ vi.mock('~/components/Layout/SideNavigation/LanguageSelector', () => ({
 vi.mock('@repo/ui/View', () => ({
   Divider: () => <hr />,
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('SideNavigation', () => {
   it('should render ul elements with only li as direct children', async () => {
@@ -63,5 +92,16 @@ describe('SideNavigation', () => {
         expect(child.tagName).toBe('LI');
       });
     });
+  });
+
+  it('should provide closeMenu to descendants via SideNavigationContext', async () => {
+    const { SideNavigation } = await import(
+      '~/components/Layout/SideNavigation'
+    );
+    render(React.createElement(SideNavigation));
+
+    fireEvent.click(screen.getByText('home'));
+
+    expect(mockSetFalse).toHaveBeenCalledOnce();
   });
 });

--- a/apps/site/tests/components/View/SideNavigation/ThemeToggle.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/ThemeToggle.test.tsx
@@ -7,9 +7,14 @@ import { ThemeToggle } from '~/components/Layout/SideNavigation/ThemeToggle';
 // ---------------------------------------------------------------------------
 
 const mockSetTheme = vi.fn();
+const mockCloseMenu = vi.fn();
 
 vi.mock('~hooks', () => ({
   useTheme: () => ({ theme: 'system', setTheme: mockSetTheme }),
+}));
+
+vi.mock('~/components/Layout/SideNavigation/context', () => ({
+  useSideNavigation: () => ({ closeMenu: mockCloseMenu }),
 }));
 
 vi.mock('next-intl', () => ({
@@ -124,5 +129,13 @@ describe('ThemeToggle', () => {
     render(<ThemeToggle />);
 
     expect(screen.getByTestId('theme-expandable')).toBeInTheDocument();
+  });
+
+  it('should call closeMenu when a theme option is selected', () => {
+    render(<ThemeToggle />);
+
+    fireEvent.click(screen.getByTestId('radio-dark'));
+
+    expect(mockCloseMenu).toHaveBeenCalledOnce();
   });
 });

--- a/apps/site/tests/components/View/SideNavigation/context.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/context.test.tsx
@@ -31,9 +31,9 @@ describe('SideNavigationContext', () => {
     expect(mockCloseMenu).toHaveBeenCalledOnce();
   });
 
-  it('should throw when used outside a SideNavigationProvider', () => {
-    expect(() => renderHook(() => useSideNavigation())).toThrow(
-      'useSideNavigation must be used within a SideNavigationProvider.',
-    );
+  it('should default closeMenu to a no-op when there is no provider', () => {
+    const { result } = renderHook(() => useSideNavigation());
+
+    expect(() => result.current.closeMenu()).not.toThrow();
   });
 });

--- a/apps/site/tests/components/View/SideNavigation/context.test.tsx
+++ b/apps/site/tests/components/View/SideNavigation/context.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen, fireEvent, renderHook } from '@testing-library/react';
+
+import {
+  SideNavigationProvider,
+  useSideNavigation,
+} from '~/components/Layout/SideNavigation/context';
+
+const Consumer: React.FC = () => {
+  const { closeMenu } = useSideNavigation();
+
+  return <button onClick={closeMenu}>close</button>;
+};
+
+describe('SideNavigationContext', () => {
+  it('should call the provided closeMenu when a consumer invokes it', () => {
+    const mockCloseMenu = vi.fn();
+
+    render(
+      <SideNavigationProvider value={{ closeMenu: mockCloseMenu }}>
+        <Consumer />
+      </SideNavigationProvider>,
+    );
+
+    fireEvent.click(screen.getByText('close'));
+
+    expect(mockCloseMenu).toHaveBeenCalledOnce();
+  });
+
+  it('should throw when used outside a SideNavigationProvider', () => {
+    expect(() => renderHook(() => useSideNavigation())).toThrow(
+      'useSideNavigation must be used within a SideNavigationProvider.',
+    );
+  });
+});

--- a/docs/superpowers/specs/2026-07-01-mobile-menu-close-on-item-click-design.md
+++ b/docs/superpowers/specs/2026-07-01-mobile-menu-close-on-item-click-design.md
@@ -1,0 +1,56 @@
+# Mobile side menu: close on item click
+
+## Problem
+
+On mobile, `SideNavigation` (`apps/site/src/components/Layout/SideNavigation/index.tsx`) opens as an overlay controlled by `useBoolean(false)` (`open`/`toggle`) at line 22, toggled only by the `Header` hamburger button. Clicking a menu item (page link, external link, or a theme/language option) does not close the menu — the user must tap the hamburger again.
+
+## Scope
+
+Close the mobile menu whenever the user acts on any menu item:
+
+- `MenuItem.Item1` links (Home, Projects, About, Resume)
+- `MenuItem.Item2.Link` / `MenuItem.Item2.ShortLink` (LinkedIn, GitHub, RSS)
+- Selecting a `Radio` option inside the `ThemeToggle` or `LanguageSelector` expandables (i.e. their `RadioGroup`'s `onChange`)
+
+Out of scope: any change to `Accordion` semantics. `ThemeToggle` and `LanguageSelector` remain two independent `Accordion.Root` instances — expanding one does not collapse the other. The "radio" behavior referenced in the request is the existing `Radio`/`RadioGroup` used for selecting a theme/language inside each expandable, not a radio relationship between the two accordions.
+
+Desktop is unaffected: `isOpen` is already gated by `!isDesktop && open`, so calling close on desktop is a no-op in practice, but consumers don't need to know or care about breakpoint — they just declare "close on selection."
+
+## Design
+
+### State reuse
+
+No new state. `SideNavigation` already holds the open/closed state via `useBoolean(false)` at line 22. Swap the destructure to also pull `setFalse`:
+
+```ts
+const { value: open, toggle, setFalse: closeMenu } = useBoolean(false);
+```
+
+### Declarative propagation via Context
+
+Add `SideNavigationContext` (React context) created and provided by `SideNavigation`, exposing `{ closeMenu: () => void }`. A `useSideNavigation()` hook reads it (with an `invariant` guard, following the existing `useAccordion` pattern in `packages/ui/src/Control/Accordion/useAccordion.ts`).
+
+Consumers call `closeMenu()` from their existing `onClick`/`onChange` handlers — they don't manage or know about open/closed state, just declare "this action closes the menu":
+
+- `MenuItem/Item1/index.tsx`: add `onClick={closeMenu}` on the `<Link>`.
+- `MenuItem/Item2/Link/index.tsx` and `MenuItem/Item2/ShortLink/index.tsx`: same, `onClick={closeMenu}` on `<NextLink>`.
+- `ThemeToggle.tsx`: call `closeMenu()` inside `onChangeTheme`, after `setTheme(...)`.
+- `LanguageSelector.tsx`: call `closeMenu()` inside `onChangeLanguage`, after `replace(...)`.
+
+### Placement
+
+The context lives alongside `SideNavigation` (`apps/site/src/components/Layout/SideNavigation/context.ts` + hook), not in `packages/ui`, since it's specific to this app-level navigation composition, not a reusable design-system primitive.
+
+## Testing
+
+Behavior-focused tests (no implementation details):
+
+- `Item1`, `Item2.Link`, `Item2.ShortLink`: clicking the link calls `closeMenu` from a mocked `SideNavigationContext`.
+- `ThemeToggle`, `LanguageSelector`: selecting a radio option calls `closeMenu` in addition to the existing `setTheme`/`replace` side effect.
+- `SideNavigation`: an integration-level test (or the existing test file for it, if any) confirming that clicking a nested `Item1` link transitions `open` back to `false`.
+
+## Non-goals
+
+- No change to `Accordion` component or its context/hook.
+- No change to desktop behavior.
+- No new shared state beyond the existing `useBoolean`.


### PR DESCRIPTION
## Summary
- Add `SideNavigationContext`/`useSideNavigation` (default no-op `closeMenu`) so mobile menu items can declaratively close the overlay without prop drilling.
- Wire `closeMenu` into `Item1`, `Item2.Link`, `Item2.ShortLink` (`onClick`) and `ThemeToggle`/`LanguageSelector` (`onChange`, after applying the theme/language change).
- Reuses the existing `useBoolean` state in `SideNavigation` (`setFalse`) — no new state introduced.
- `ThemeToggle`/`LanguageSelector` accordions remain independent (`Accordion.Root` per component); "radio" behavior refers to the existing `Radio`/`RadioGroup` used to pick a theme/language, not a relationship between the two accordions.
- Fixed a build break: `MenuItem.Item2.ShortLink` is also reused in `ContactInfo` (footer social links) outside `SideNavigation`, so `closeMenu` defaults to a no-op instead of requiring a provider.

Refs #887

Tracked via Task Master (`mobile-menu-close-on-item-click` tag, `.taskmaster/docs/mobile-menu-close-on-item-click-prd.md`), 7/7 tasks done.

## Test plan
- [x] `pnpm test` (site): 44 files / 186 tests passing
- [x] `pnpm lint` / `pnpm types` (site): clean, 0 errors
- [x] `pnpm build` (site): static export succeeds, including `/about` for all locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)