### PR TITLE
chore(infra): seed liveUrl for private/closed-source projects

### DIFF
--- a/packages/infra/prisma/seeders.ts
+++ b/packages/infra/prisma/seeders.ts
@@ -1115,6 +1115,7 @@ La compatibilidad retroactiva fue el principal driver de diseño: la nueva UI de
       featured: false,
       status: 'PUBLISHED' as const,
       weight: 50,
+      liveUrl: 'https://www.galaxies.com.br/',
       periodStart: new Date('2023-10-01'),
       periodEnd: new Date('2023-12-31'),
       skillIds: [ID.skills.typescript, ID.skills.react, ID.skills.graphql],
@@ -1370,6 +1371,7 @@ El storefront y el admin de merchants viven en un único monorepo con npm worksp
       featured: false,
       status: 'PUBLISHED' as const,
       weight: 70,
+      liveUrl: 'https://apps.shopify.com/buyr',
       periodStart: new Date('2024-10-01'),
       periodEnd: new Date('2025-02-28'),
       skillIds: [
@@ -1534,6 +1536,7 @@ CSS Modules con alcance via Vite aisló los estilos del widget de cualquier tema
       featured: false,
       status: 'PUBLISHED' as const,
       weight: 60,
+      liveUrl: 'https://www.noteefy.com/products/ai-pro-shop-assistant',
       periodStart: new Date('2025-01-01'),
       periodEnd: new Date('2025-03-31'),
       skillIds: [ID.skills.react, ID.skills.vite, ID.skills.typescript],


### PR DESCRIPTION
## Summary
- Added `liveUrl` for the three projects without a public repository (closed-source): `buyr-shopify-app`, `ai-golf-assistant`, `galaxies-survey-builder`
- `buyr-shopify-app` → Shopify App Store listing, already linked in the project's own content
- `ai-golf-assistant` → Noteefy product page, already linked in the project's own content
- `galaxies-survey-builder` → Galaxies landing page (`https://www.galaxies.com.br/`), confirmed directly by the user since it's an internal backoffice tool with no public link in its content

## Test plan
- [x] `pnpm run seed` re-applied against dev DB, verified all 4 non-open-source projects now have `liveUrl`
- [x] `pnpm run types:ci` clean
- [x] `pnpm build` (pre-push hook) confirmed local build only touches `.env.local` (dev), not production