### PR TITLE
feat(site): add Google Analytics (GA4) via @next/third-parties

### DIFF
--- a/apps/site/.env.example
+++ b/apps/site/.env.example
@@ -41,3 +41,7 @@ NEXT_PUBLIC_RESUME_URL_EN_US="https://..."
 NEXT_PUBLIC_RESUME_URL_PT_BR="https://..."
 NEXT_PUBLIC_RESUME_URL_ES="https://..."
 NEXT_PUBLIC_WHATSAPP_URL="https://api.whatsapp.com/send?phone=5511999999999"
+
+# ── Google Analytics (GA4) ─────────────────────────────────────────────────────
+# analytics.google.com → Admin → Data Streams → Web stream
+NEXT_PUBLIC_GA_MEASUREMENT_ID="G-XXXXXXXXXX"

--- a/apps/site/environment.d.ts
+++ b/apps/site/environment.d.ts
@@ -11,6 +11,7 @@ declare global {
       readonly NEXT_PUBLIC_RESUME_URL_PT_BR: string;
       readonly NEXT_PUBLIC_RESUME_URL_ES: string;
       readonly NEXT_PUBLIC_WHATSAPP_URL: string;
+      readonly NEXT_PUBLIC_GA_MEASUREMENT_ID?: string;
     }
   }
 }

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -10,6 +10,7 @@ const nextConfig = {
     NEXT_PUBLIC_RESUME_URL: process.env.NEXT_PUBLIC_RESUME_URL,
     NEXT_PUBLIC_WHATSAPP_URL: process.env.NEXT_PUBLIC_WHATSAPP_URL,
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+    NEXT_PUBLIC_GA_MEASUREMENT_ID: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
   },
   images: {
     qualities: [100, 75],

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@next/third-parties": "^16.2.10",
     "@repo/application": "workspace:*",
     "@repo/core": "workspace:*",
     "@repo/infra": "workspace:*",

--- a/apps/site/src/app/[locale]/feed.xml/route.ts
+++ b/apps/site/src/app/[locale]/feed.xml/route.ts
@@ -3,11 +3,10 @@ import { LOCALES } from '@repo/core/shared';
 import type { Locale } from '@repo/core/shared';
 import { getTranslations } from 'next-intl/server';
 
+import { env } from '~/config/env';
 import { getServerContainer } from '~/lib/server/container';
 
 export const dynamic = 'force-static';
-
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
 function escapeXml(value: string): string {
   return value
@@ -44,9 +43,9 @@ export async function GET(
       (p) => `
     <item>
       <title>${escapeXml(p.title)}</title>
-      <link>${SITE_URL}/${locale}/projects/${escapeXml(p.slug)}</link>
+      <link>${env.siteUrl}/${locale}/projects/${escapeXml(p.slug)}</link>
       <description>${escapeXml(p.caption)}</description>
-      <guid isPermaLink="true">${SITE_URL}/${locale}/projects/${escapeXml(p.slug)}</guid>
+      <guid isPermaLink="true">${env.siteUrl}/${locale}/projects/${escapeXml(p.slug)}</guid>
     </item>`,
     )
     .join('');
@@ -55,11 +54,11 @@ export async function GET(
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Wallace Ferreira</title>
-    <link>${SITE_URL}/${locale}</link>
+    <link>${env.siteUrl}/${locale}</link>
     <description>${escapeXml(description)}</description>
     <language>${locale}</language>
     <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
-    <atom:link href="${SITE_URL}/${locale}/feed.xml" rel="self" type="application/rss+xml"/>
+    <atom:link href="${env.siteUrl}/${locale}/feed.xml" rel="self" type="application/rss+xml"/>
     ${items}
   </channel>
 </rss>`;

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import { GetProfile } from '@repo/application/portfolio';
 import { type Locale, LOCALES } from '@repo/core/shared';
+import { GoogleAnalytics } from '@next/third-parties/google';
 import classNames from 'classnames';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
@@ -104,6 +105,9 @@ export default async function RootLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <AppLayout>{children}</AppLayout>
         </NextIntlClientProvider>
+        {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
+        )}
       </body>
     </html>
   );

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
+import { GoogleAnalytics } from '@next/third-parties/google';
 import { GetProfile } from '@repo/application/portfolio';
 import { type Locale, LOCALES } from '@repo/core/shared';
-import { GoogleAnalytics } from '@next/third-parties/google';
 import classNames from 'classnames';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
@@ -11,7 +11,7 @@ import {
 } from 'next-intl/server';
 import { Inter } from 'next/font/google';
 
-import { SITE_URL } from '~/lib/og';
+import { env } from '~/config/env';
 import { buildAlternates } from '~/lib/seo/alternates';
 import { buildPersonJsonLd } from '~/lib/seo/structuredData';
 import { getServerContainer } from '~/lib/server/container';
@@ -31,7 +31,7 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'Metadata' });
   return {
-    metadataBase: new URL(SITE_URL),
+    metadataBase: new URL(env.siteUrl),
     title: {
       default: 'Wallace Ferreira',
       template: '%s | Wallace Ferreira',
@@ -57,7 +57,7 @@ export async function generateMetadata({
       types: {
         'application/rss+xml': [
           {
-            url: `${SITE_URL}/${locale}/feed.xml`,
+            url: `${env.siteUrl}/${locale}/feed.xml`,
             title: 'Wallace Ferreira',
           },
         ],
@@ -105,9 +105,7 @@ export default async function RootLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <AppLayout>{children}</AppLayout>
         </NextIntlClientProvider>
-        {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
-          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
-        )}
+        {env.gaMeasurementId && <GoogleAnalytics gaId={env.gaMeasurementId} />}
       </body>
     </html>
   );

--- a/apps/site/src/app/feed.xml/route.ts
+++ b/apps/site/src/app/feed.xml/route.ts
@@ -1,9 +1,8 @@
+import { env } from '~/config/env';
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 
 export const dynamic = 'force-static';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
-
 export function GET(): Response {
-  return Response.redirect(`${SITE_URL}/${DEFAULT_LOCALE}/feed.xml`, 301);
+  return Response.redirect(`${env.siteUrl}/${DEFAULT_LOCALE}/feed.xml`, 301);
 }

--- a/apps/site/src/app/og/route.tsx
+++ b/apps/site/src/app/og/route.tsx
@@ -2,12 +2,12 @@ import { DEFAULT_LOCALE } from '@repo/core';
 import { ImageResponse } from 'next/og';
 import { type NextRequest } from 'next/server';
 
-import { SITE_URL } from '~/lib/og';
+import { env } from '~/config/env';
 
 export const runtime = 'edge';
 
 const SIZE = { width: 1200, height: 630 };
-const siteHost = new URL(SITE_URL).host;
+const siteHost = new URL(env.siteUrl).host;
 
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;

--- a/apps/site/src/app/robots.ts
+++ b/apps/site/src/app/robots.ts
@@ -1,12 +1,12 @@
 import type { MetadataRoute } from 'next';
 
-export const dynamic = 'force-static';
+import { env } from '~/config/env';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+export const dynamic = 'force-static';
 
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: '*', allow: '/' },
-    sitemap: `${SITE_URL}/sitemap.xml`,
+    sitemap: `${env.siteUrl}/sitemap.xml`,
   };
 }

--- a/apps/site/src/app/sitemap.ts
+++ b/apps/site/src/app/sitemap.ts
@@ -2,12 +2,11 @@ import { GetPublishedProjects } from '@repo/application/portfolio';
 import { LOCALES } from '@repo/core/shared';
 import type { MetadataRoute } from 'next';
 
+import { env } from '~/config/env';
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { getServerContainer } from '~/lib/server/container';
 
 export const dynamic = 'force-static';
-
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
 const BUILD_DATE = new Date().toISOString();
 
@@ -16,7 +15,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const staticEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) =>
     staticRoutes.map((route) => ({
-      url: `${SITE_URL}/${locale}${route}`,
+      url: `${env.siteUrl}/${locale}${route}`,
       lastModified: BUILD_DATE,
       changeFrequency: 'monthly' as const,
       priority: route === '' ? 1.0 : 0.8,
@@ -34,7 +33,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     const projectEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) =>
       projects.map((project) => ({
-        url: `${SITE_URL}/${locale}/projects/${project.slug}`,
+        url: `${env.siteUrl}/${locale}/projects/${project.slug}`,
         lastModified: BUILD_DATE,
         changeFrequency: 'monthly' as const,
         priority: 0.6,

--- a/apps/site/src/components/Layout/SideNavigation/index.tsx
+++ b/apps/site/src/components/Layout/SideNavigation/index.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { useLocale, useTranslations } from 'next-intl';
 import { useBoolean, useScrollLock } from 'usehooks-ts';
 
+import { env } from '~/config/env';
 import { getResumeUrl } from '~/lib/resume';
 import { useBreakpoint } from '~hooks';
 
@@ -72,7 +73,7 @@ export const SideNavigation: FC = () => {
           <ul className="flex flex-col gap-y-3 px-6 pb-8 lg:justify-end lg:px-0">
             <li>
               <MenuItem.Item2.Link
-                href={process.env.NEXT_PUBLIC_LINKEDIN_URL}
+                href={env.linkedinUrl}
                 icon="devicon:linkedin"
                 newTab
               >
@@ -81,7 +82,7 @@ export const SideNavigation: FC = () => {
             </li>
             <li>
               <MenuItem.Item2.Link
-                href={process.env.NEXT_PUBLIC_GITHUB_URL}
+                href={env.githubUrl}
                 icon="mdi:github"
                 iconClassName="text-content-primary"
                 newTab

--- a/apps/site/src/config/env.ts
+++ b/apps/site/src/config/env.ts
@@ -1,27 +1,40 @@
 import type { Locale } from '@repo/core/shared';
 
+/**
+ * Single source of truth for all `NEXT_PUBLIC_*` environment variables.
+ * Each key is a lazy getter so values are read from `process.env` on
+ * access rather than frozen at module load.
+ */
 export const env = {
+  /** Canonical site origin used to build absolute URLs (sitemap, feed, OG, JSON-LD). Falls back to localhost outside production. */
   get siteUrl() {
     return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
   },
+  /** Contact email shown in the Contact section and used as the mailto: target. */
   get contactEmail() {
     return process.env.NEXT_PUBLIC_CONTACT_EMAIL;
   },
+  /** Contact phone number, shown formatted and used to build the WhatsApp deep link. */
   get contactNumber() {
     return process.env.NEXT_PUBLIC_CONTACT_NUMBER;
   },
+  /** GitHub profile URL, linked from navigation, contact section, and Person JSON-LD sameAs. */
   get githubUrl() {
     return process.env.NEXT_PUBLIC_GITHUB_URL;
   },
+  /** LinkedIn profile URL, linked from navigation, contact section, and Person JSON-LD sameAs. */
   get linkedinUrl() {
     return process.env.NEXT_PUBLIC_LINKEDIN_URL;
   },
+  /** Pre-filled WhatsApp chat link, currently unused but reserved for future contact flows. */
   get whatsappUrl() {
     return process.env.NEXT_PUBLIC_WHATSAPP_URL;
   },
+  /** GA4 Measurement ID; when unset, <GoogleAnalytics> is not rendered. */
   get gaMeasurementId() {
     return process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
   },
+  /** Resume file URL per locale, used by the side navigation's "Resume" link. */
   get resumeUrlByLocale(): Record<Locale, string> {
     return {
       'en-US': process.env.NEXT_PUBLIC_RESUME_URL_EN_US,

--- a/apps/site/src/config/env.ts
+++ b/apps/site/src/config/env.ts
@@ -1,0 +1,32 @@
+import type { Locale } from '@repo/core/shared';
+
+export const env = {
+  get siteUrl() {
+    return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+  },
+  get contactEmail() {
+    return process.env.NEXT_PUBLIC_CONTACT_EMAIL;
+  },
+  get contactNumber() {
+    return process.env.NEXT_PUBLIC_CONTACT_NUMBER;
+  },
+  get githubUrl() {
+    return process.env.NEXT_PUBLIC_GITHUB_URL;
+  },
+  get linkedinUrl() {
+    return process.env.NEXT_PUBLIC_LINKEDIN_URL;
+  },
+  get whatsappUrl() {
+    return process.env.NEXT_PUBLIC_WHATSAPP_URL;
+  },
+  get gaMeasurementId() {
+    return process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  },
+  get resumeUrlByLocale(): Record<Locale, string> {
+    return {
+      'en-US': process.env.NEXT_PUBLIC_RESUME_URL_EN_US,
+      'pt-BR': process.env.NEXT_PUBLIC_RESUME_URL_PT_BR,
+      es: process.env.NEXT_PUBLIC_RESUME_URL_ES,
+    };
+  },
+} as const;

--- a/apps/site/src/config/env.ts
+++ b/apps/site/src/config/env.ts
@@ -10,30 +10,37 @@ export const env = {
   get siteUrl() {
     return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
   },
+
   /** Contact email shown in the Contact section and used as the mailto: target. */
   get contactEmail() {
     return process.env.NEXT_PUBLIC_CONTACT_EMAIL;
   },
+
   /** Contact phone number, shown formatted and used to build the WhatsApp deep link. */
   get contactNumber() {
     return process.env.NEXT_PUBLIC_CONTACT_NUMBER;
   },
+
   /** GitHub profile URL, linked from navigation, contact section, and Person JSON-LD sameAs. */
   get githubUrl() {
     return process.env.NEXT_PUBLIC_GITHUB_URL;
   },
+
   /** LinkedIn profile URL, linked from navigation, contact section, and Person JSON-LD sameAs. */
   get linkedinUrl() {
     return process.env.NEXT_PUBLIC_LINKEDIN_URL;
   },
+
   /** Pre-filled WhatsApp chat link, currently unused but reserved for future contact flows. */
   get whatsappUrl() {
     return process.env.NEXT_PUBLIC_WHATSAPP_URL;
   },
+
   /** GA4 Measurement ID; when unset, <GoogleAnalytics> is not rendered. */
   get gaMeasurementId() {
     return process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
   },
+
   /** Resume file URL per locale, used by the side navigation's "Resume" link. */
   get resumeUrlByLocale(): Record<Locale, string> {
     return {

--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -7,6 +7,8 @@ import { Button, Label, Text, TextArea } from '@repo/ui/Control';
 import { useTranslations } from 'next-intl';
 import { useForm } from 'react-hook-form';
 
+import { env } from '~/config/env';
+
 import { contactSchema, ContactFormValues } from './contact-schema';
 
 export const ContactForm: FC = () => {
@@ -28,7 +30,7 @@ export const ContactForm: FC = () => {
     const body = encodeURIComponent(
       `${data.name} <${data.email}>\n\n${data.message}`,
     );
-    window.location.href = `mailto:${process.env.NEXT_PUBLIC_CONTACT_EMAIL}?subject=${subject}&body=${body}`;
+    window.location.href = `mailto:${env.contactEmail}?subject=${subject}&body=${body}`;
     setSubmitted(true);
   };
 

--- a/apps/site/src/features/contact/ContactInfo/index.tsx
+++ b/apps/site/src/features/contact/ContactInfo/index.tsx
@@ -9,12 +9,13 @@ import { formatCellphone } from '@repo/utils';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { MenuItem } from '~/components/Layout/SideNavigation/MenuItem';
+import { env } from '~/config/env';
 
 export const ContactInfo: FC = () => {
   const t = useTranslations('ContactInfo');
   const tClip = useTranslations('Clipboard');
   const locale = useLocale();
-  const whatsappUrl = `https://wa.me/${process.env.NEXT_PUBLIC_CONTACT_NUMBER}?text=${encodeURIComponent(t('whatsappMessage'))}`;
+  const whatsappUrl = `https://wa.me/${env.contactNumber}?text=${encodeURIComponent(t('whatsappMessage'))}`;
 
   return (
     <section className="flex flex-col gap-y-6 xl:w-[326px]">
@@ -33,10 +34,10 @@ export const ContactInfo: FC = () => {
           </div>
           <div className="flex items-center gap-x-2">
             <span className="text-base text-content-secondary">
-              {process.env.NEXT_PUBLIC_CONTACT_EMAIL}
+              {env.contactEmail}
             </span>
             <Button.Clipboard
-              text={process.env.NEXT_PUBLIC_CONTACT_EMAIL ?? ''}
+              text={env.contactEmail ?? ''}
               tooltip={tClip('copy')}
               aria-label={tClip('copy')}
               unstyled
@@ -61,10 +62,10 @@ export const ContactInfo: FC = () => {
           </div>
           <div className="flex items-center gap-x-2">
             <span className="text-base text-content-secondary">
-              {formatCellphone(process.env.NEXT_PUBLIC_CONTACT_NUMBER)}
+              {formatCellphone(env.contactNumber)}
             </span>
             <Button.Clipboard
-              text={process.env.NEXT_PUBLIC_CONTACT_NUMBER ?? ''}
+              text={env.contactNumber ?? ''}
               tooltip={tClip('copy')}
               aria-label={tClip('copy')}
               unstyled
@@ -91,13 +92,13 @@ export const ContactInfo: FC = () => {
           newTab
         />
         <MenuItem.Item2.ShortLink
-          href={process.env.NEXT_PUBLIC_LINKEDIN_URL}
+          href={env.linkedinUrl}
           icon="devicon:linkedin"
           aria-label={t('linkedin')}
           newTab
         />
         <MenuItem.Item2.ShortLink
-          href={process.env.NEXT_PUBLIC_GITHUB_URL}
+          href={env.githubUrl}
           icon="mdi:github"
           iconClassName="text-content-primary"
           aria-label={t('github')}

--- a/apps/site/src/lib/og.ts
+++ b/apps/site/src/lib/og.ts
@@ -1,4 +1,4 @@
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+import { env } from '~/config/env';
 
 interface OgImageParams {
   title: string;
@@ -15,7 +15,7 @@ export function buildOgImageUrl({
   page,
   jobTitle,
 }: OgImageParams): string {
-  const url = new URL('/og', SITE_URL);
+  const url = new URL('/og', env.siteUrl);
   url.searchParams.set('title', title);
   if (subtitle) url.searchParams.set('subtitle', subtitle);
   if (locale) url.searchParams.set('locale', locale);
@@ -23,5 +23,3 @@ export function buildOgImageUrl({
   if (jobTitle) url.searchParams.set('jobTitle', jobTitle);
   return url.toString();
 }
-
-export { SITE_URL };

--- a/apps/site/src/lib/resume.ts
+++ b/apps/site/src/lib/resume.ts
@@ -1,11 +1,7 @@
 import { type Locale } from '@repo/core/shared';
 
-const RESUME_URL_BY_LOCALE: Record<Locale, string> = {
-  'en-US': process.env.NEXT_PUBLIC_RESUME_URL_EN_US,
-  'pt-BR': process.env.NEXT_PUBLIC_RESUME_URL_PT_BR,
-  es: process.env.NEXT_PUBLIC_RESUME_URL_ES,
-};
+import { env } from '~/config/env';
 
 export function getResumeUrl(locale: Locale): string {
-  return RESUME_URL_BY_LOCALE[locale];
+  return env.resumeUrlByLocale[locale];
 }

--- a/apps/site/src/lib/seo/alternates.ts
+++ b/apps/site/src/lib/seo/alternates.ts
@@ -1,7 +1,7 @@
 import type { Locale } from '@repo/core/shared';
 import { DEFAULT_LOCALE, LOCALES } from '@repo/core/shared';
 
-import { SITE_URL } from '~/lib/og';
+import { env } from '~/config/env';
 
 import type { HreflangMap, Pathname } from './types';
 
@@ -11,16 +11,16 @@ export function buildAlternates(
 ): { canonical: string; languages: HreflangMap } {
   const languages = LOCALES.reduce<HreflangMap>(
     (acc, loc) => {
-      acc[loc] = `${SITE_URL}/${loc}${pathname}`;
+      acc[loc] = `${env.siteUrl}/${loc}${pathname}`;
       return acc;
     },
     {
-      'x-default': `${SITE_URL}/${DEFAULT_LOCALE}${pathname}`,
+      'x-default': `${env.siteUrl}/${DEFAULT_LOCALE}${pathname}`,
     } as HreflangMap,
   );
 
   return {
-    canonical: `${SITE_URL}/${locale}${pathname}`,
+    canonical: `${env.siteUrl}/${locale}${pathname}`,
     languages,
   };
 }

--- a/apps/site/src/lib/seo/structuredData.ts
+++ b/apps/site/src/lib/seo/structuredData.ts
@@ -1,6 +1,6 @@
 import type { Locale } from '@repo/core/shared';
 
-import { SITE_URL } from '~/lib/og';
+import { env } from '~/config/env';
 
 interface BuildPersonJsonLdParams {
   name: string;
@@ -33,10 +33,9 @@ export function buildPersonJsonLd({
   headline,
   photo,
 }: BuildPersonJsonLdParams): PersonJsonLd {
-  const sameAs = [
-    process.env.NEXT_PUBLIC_LINKEDIN_URL,
-    process.env.NEXT_PUBLIC_GITHUB_URL,
-  ].filter((url): url is string => Boolean(url));
+  const sameAs = [env.linkedinUrl, env.githubUrl].filter((url): url is string =>
+    Boolean(url),
+  );
 
   return {
     '@context': 'https://schema.org',
@@ -46,13 +45,13 @@ export function buildPersonJsonLd({
         name,
         jobTitle: headline,
         image: photo.url,
-        url: SITE_URL,
+        url: env.siteUrl,
         sameAs,
       },
       {
         '@type': 'WebSite',
         name: 'Wallace Ferreira',
-        url: SITE_URL,
+        url: env.siteUrl,
       },
     ],
   };
@@ -102,7 +101,7 @@ export function buildProjectJsonLd({
   homeLabel,
   projectsLabel,
 }: BuildProjectJsonLdParams): ProjectJsonLd {
-  const homeUrl = `${SITE_URL}/${locale}`;
+  const homeUrl = `${env.siteUrl}/${locale}`;
   const projectsUrl = `${homeUrl}/projects`;
   const projectUrl = `${projectsUrl}/${slug}`;
 

--- a/apps/site/src/lib/seo/types.ts
+++ b/apps/site/src/lib/seo/types.ts
@@ -1,7 +1,5 @@
 import type { Locale } from '@repo/core/shared';
 
-export { SITE_URL } from '~/lib/og';
-
 /**
  * Locale-agnostic path used to build alternates/canonical URLs,
  * e.g. '', '/about', '/projects', '/projects/my-project'.

--- a/apps/site/tests/config/env.test.ts
+++ b/apps/site/tests/config/env.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { env } from '../../src/config/env';
+
+describe('env', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('siteUrl', () => {
+    it('should return NEXT_PUBLIC_SITE_URL when it is set', () => {
+      vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://wallace-ferreira.dev');
+
+      expect(env.siteUrl).toBe('https://wallace-ferreira.dev');
+    });
+
+    it('should fall back to localhost when NEXT_PUBLIC_SITE_URL is unset', () => {
+      vi.stubEnv('NEXT_PUBLIC_SITE_URL', undefined);
+
+      expect(env.siteUrl).toBe('http://localhost:3000');
+    });
+  });
+
+  describe('contactEmail', () => {
+    it('should return NEXT_PUBLIC_CONTACT_EMAIL when it is set', () => {
+      vi.stubEnv('NEXT_PUBLIC_CONTACT_EMAIL', 'wallace@example.com');
+
+      expect(env.contactEmail).toBe('wallace@example.com');
+    });
+
+    it('should return undefined when NEXT_PUBLIC_CONTACT_EMAIL is unset', () => {
+      vi.stubEnv('NEXT_PUBLIC_CONTACT_EMAIL', undefined);
+
+      expect(env.contactEmail).toBeUndefined();
+    });
+  });
+
+  describe('contactNumber', () => {
+    it('should return NEXT_PUBLIC_CONTACT_NUMBER when it is set', () => {
+      vi.stubEnv('NEXT_PUBLIC_CONTACT_NUMBER', '5511913462107');
+
+      expect(env.contactNumber).toBe('5511913462107');
+    });
+  });
+
+  describe('githubUrl', () => {
+    it('should return NEXT_PUBLIC_GITHUB_URL when it is set', () => {
+      vi.stubEnv('NEXT_PUBLIC_GITHUB_URL', 'https://github.com/wallace-sf');
+
+      expect(env.githubUrl).toBe('https://github.com/wallace-sf');
+    });
+  });
+
+  describe('linkedinUrl', () => {
+    it('should return NEXT_PUBLIC_LINKEDIN_URL when it is set', () => {
+      vi.stubEnv(
+        'NEXT_PUBLIC_LINKEDIN_URL',
+        'https://www.linkedin.com/in/wallace-silva-ferreira/',
+      );
+
+      expect(env.linkedinUrl).toBe(
+        'https://www.linkedin.com/in/wallace-silva-ferreira/',
+      );
+    });
+  });
+
+  describe('whatsappUrl', () => {
+    it('should return NEXT_PUBLIC_WHATSAPP_URL when it is set', () => {
+      vi.stubEnv(
+        'NEXT_PUBLIC_WHATSAPP_URL',
+        'https://api.whatsapp.com/send?phone=5511913462107',
+      );
+
+      expect(env.whatsappUrl).toBe(
+        'https://api.whatsapp.com/send?phone=5511913462107',
+      );
+    });
+  });
+
+  describe('gaMeasurementId', () => {
+    it('should return NEXT_PUBLIC_GA_MEASUREMENT_ID when it is set', () => {
+      vi.stubEnv('NEXT_PUBLIC_GA_MEASUREMENT_ID', 'G-X7JEY0B6MZ');
+
+      expect(env.gaMeasurementId).toBe('G-X7JEY0B6MZ');
+    });
+
+    it('should return undefined when NEXT_PUBLIC_GA_MEASUREMENT_ID is unset', () => {
+      vi.stubEnv('NEXT_PUBLIC_GA_MEASUREMENT_ID', undefined);
+
+      expect(env.gaMeasurementId).toBeUndefined();
+    });
+  });
+
+  describe('resumeUrlByLocale', () => {
+    it('should map each supported locale to its resume URL env var', () => {
+      vi.stubEnv(
+        'NEXT_PUBLIC_RESUME_URL_EN_US',
+        'https://example.com/resume-en.pdf',
+      );
+      vi.stubEnv(
+        'NEXT_PUBLIC_RESUME_URL_PT_BR',
+        'https://example.com/resume-pt.pdf',
+      );
+      vi.stubEnv(
+        'NEXT_PUBLIC_RESUME_URL_ES',
+        'https://example.com/resume-es.pdf',
+      );
+
+      expect(env.resumeUrlByLocale).toEqual({
+        'en-US': 'https://example.com/resume-en.pdf',
+        'pt-BR': 'https://example.com/resume-pt.pdf',
+        es: 'https://example.com/resume-es.pdf',
+      });
+    });
+  });
+});

--- a/apps/site/tests/lib/seo/alternates.test.ts
+++ b/apps/site/tests/lib/seo/alternates.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { env } from '../../../src/config/env';
 import { buildAlternates } from '../../../src/lib/seo/alternates';
-import { SITE_URL } from '../../../src/lib/og';
+
+const SITE_URL = env.siteUrl;
 
 describe('buildAlternates', () => {
   it('should build canonical and all locale alternates when given a pathname and locale', () => {

--- a/apps/site/tests/lib/seo/structuredData.test.ts
+++ b/apps/site/tests/lib/seo/structuredData.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { env } from '../../../src/config/env';
 import {
   buildPersonJsonLd,
   buildProjectJsonLd,
 } from '../../../src/lib/seo/structuredData';
-import { SITE_URL } from '../../../src/lib/og';
+
+const SITE_URL = env.siteUrl;
 
 const PROFILE = {
   name: 'Wallace Ferreira',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.4.0(react-hook-form@7.78.0)
+      '@next/third-parties':
+        specifier: ^16.2.10
+        version: 16.2.10(next@16.2.6)(react@19.2.7)
       '@repo/application':
         specifier: workspace:*
         version: link:../../packages/application
@@ -2043,6 +2046,17 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@next/third-parties@16.2.10(next@16.2.6)(react@19.2.7):
+    resolution: {integrity: sha512-H3yxCMLziM1JKXnjQv83WBH2cp1fB1vMxpC1/bBTpvvaesBEuRuprpzq5RI32atis0VhUZflgdpJdGNZIGpQaQ==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    dependencies:
+      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7)(react@19.2.7)
+      react: 19.2.7
+      third-party-capital: 1.0.20
+    dev: false
 
   /@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1:
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
@@ -9249,6 +9263,10 @@ packages:
     dependencies:
       any-promise: 1.3.0
     dev: true
+
+  /third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+    dev: false
 
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}


### PR DESCRIPTION
## Summary
- Adds GA4 pageview tracking to the public site, wired through `@next/third-parties`'s `<GoogleAnalytics>` component in the locale layout
- Adds `NEXT_PUBLIC_GA_MEASUREMENT_ID` to `next.config.mjs` (env passthrough) and `environment.d.ts` (typing), as an optional variable so local/dev environments without it keep working unaffected
- Part of the post-launch SEO/analytics rollout (Search Console + Bing Webmaster Tools already verified and sitemap submitted)

## Test plan
- [x] `tsc --noEmit` passes
- [x] `turbo build` passes across all workspaces (pre-push hook)
- [x] Set `NEXT_PUBLIC_GA_MEASUREMENT_ID` in Vercel (Production) environment variables — required for the tag to render in the deployed site
- [ ] After deploy, confirm pageviews arrive in GA4 Realtime report

🤖 Generated with [Claude Code](https://claude.com/claude-code)