### PR TITLE
feat(ui,site): responsive heading typography scale

### DIFF
--- a/apps/site/src/features/about/BioSection/index.tsx
+++ b/apps/site/src/features/about/BioSection/index.tsx
@@ -17,9 +17,7 @@ export async function BioSection({ locale }: { locale: Locale }) {
 
   return (
     <section className="mt-10 flex flex-col gap-y-4 xl:mt-16 2xl:mt-20">
-      <h2 className="text-left text-[32px] font-bold text-content-primary">
-        {t('bio_title')}
-      </h2>
+      <h2 className="text-heading-h4 text-left">{t('bio_title')}</h2>
       <TextRich content={bio} className="text-base text-content-disabled" />
     </section>
   );

--- a/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperienceCard.tsx
@@ -85,7 +85,7 @@ export const ExperienceCard: FC<IExperienceCardProps> = ({
       )}
 
       <div className="flex min-w-0 flex-1 flex-col gap-y-2">
-        <h3 className="text-2xl font-bold text-content-primary">{position}</h3>
+        <h3 className="text-heading-h5">{position}</h3>
 
         <div className="flex flex-col">
           <span className="text-base font-bold uppercase text-content-disabled">

--- a/apps/site/src/features/about/ExperiencesSection/ExperiencesSection.tsx
+++ b/apps/site/src/features/about/ExperiencesSection/ExperiencesSection.tsx
@@ -24,9 +24,7 @@ export async function ExperiencesSection({ locale }: { locale: Locale }) {
 
   return (
     <section className="mt-10 flex flex-col gap-y-4 xl:mt-16 2xl:mt-20">
-      <h2 className="text-left text-[32px] font-bold text-content-primary">
-        {t('experience_title')}
-      </h2>
+      <h2 className="text-heading-h4 text-left">{t('experience_title')}</h2>
       <ul className="flex flex-col">
         {experiences.map((experience, i) => (
           <li

--- a/apps/site/src/features/about/HeroSection/index.tsx
+++ b/apps/site/src/features/about/HeroSection/index.tsx
@@ -20,7 +20,6 @@ export async function HeroSection({ locale }: { locale: Locale }) {
       title={profile?.name ?? t('hero_title')}
       caption={profile?.headline ?? t('hero_caption')}
       alt={t('hero_image_alt')}
-      titleAs="h1"
       titleClassName="text-heading-h1"
       textColumnClassName="lg:w-1/2"
       imageClassName="object-contain"

--- a/apps/site/src/features/about/HeroSection/index.tsx
+++ b/apps/site/src/features/about/HeroSection/index.tsx
@@ -20,8 +20,8 @@ export async function HeroSection({ locale }: { locale: Locale }) {
       title={profile?.name ?? t('hero_title')}
       caption={profile?.headline ?? t('hero_caption')}
       alt={t('hero_image_alt')}
-      titleSize="xl"
       titleAs="h1"
+      titleClassName="text-heading-h1"
       textColumnClassName="lg:w-1/2"
       imageClassName="object-contain"
       className="shadow-drop-md"

--- a/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
+++ b/apps/site/src/features/about/ValuesSection/ValuesSection.tsx
@@ -22,9 +22,7 @@ export async function ValuesSection({ locale }: { locale: Locale }) {
 
   return (
     <section className="mt-10 flex flex-col gap-y-4 xl:mt-16 2xl:mt-20">
-      <h2 className="text-left text-[32px] font-bold text-content-primary">
-        {t('values_title')}
-      </h2>
+      <h2 className="text-heading-h4 text-left">{t('values_title')}</h2>
       <ul className="grid grid-cols-2 items-stretch gap-4 sm:grid-cols-3 lg:grid-cols-4">
         {professionalValues.map((professionalValue) => (
           <li key={professionalValue.id}>

--- a/apps/site/src/features/contact/ContactForm/index.tsx
+++ b/apps/site/src/features/contact/ContactForm/index.tsx
@@ -37,9 +37,7 @@ export const ContactForm: FC = () => {
   if (submitted) {
     return (
       <div className="w-full">
-        <h2 className="mb-6 text-2xl font-bold text-content-primary">
-          {tForm('title')}
-        </h2>
+        <h2 className="text-heading-h5 mb-6">{tForm('title')}</h2>
         <p className="text-accent">{tForm('success')}</p>
       </div>
     );
@@ -47,10 +45,7 @@ export const ContactForm: FC = () => {
 
   return (
     <>
-      <h2
-        id="contact-form-title"
-        className="mb-6 text-2xl font-bold text-content-primary"
-      >
+      <h2 id="contact-form-title" className="text-heading-h5 mb-6">
         {tForm('title')}
       </h2>
 

--- a/apps/site/src/features/contact/ContactInfo/index.tsx
+++ b/apps/site/src/features/contact/ContactInfo/index.tsx
@@ -19,7 +19,7 @@ export const ContactInfo: FC = () => {
 
   return (
     <section className="flex flex-col gap-y-6 xl:w-[326px]">
-      <h2 className="text-2xl font-bold text-content-primary">{t('title')}</h2>
+      <h2 className="text-heading-h5">{t('title')}</h2>
 
       <address className="flex flex-col gap-y-6 not-italic">
         <div className="flex flex-col gap-y-1">

--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -42,7 +42,6 @@ export async function HeroSection({ locale, profile }: HeroSectionProps) {
         title={profile?.name ?? t('hero_title')}
         caption={profile?.headline ?? t('hero_caption')}
         alt={profile?.photo.alt ?? t('hero_image_alt')}
-        titleSize="lg"
         titleAs="h1"
         textColumnClassName="lg:w-1/2"
         imageClassName="object-contain 2xl:object-cover"

--- a/apps/site/src/features/home/HeroSection/index.tsx
+++ b/apps/site/src/features/home/HeroSection/index.tsx
@@ -42,7 +42,6 @@ export async function HeroSection({ locale, profile }: HeroSectionProps) {
         title={profile?.name ?? t('hero_title')}
         caption={profile?.headline ?? t('hero_caption')}
         alt={profile?.photo.alt ?? t('hero_image_alt')}
-        titleAs="h1"
         textColumnClassName="lg:w-1/2"
         imageClassName="object-contain 2xl:object-cover"
         className="shadow-drop-md"

--- a/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
+++ b/apps/site/src/features/home/ProjectsSection/HomeProjectsSection.tsx
@@ -18,7 +18,7 @@ export async function ProjectsSection({
 
   return (
     <>
-      <h2 className="my-6 !text-xl text-content-primary lg:mx-auto lg:my-8 lg:block lg:w-full lg:max-w-237.5 lg:!text-[32px]">
+      <h2 className="text-heading-h4 my-6 lg:mx-auto lg:my-8 lg:block lg:w-full lg:max-w-237.5">
         {t('projects_title')}
       </h2>
       <ProjectList projects={projects} compact className="pb-6" />

--- a/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
+++ b/apps/site/src/features/home/ProjectsSection/ProjectCard.tsx
@@ -89,10 +89,8 @@ export const ProjectCard: FC<IProjectCardProps> = ({
             </span>
           )}
 
-          <div className="min-h-16 flex flex-wrap items-center gap-x-2 gap-y-2">
-            <h3 className="line-clamp-2 text-2xl font-bold text-content-primary">
-              {title}
-            </h3>
+          <div className="flex min-h-16 flex-wrap items-center gap-2">
+            <h3 className="text-heading-h5 line-clamp-2">{title}</h3>
             {repositoryUrl && <OpenSourceBadge repositoryUrl={repositoryUrl} />}
           </div>
 

--- a/apps/site/src/features/projects/HeroSection/index.tsx
+++ b/apps/site/src/features/projects/HeroSection/index.tsx
@@ -13,7 +13,6 @@ export async function HeroSection({ locale }: { locale: Locale }) {
       title={t('hero_title')}
       caption={t('hero_caption')}
       alt={t('hero_image_alt')}
-      titleAs="h1"
       imageClassName="object-contain p-6 lg:py-8"
       className="shadow-drop-sm"
       textColumnClassName="md:w-1/2"

--- a/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
+++ b/apps/site/src/features/projects/ProjectDetail/ProjectDetail.tsx
@@ -86,9 +86,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
 
           <header className="flex flex-col gap-y-3">
             <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-              <h1 className="text-[40px] font-bold text-content-primary">
-                {title}
-              </h1>
+              <h1 className="text-heading-h2">{title}</h1>
               {repositoryUrl && (
                 <OpenSourceBadge repositoryUrl={repositoryUrl} />
               )}
@@ -129,9 +127,7 @@ export const ProjectDetail: FC<IProjectDetailProps> = ({
 
         {relatedProjects.length > 0 && (
           <section className="flex flex-col gap-y-6">
-            <h2 className="text-[32px] font-bold text-content-primary">
-              {t('related_title')}
-            </h2>
+            <h2 className="text-heading-h4">{t('related_title')}</h2>
             <ProjectList projects={relatedProjects} />
           </section>
         )}

--- a/apps/site/src/features/shared/HeroBanner/index.tsx
+++ b/apps/site/src/features/shared/HeroBanner/index.tsx
@@ -9,8 +9,8 @@ export interface IHeroBannerProps {
   title: string;
   caption: string;
   alt: string;
-  titleSize?: 'lg' | 'xl';
   titleAs?: 'h1' | 'h2';
+  titleClassName?: string;
   className?: string;
   imageClassName?: string;
   textColumnClassName?: string;
@@ -21,8 +21,8 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
   title,
   caption,
   alt,
-  titleSize = 'lg',
   titleAs: TitleTag = 'h2',
+  titleClassName = 'text-heading-h2',
   className = '',
   imageClassName = '',
   textColumnClassName = '',
@@ -51,12 +51,7 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
           textColumnClassName,
         )}
       >
-        <TitleTag
-          className={classNames('mb-3 line-clamp-2', {
-            'text-heading-h2': titleSize === 'lg',
-            'text-heading-h1': titleSize === 'xl',
-          })}
-        >
+        <TitleTag className={classNames('mb-3 line-clamp-2', titleClassName)}>
           {title}
         </TitleTag>
         <p className="text-sm text-content-secondary md:text-base lg:text-lg 2xl:text-2xl 2xl:leading-[33.6px]">

--- a/apps/site/src/features/shared/HeroBanner/index.tsx
+++ b/apps/site/src/features/shared/HeroBanner/index.tsx
@@ -9,7 +9,6 @@ export interface IHeroBannerProps {
   title: string;
   caption: string;
   alt: string;
-  titleAs?: 'h1' | 'h2';
   titleClassName?: string;
   className?: string;
   imageClassName?: string;
@@ -21,7 +20,6 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
   title,
   caption,
   alt,
-  titleAs: TitleTag = 'h2',
   titleClassName = 'text-heading-h2',
   className = '',
   imageClassName = '',
@@ -51,9 +49,9 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
           textColumnClassName,
         )}
       >
-        <TitleTag className={classNames('mb-3 line-clamp-2', titleClassName)}>
+        <h1 className={classNames('mb-3 line-clamp-2', titleClassName)}>
           {title}
-        </TitleTag>
+        </h1>
         <p className="text-sm text-content-secondary md:text-base lg:text-lg 2xl:text-2xl 2xl:leading-[33.6px]">
           {caption}
         </p>

--- a/apps/site/src/features/shared/HeroBanner/index.tsx
+++ b/apps/site/src/features/shared/HeroBanner/index.tsx
@@ -52,15 +52,10 @@ export const HeroBanner: FC<IHeroBannerProps> = ({
         )}
       >
         <TitleTag
-          className={classNames(
-            'text-content-primary font-bold mb-3 line-clamp-2',
-            {
-              'text-3xl leading-[42px] lg:text-[32px] lg:leading-[44.8px] 2xl:text-[40px] 2xl:leading-[56px]':
-                titleSize === 'lg',
-              'text-3xl leading-[42px] lg:text-4xl lg:leading-[50.4px] 2xl:text-5xl 2xl:leading-[67.2px]':
-                titleSize === 'xl',
-            },
-          )}
+          className={classNames('mb-3 line-clamp-2', {
+            'text-heading-h2': titleSize === 'lg',
+            'text-heading-h1': titleSize === 'xl',
+          })}
         >
           {title}
         </TitleTag>

--- a/apps/site/tests/features/home/HeroSection.test.tsx
+++ b/apps/site/tests/features/home/HeroSection.test.tsx
@@ -14,16 +14,8 @@ vi.mock('~assets/images/hero-landing-page.png', () => ({
 }));
 
 vi.mock('~features/shared/HeroBanner', () => ({
-  HeroBanner: ({
-    title,
-    caption,
-    titleAs,
-  }: {
-    title: string;
-    caption: string;
-    titleAs?: string;
-  }) => (
-    <div data-testid="hero-banner" data-title-as={titleAs}>
+  HeroBanner: ({ title, caption }: { title: string; caption: string }) => (
+    <div data-testid="hero-banner">
       <span data-testid="hero-title">{title}</span>
       <span data-testid="hero-caption">{caption}</span>
     </div>
@@ -86,12 +78,5 @@ describe('home/HeroSection', () => {
     render(await HeroSection({ locale: 'en-US', profile: null }));
 
     expect(screen.queryByTestId('stat-card')).not.toBeInTheDocument();
-  });
-
-  it('should render HeroBanner with titleAs h1', async () => {
-    const { HeroSection } = await import('~features/home/HeroSection');
-    render(await HeroSection({ locale: 'en-US', profile: PROFILE }));
-
-    expect(screen.getByTestId('hero-banner')).toHaveAttribute('data-title-as', 'h1');
   });
 });

--- a/apps/site/tests/features/projects/HeroSection.test.tsx
+++ b/apps/site/tests/features/projects/HeroSection.test.tsx
@@ -14,16 +14,8 @@ vi.mock('~assets/images/hero-projects.png', () => ({
 }));
 
 vi.mock('~features/shared/HeroBanner', () => ({
-  HeroBanner: ({
-    title,
-    caption,
-    titleAs,
-  }: {
-    title: string;
-    caption: string;
-    titleAs?: string;
-  }) => (
-    <div data-testid="hero-banner" data-title-as={titleAs}>
+  HeroBanner: ({ title, caption }: { title: string; caption: string }) => (
+    <div data-testid="hero-banner">
       <span data-testid="hero-title">{title}</span>
       <span data-testid="hero-caption">{caption}</span>
     </div>
@@ -37,12 +29,5 @@ describe('projects/HeroSection', () => {
 
     expect(screen.getByTestId('hero-title')).toHaveTextContent('t.hero_title');
     expect(screen.getByTestId('hero-caption')).toHaveTextContent('t.hero_caption');
-  });
-
-  it('should render HeroBanner with titleAs h1', async () => {
-    const { HeroSection } = await import('~features/projects/HeroSection');
-    render(await HeroSection({ locale: 'en-US' }));
-
-    expect(screen.getByTestId('hero-banner')).toHaveAttribute('data-title-as', 'h1');
   });
 });

--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -55,28 +55,6 @@
   --tw-shadow-drop-up: 0px -4px 15px 0px #0000001A;
 }
 
-@layer base {
-  h1 {
-    @apply text-5xl font-bold leading-[67.2px] tracking-[0.24px] text-content-primary;
-  }
-
-  h2 {
-    @apply text-[40px] font-bold leading-[56px] tracking-[0.2px] text-content-primary;
-  }
-
-  h3 {
-    @apply text-4xl font-bold leading-[50.4px] tracking-[0.18px] text-content-primary;
-  }
-
-  h4 {
-    @apply text-[32px] font-bold leading-[44.8px] tracking-[0.16px] text-content-primary;
-  }
-
-  h5 {
-    @apply text-2xl font-bold leading-[33.6px] tracking-[0.12px] text-content-primary;
-  }
-}
-
 @layer utilities {
   .text-heading-h1 {
     @apply text-4xl font-bold leading-[50.4px] tracking-[0.18px] text-content-primary lg:text-5xl lg:leading-[67.2px] lg:tracking-[0.24px];

--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -79,7 +79,7 @@
 
 @layer utilities {
   .text-heading-h1 {
-    @apply text-5xl font-bold leading-[67.2px] tracking-[0.24px] text-content-primary;
+    @apply text-4xl font-bold leading-[50.4px] tracking-[0.18px] text-content-primary lg:text-5xl lg:leading-[67.2px] lg:tracking-[0.24px];
   }
 
   .text-heading-h2 {

--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -78,6 +78,26 @@
 }
 
 @layer utilities {
+  .text-heading-h1 {
+    @apply text-5xl font-bold leading-[67.2px] tracking-[0.24px] text-content-primary;
+  }
+
+  .text-heading-h2 {
+    @apply text-4xl font-bold leading-[50.4px] tracking-[0.18px] text-content-primary lg:text-[40px] lg:leading-[56px] lg:tracking-[0.2px];
+  }
+
+  .text-heading-h3 {
+    @apply text-4xl font-bold leading-[50.4px] tracking-[0.18px] text-content-primary;
+  }
+
+  .text-heading-h4 {
+    @apply text-2xl font-bold leading-[33.6px] tracking-[0.12px] text-content-primary lg:text-[32px] lg:leading-[44.8px] lg:tracking-[0.16px];
+  }
+
+  .text-heading-h5 {
+    @apply text-2xl font-bold leading-[33.6px] tracking-[0.12px] text-content-primary;
+  }
+
   .text-body-xl {
     @apply text-2xl font-normal leading-[33.6px] tracking-[0.12px] text-content-primary;
   }
@@ -96,5 +116,21 @@
 
   .text-body-xs {
     @apply text-sm font-normal leading-[19.6px] tracking-[0.07px] text-content-primary;
+  }
+
+  .text-body-smallest {
+    @apply text-xs font-normal leading-[16.8px] tracking-[0.06px] text-content-primary;
+  }
+
+  .text-overline-lg {
+    @apply text-xl font-semibold uppercase tracking-widest leading-7 text-content-primary;
+  }
+
+  .text-overline-md {
+    @apply text-base font-semibold uppercase tracking-widest leading-[22.4px] text-content-primary;
+  }
+
+  .text-overline-sm {
+    @apply text-sm font-semibold uppercase tracking-widest leading-[19.6px] text-content-primary;
   }
 }

--- a/packages/ui/src/View/SectionHeader/index.tsx
+++ b/packages/ui/src/View/SectionHeader/index.tsx
@@ -30,9 +30,7 @@ export const SectionHeader: FC<ISectionHeaderProps> = ({
       )}
     >
       {overline && (
-        <span className="text-body-xs !font-semibold tracking-widest uppercase !text-content-muted">
-          {overline}
-        </span>
+        <span className="text-overline-sm !text-content-muted">{overline}</span>
       )}
       <Tag className="text-body-lg !font-bold !text-content-primary">
         {title}


### PR DESCRIPTION
## Summary
- Introduces `text-heading-h1..h5` design-system utility classes matching the Figma typography scale, replacing scattered arbitrary Tailwind values across site components.
- `text-heading-h1/h2/h4` bake in a mobile → `lg` (1024px) responsive step-down internally, so consumers only ever write one class name.
- Migrates `HeroBanner` (Home/About/Projects hero titles) off its own bespoke 3-tier responsive scale onto the shared classes, drops the now-redundant `titleSize`/`titleAs` props (title is always `h1`), and removes the dead `@layer base` h1-h5 tag styling now that every heading uses an explicit class.

## Test plan
- [x] `pnpm --filter site test` (229 tests) and `pnpm --filter admin test` (20 tests) pass
- [x] `pnpm --filter site lint` / `pnpm --filter admin lint` — no errors
- [x] Verified rendered output live in dev server: Home/Projects heroes use `text-heading-h2`, About hero uses `text-heading-h1`, compiled CSS confirms the `@media (min-width: 1024px)` step-up for each
- [x] Verified `ErrorView`/404 (intentionally left off the new scale) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)