### PR TITLE
fix(site): shrink company name and move period below it in ExperienceCard

### DIFF
--- a/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
@@ -87,8 +87,8 @@ export const ExperienceCard: FC<IExperienceCardProps> = ({
       <div className="flex min-w-0 flex-1 flex-col gap-y-2">
         <h2 className="text-2xl font-bold text-content-primary">{position}</h2>
 
-        <div className="flex flex-wrap items-baseline gap-x-2">
-          <span className="text-xl font-bold uppercase text-content-primary">
+        <div className="flex flex-col">
+          <span className="text-base font-bold uppercase text-content-disabled">
             {company}
           </span>
           <span className="text-base text-content-disabled">


### PR DESCRIPTION
## Summary
- Company name in `ExperienceCard` was styled as large and bold as the h2 position title, competing for attention
- Reduced its font size and matched its color to the period/duration muted tone
- Moved period/duration to its own line below the company name for clearer visual hierarchy

## Test plan
- [x] Verified rendering via screenshot on `/pt-BR/about`