### PR TITLE
fix(site): add security headers and complete Open Graph metadata

### DIFF
--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -1,8 +1,17 @@
 import createNextIntlPlugin from 'next-intl/plugin';
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://cdn.jsdelivr.net",
+  [
+    "script-src 'self' 'unsafe-inline'",
+    // React dev mode uses eval() for debugging; never used in production builds.
+    !isProduction && "'unsafe-eval'",
+    'https://www.googletagmanager.com https://cdn.jsdelivr.net',
+  ]
+    .filter(Boolean)
+    .join(' '),
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: https:",
   "font-src 'self' data:",

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -1,7 +1,27 @@
 import createNextIntlPlugin from 'next-intl/plugin';
 
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://cdn.jsdelivr.net",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://api.iconify.design https://api.unisvg.com https://api.simplesvg.com",
+  "frame-ancestors 'none'",
+].join('; ');
+
+const SECURITY_HEADERS = [
+  { key: 'Content-Security-Policy', value: CONTENT_SECURITY_POLICY },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return [{ source: '/(.*)', headers: SECURITY_HEADERS }];
+  },
   env: {
     NEXT_PUBLIC_CONTACT_EMAIL: process.env.NEXT_PUBLIC_CONTACT_EMAIL,
     NEXT_PUBLIC_CONTACT_NUMBER: process.env.NEXT_PUBLIC_CONTACT_NUMBER,

--- a/apps/site/src/app/[locale]/about/page.tsx
+++ b/apps/site/src/app/[locale]/about/page.tsx
@@ -7,6 +7,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { buildOgImageUrl } from '~/lib/og';
 import { buildAlternates } from '~/lib/seo/alternates';
+import { buildOpenGraph } from '~/lib/seo/openGraph';
 import { getServerContainer } from '~/lib/server/container';
 import { BioSection } from '~features/about/BioSection';
 import { CurriculumCTA } from '~features/about/CurriculumCTA';
@@ -45,9 +46,9 @@ export async function generateMetadata({
     description: bio,
     alternates: buildAlternates('/about', locale),
     openGraph: {
+      ...buildOpenGraph(locale, '/about'),
       title,
       description: bio,
-      siteName: 'Wallace Ferreira',
       images: [
         {
           url: buildOgImageUrl({

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -13,6 +13,7 @@ import { Inter } from 'next/font/google';
 
 import { env } from '~/config/env';
 import { buildAlternates } from '~/lib/seo/alternates';
+import { buildOpenGraph } from '~/lib/seo/openGraph';
 import { buildPersonJsonLd } from '~/lib/seo/structuredData';
 import { getServerContainer } from '~/lib/server/container';
 import { AppLayout, JsonLd } from '~components';
@@ -38,8 +39,7 @@ export async function generateMetadata({
     },
     description: t('Layout.description'),
     openGraph: {
-      type: 'website',
-      siteName: 'Wallace Ferreira',
+      ...buildOpenGraph(locale as Locale, ''),
       images: [
         {
           url: '/og',

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -6,6 +6,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { buildOgImageUrl } from '~/lib/og';
 import { buildAlternates } from '~/lib/seo/alternates';
+import { buildOpenGraph } from '~/lib/seo/openGraph';
 import { getServerContainer } from '~/lib/server/container';
 import { HeroSection } from '~features/home/HeroSection';
 import { ProjectsSection } from '~features/home/ProjectsSection';
@@ -43,9 +44,9 @@ export async function generateMetadata({
     description: headline,
     alternates: buildAlternates('', locale),
     openGraph: {
+      ...buildOpenGraph(locale, ''),
       title: name,
       description: headline,
-      siteName: 'Wallace Ferreira',
       images: [
         {
           url: buildOgImageUrl({

--- a/apps/site/src/app/[locale]/projects/[slug]/page.tsx
+++ b/apps/site/src/app/[locale]/projects/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { notFound } from 'next/navigation';
 
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { buildAlternates } from '~/lib/seo/alternates';
+import { buildOpenGraph } from '~/lib/seo/openGraph';
 import { buildProjectJsonLd } from '~/lib/seo/structuredData';
 import { getServerContainer } from '~/lib/server/container';
 import { JsonLd } from '~components';
@@ -50,9 +51,9 @@ export async function generateMetadata({
     description: caption,
     alternates: buildAlternates(`/projects/${slug}`, locale as Locale),
     openGraph: {
+      ...buildOpenGraph(locale as Locale, `/projects/${slug}`, 'article'),
       title,
       description: caption,
-      siteName: 'Wallace Ferreira',
       images: [{ url: coverImage.url, alt: coverImage.alt }],
     },
   };

--- a/apps/site/src/app/[locale]/projects/page.tsx
+++ b/apps/site/src/app/[locale]/projects/page.tsx
@@ -6,6 +6,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { DEFAULT_LOCALE } from '~/i18n/routing';
 import { buildOgImageUrl } from '~/lib/og';
 import { buildAlternates } from '~/lib/seo/alternates';
+import { buildOpenGraph } from '~/lib/seo/openGraph';
 import { getServerContainer } from '~/lib/server/container';
 import { HeroSection } from '~features/projects/HeroSection';
 import { ProjectsSection } from '~features/projects/ProjectsSection';
@@ -33,9 +34,9 @@ export async function generateMetadata({
     description,
     alternates: buildAlternates('/projects', locale),
     openGraph: {
+      ...buildOpenGraph(locale, '/projects'),
       title,
       description,
-      siteName: 'Wallace Ferreira',
       images: [
         {
           url: buildOgImageUrl({

--- a/apps/site/src/lib/seo/openGraph.ts
+++ b/apps/site/src/lib/seo/openGraph.ts
@@ -1,0 +1,31 @@
+import type { Locale } from '@repo/core/shared';
+
+import { env } from '~/config/env';
+
+import type { Pathname } from './types';
+
+interface BaseOpenGraph {
+  type: 'website' | 'article';
+  url: string;
+  locale: Locale;
+  siteName: string;
+}
+
+/**
+ * Base Open Graph fields shared by every page. Next.js does not deep-merge
+ * `openGraph` between layout and page metadata — a page-level `openGraph`
+ * fully replaces the layout's, so `type`/`url`/`locale` must be re-applied
+ * on every page rather than declared once in the root layout.
+ */
+export function buildOpenGraph(
+  locale: Locale,
+  pathname: Pathname,
+  type: 'website' | 'article' = 'website',
+): BaseOpenGraph {
+  return {
+    type,
+    url: `${env.siteUrl}/${locale}${pathname}`,
+    locale,
+    siteName: 'Wallace Ferreira',
+  };
+}

--- a/apps/site/tests/config/security-headers.test.ts
+++ b/apps/site/tests/config/security-headers.test.ts
@@ -34,4 +34,27 @@ describe('security headers', () => {
     expect(csp).toContain('https://cdn.jsdelivr.net');
     expect(csp).toContain('https://api.iconify.design');
   });
+
+  it('should only allow unsafe-eval outside production, since React dev mode requires it but production never uses eval()', async () => {
+    const originalEnv = process.env.NODE_ENV;
+
+    vi.resetModules();
+    vi.stubEnv('NODE_ENV', 'development');
+    const { default: devConfig } = await import('../../next.config.mjs');
+    const devCsp = (await devConfig.headers?.())
+      ?.find((r) => r.source === '/(.*)')
+      ?.headers.find((h) => h.key === 'Content-Security-Policy')?.value;
+
+    vi.resetModules();
+    vi.stubEnv('NODE_ENV', 'production');
+    const { default: prodConfig } = await import('../../next.config.mjs');
+    const prodCsp = (await prodConfig.headers?.())
+      ?.find((r) => r.source === '/(.*)')
+      ?.headers.find((h) => h.key === 'Content-Security-Policy')?.value;
+
+    expect(devCsp).toContain("'unsafe-eval'");
+    expect(prodCsp).not.toContain("'unsafe-eval'");
+
+    vi.stubEnv('NODE_ENV', originalEnv ?? 'test');
+  });
 });

--- a/apps/site/tests/config/security-headers.test.ts
+++ b/apps/site/tests/config/security-headers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import nextConfig from '../../next.config.mjs';
+
+describe('security headers', () => {
+  it('should apply CSP, X-Frame-Options, X-Content-Type-Options and Referrer-Policy to every route', async () => {
+    const rules = await nextConfig.headers?.();
+    const rule = rules?.find((r) => r.source === '/(.*)');
+    const keys = rule?.headers.map((h) => h.key);
+
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        'Content-Security-Policy',
+        'X-Frame-Options',
+        'X-Content-Type-Options',
+        'Referrer-Policy',
+      ]),
+    );
+  });
+
+  it('should deny framing and allow known third-party script/connect origins in the CSP', async () => {
+    const rules = await nextConfig.headers?.();
+    const rule = rules?.find((r) => r.source === '/(.*)');
+    const csp = rule?.headers.find(
+      (h) => h.key === 'Content-Security-Policy',
+    )?.value;
+    const frameOptions = rule?.headers.find(
+      (h) => h.key === 'X-Frame-Options',
+    )?.value;
+
+    expect(frameOptions).toBe('DENY');
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain('https://www.googletagmanager.com');
+    expect(csp).toContain('https://cdn.jsdelivr.net');
+    expect(csp).toContain('https://api.iconify.design');
+  });
+});

--- a/apps/site/tests/lib/seo/openGraph.test.ts
+++ b/apps/site/tests/lib/seo/openGraph.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { env } from '../../../src/config/env';
+import { buildOpenGraph } from '../../../src/lib/seo/openGraph';
+
+const SITE_URL = env.siteUrl;
+
+describe('buildOpenGraph', () => {
+  it('should default to type website and build the locale-prefixed url', () => {
+    const result = buildOpenGraph('pt-BR', '/about');
+
+    expect(result).toEqual({
+      type: 'website',
+      url: `${SITE_URL}/pt-BR/about`,
+      locale: 'pt-BR',
+      siteName: 'Wallace Ferreira',
+    });
+  });
+
+  it('should build the root url when pathname is empty (home page)', () => {
+    const result = buildOpenGraph('en-US', '');
+
+    expect(result.url).toBe(`${SITE_URL}/en-US`);
+  });
+
+  it('should use type article when explicitly requested for project detail pages', () => {
+    const result = buildOpenGraph('es', '/projects/my-project', 'article');
+
+    expect(result.type).toBe('article');
+    expect(result.url).toBe(`${SITE_URL}/es/projects/my-project`);
+  });
+});


### PR DESCRIPTION
## Summary
- SiteChecker.pro flagged wallace-ferreira.dev with 46 criticals / 161 warnings. Investigated the "Security" (4 issues) and "Open Graph tags incomplete" / "Twitter card incomplete" (27 pages each) categories.
- Added CSP, `X-Frame-Options`, `X-Content-Type-Options` and `Referrer-Policy` via `next.config.mjs` `headers()`. This is unrelated to the earlier `next/headers()` runtime patch (task 5 / commit 1f2bdde) — that one was a request-time API forcing routes out of ISR; this one is a static build-time config that only injects response headers and does not affect prerendering.
- Fixed a real bug: every page's `openGraph` object was fully replacing the root layout's `openGraph` (Next.js doesn't deep-merge that key between layout and page metadata), silently dropping `og:type`/`og:url` on all 27 pages. Added `buildOpenGraph()` (same pattern as the existing `buildAlternates()`) and applied it on the layout + all 4 page-level `generateMetadata` functions.

## Verification
- `next build` before/after: `/[locale]`, `/about`, `/projects`, `/projects/[slug]`, `/feed.xml` all remain `●` (SSG) — no regression to Dynamic rendering.
- Ran a production build (`next start`) and drove it with Playwright (webkit) across every locale and all 6 project detail pages, asserting zero console errors / CSP violations. This caught two real breakages before merge and the CSP was adjusted accordingly:
  - `@iconify/react` fetching icon data from `api.iconify.design` / `api.unisvg.com` / `api.simplesvg.com` (added to `connect-src`)
  - Mermaid.js loaded from `cdn.jsdelivr.net` in project content (added to `script-src`)
- Confirmed via `curl` that `og:type` (`website` / `article`) and `og:url` now render correctly on the home page and a project detail page.
- `pnpm test` (223 tests, +5 new), `pnpm types`, `pnpm lint:check` all clean.

## Test plan
- [x] `pnpm test` passes
- [x] `pnpm types` passes
- [x] `pnpm build` — all locale routes remain SSG
- [x] Playwright smoke across all pages/locales with zero CSP/console violations
- [ ] Re-run SiteChecker audit after deploy to confirm Security + Open Graph issues clear