### PR TITLE
fix(site,seo): remove duplicate headings flagged by SiteChecker audit

### DIFF
--- a/apps/site/messages/en-US.json
+++ b/apps/site/messages/en-US.json
@@ -86,7 +86,8 @@
     "hero_caption": "Frontend Engineer · React · Next.js · TypeScript",
     "hero_image_alt": "Professional Picture 2 of Wallace Ferreira",
     "bio_title": "About me",
-    "values_title": "My professional values"
+    "values_title": "My professional values",
+    "experience_title": "Experience"
   },
   "CurriculumCTA": {
     "description": "Access my resume to discover exclusive details about my projects, achievements and technical skills.",

--- a/apps/site/messages/es.json
+++ b/apps/site/messages/es.json
@@ -86,7 +86,8 @@
     "hero_caption": "Ingeniero Front-end · React · Next.js · TypeScript",
     "hero_image_alt": "Foto profesional 2 de Wallace Ferreira",
     "bio_title": "Sobre mí",
-    "values_title": "Mis valores profesionales"
+    "values_title": "Mis valores profesionales",
+    "experience_title": "Experiencia"
   },
   "CurriculumCTA": {
     "description": "Accede a mi currículum para descubrir detalles exclusivos sobre mis proyectos, logros y habilidades técnicas.",

--- a/apps/site/messages/pt-BR.json
+++ b/apps/site/messages/pt-BR.json
@@ -86,7 +86,8 @@
     "hero_caption": "Engenheiro Front-end · React · Next.js · TypeScript",
     "hero_image_alt": "Foto profissional 2 de Wallace Ferreira",
     "bio_title": "Sobre mim",
-    "values_title": "Meus valores profissionais"
+    "values_title": "Meus valores profissionais",
+    "experience_title": "Experiência"
   },
   "CurriculumCTA": {
     "description": "Acesse meu currículo para descobrir detalhes exclusivos sobre meus projetos, conquistas e habilidades técnicas.",

--- a/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
@@ -85,7 +85,7 @@ export const ExperienceCard: FC<IExperienceCardProps> = ({
       )}
 
       <div className="flex min-w-0 flex-1 flex-col gap-y-2">
-        <h2 className="text-2xl font-bold text-content-primary">{position}</h2>
+        <h3 className="text-2xl font-bold text-content-primary">{position}</h3>
 
         <div className="flex flex-col">
           <span className="text-base font-bold uppercase text-content-disabled">

--- a/apps/site/src/features/about/ExperiencesSection/ExperiencesSection.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperiencesSection.tsx
@@ -1,6 +1,7 @@
 import { GetExperiences } from '@repo/application/portfolio';
 import { type Locale } from '@repo/core/shared';
 import classNames from 'classnames';
+import { getTranslations } from 'next-intl/server';
 
 import { getServerContainer } from '~/lib/server/container';
 
@@ -8,31 +9,40 @@ import { ExperienceCard, IExperienceCardProps } from './ExperienceCard';
 
 export async function ExperiencesSection({ locale }: { locale: Locale }) {
   const { experienceRepository, skillRepository } = getServerContainer();
-  const experiencesResult = await new GetExperiences(
-    experienceRepository,
-    skillRepository,
-  ).execute({ locale });
+  const [t, experiencesResult] = await Promise.all([
+    getTranslations({ locale, namespace: 'About' }),
+    new GetExperiences(experienceRepository, skillRepository).execute({
+      locale,
+    }),
+  ]);
 
   const experiences: IExperienceCardProps[] = experiencesResult.isRight()
     ? experiencesResult.value
     : [];
 
+  if (experiences.length === 0) return null;
+
   return (
-    <ul className="flex flex-col">
-      {experiences.map((experience, i) => (
-        <li
-          key={experience.id}
-          className={classNames(
-            'border-b border-border-default last:border-b-0 py-6',
-            {
-              'pt-0': i === 0,
-              'pb-0': i === experiences.length - 1,
-            },
-          )}
-        >
-          <ExperienceCard {...experience} />
-        </li>
-      ))}
-    </ul>
+    <section className="mt-10 flex flex-col gap-y-4 xl:mt-16 2xl:mt-20">
+      <h2 className="text-left text-[32px] font-bold text-content-primary">
+        {t('experience_title')}
+      </h2>
+      <ul className="flex flex-col">
+        {experiences.map((experience, i) => (
+          <li
+            key={experience.id}
+            className={classNames(
+              'border-b border-border-default last:border-b-0 py-6',
+              {
+                'pt-0': i === 0,
+                'pb-0': i === experiences.length - 1,
+              },
+            )}
+          >
+            <ExperienceCard {...experience} />
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/apps/site/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
+++ b/apps/site/tests/components/View/ExperienceCard/ExperienceCard.test.tsx
@@ -123,10 +123,10 @@ const defaultProps = {
 };
 
 describe('ExperienceCard', () => {
-  it('should render position as h2', () => {
+  it('should render position as h3', () => {
     render(<ExperienceCard {...defaultProps} />);
     expect(
-      screen.getByRole('heading', { level: 2, name: 'Senior Developer' }),
+      screen.getByRole('heading', { level: 3, name: 'Senior Developer' }),
     ).toBeInTheDocument();
   });
 

--- a/apps/site/tests/features/about/ExperiencesSection.test.tsx
+++ b/apps/site/tests/features/about/ExperiencesSection.test.tsx
@@ -5,6 +5,9 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => `t.${key}`),
+}));
 
 vi.mock('@repo/ui/View', () => ({
   Divider: () => <hr />,
@@ -69,6 +72,30 @@ beforeEach(() => {
 });
 
 describe('about/ExperiencesSection', () => {
+  it('should render section title from i18n', async () => {
+    mockExecute.mockResolvedValue(right(EXPERIENCES));
+
+    const { ExperiencesSection } = await import(
+      '~features/about/ExperiencesSection'
+    );
+    render(await ExperiencesSection({ locale: 'en-US' }));
+
+    expect(screen.getByText('t.experience_title')).toBeInTheDocument();
+  });
+
+  it('should not render the section when there are no experiences', async () => {
+    mockExecute.mockResolvedValue(right([]));
+
+    const { ExperiencesSection } = await import(
+      '~features/about/ExperiencesSection'
+    );
+    const { container } = render(
+      (await ExperiencesSection({ locale: 'en-US' })) ?? <></>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('should render experience cards from use case response', async () => {
     mockExecute.mockResolvedValue(right(EXPERIENCES));
 

--- a/packages/infra/prisma/seeders.ts
+++ b/packages/infra/prisma/seeders.ts
@@ -1428,7 +1428,7 @@ Delivery had a ==fixed deadline from day one==. Before implementation could star
 
 Integration against Noteefy's own backend, which manages the AI conversation engine and connects to tee sheet systems, added coordination overhead across time zones throughout the sprint.
 
-## AI Pro Shop Assistant
+## The Build
 
 Built the complete widget using **React** and **Vite**, with **Material UI** providing the component system for the chat interface and UI elements.
 
@@ -1468,7 +1468,7 @@ A entrega tinha ==prazo fixo desde o primeiro dia==. Antes de iniciar a implemen
 
 A integração com o backend próprio da Noteefy, que gerencia o motor de conversação com IA e conecta com os sistemas de tee sheet, adicionou overhead de coordenação entre fusos horários ao longo do sprint.
 
-## AI Pro Shop Assistant
+## A Construção
 
 Construí o widget completo com **React** e **Vite**, usando **Material UI** como sistema de componentes para a interface de chat e os elementos de UI.
 
@@ -1508,7 +1508,7 @@ La entrega tenía ==plazo fijo desde el primer día==. Antes de iniciar la imple
 
 La integración contra el backend propio de Noteefy, que gestiona el motor de conversación con IA y conecta con los sistemas de tee sheet, añadió overhead de coordinación entre zonas horarias a lo largo del sprint.
 
-## AI Pro Shop Assistant
+## La Construcción
 
 Construí el widget completo con **React** y **Vite**, usando **Material UI** como sistema de componentes para la interfaz de chat y los elementos de UI.
 


### PR DESCRIPTION
## Summary
- `ExperiencesSection` now renders a proper section `h2` ("Experience"/"Experiência"/"Experiencia"), demoting each `ExperienceCard` position to `h3` — previously repeated job titles (e.g. "Frontend Software Engineer" held at multiple companies) were the only `h2`s in that area, and SiteChecker flagged them as duplicate headings.
- The Noteefy/AI Pro Shop Assistant project content had a body heading (`## AI Pro Shop Assistant`) that duplicated the page's `h1` verbatim; renamed to "The Build" (and localized equivalents) to match the existing "The Constraints" section naming pattern.
- Production DB content updated via `pnpm --filter @repo/infra db:seed` against `.env.production.local` (upsert by slug — no other data touched); `seeders.ts` is the source of truth going forward.

Not addressed (flagged as non-issues): SiteChecker's "title duplicates" (15 pages) is a false positive — project titles are proper nouns intentionally identical across locales, and `hreflang`/`alternates` are already correctly configured so Google understands these as translations, not real duplicates. "Page has 0 impressions" will resolve organically as GSC accumulates data for the recently-added pages.

## Test plan
- [x] `pnpm test` — 231/231 passing (updated `ExperienceCard`/`ExperiencesSection` tests for the new heading structure)
- [x] `pnpm --filter site types` / `pnpm --filter @repo/infra types` — clean
- [x] `pnpm build` (pre-push hook) — still fully SSG, no rendering-strategy regression
- [x] Verified live in production via curl: `/about` and `/projects/ai-golf-assistant` heading structure across en-US/pt-BR/es

Refs #915 (SEO audit follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)