### PR TITLE
docs: add blog MDX-in-git design spec

### DIFF
--- a/docs/superpowers/specs/2026-07-24-blog-mdx-design.md
+++ b/docs/superpowers/specs/2026-07-24-blog-mdx-design.md
@@ -25,12 +25,13 @@ pure infra swap.
   excuse to skip a translation.
 - SEO: per-post metadata, OG images, sitemap.
 - Syntax highlighting for code blocks (posts are technical write-ups).
+- Tags: stored in `meta.json`, displayed on the post as metadata/badges.
+- RSS: one feed per locale (`/blog/<locale>/rss.xml`).
 
 **Explicitly out of scope (future phases, tracked in ROADMAP.md):**
 - Backoffice/admin authoring UI backed by a database.
-- Tags/categories as a navigation/filtering feature (tags are stored in `meta.json` now, but no
-  tag index pages yet).
-- RSS feed.
+- Tag listing/index pages (e.g. `/blog/[locale]/tag/[tag]`) — tags exist as data now, but no
+  dedicated navigation/filtering pages yet.
 - Comments, newsletter, reading analytics.
 
 ## 2. Architecture
@@ -96,7 +97,16 @@ the build — never ships a broken post to production.
   `generateStaticParams` (SSG per slug × locale), dynamic `opengraph-image.tsx` (from
   `coverImage` or generated from the title), `sitemap.ts` covering all posts × locales.
 
-## 5. Cross-app routing (Vercel multi-zone)
+## 5. RSS feeds
+
+- One feed per locale: `apps/blog/src/app/[locale]/rss.xml/route.ts` (Route Handler), reachable
+  as `wallace-ferreira.dev/blog/<locale>/rss.xml`.
+- Each feed calls `ListBlogPosts` (same use case as the listing page) and renders title,
+  description, link, and `publishedAt` for that locale only — no mixing locales in one feed.
+- Feed link (`<link rel="alternate" type="application/rss+xml">`) added per locale in the blog
+  layout `<head>`, and referenced in `robots.txt`/footer for discoverability.
+
+## 6. Cross-app routing (Vercel multi-zone)
 
 - `apps/site`: `next.config.mjs` `rewrites()` sends `/blog` and `/blog/:path*` to the `apps/blog`
   Vercel deployment URL.
@@ -106,7 +116,7 @@ the build — never ships a broken post to production.
   on the primary domain, not a subdomain, to keep domain authority/link equity unified (per
   `SEO-BACKLINK-STRATEGY.md` findings on paulie.dev's backlink profile).
 
-## 6. Testing
+## 7. Testing
 
 - **`core`**: invariant tests for `BlogPost`/`Tag` (invalid slug, missing `publishedAt`, etc.) —
   Either pattern, no mocks.
@@ -114,7 +124,8 @@ the build — never ships a broken post to production.
   directory (valid post, post missing a locale file → build error, malformed frontmatter → Zod
   error).
 - **`apps/blog`**: detail page renders correct title/OG/canonical from a mocked
-  `IBlogPostRepository` (no integration with real files).
+  `IBlogPostRepository` (no integration with real files); RSS route returns valid XML with only
+  the requested locale's posts, from the same mocked repository.
 
 ## Open questions for implementation planning
 

--- a/docs/superpowers/specs/2026-07-24-blog-mdx-design.md
+++ b/docs/superpowers/specs/2026-07-24-blog-mdx-design.md
@@ -1,0 +1,123 @@
+# Blog (`apps/blog`) — MDX-in-Git Design
+
+> Status: approved design, pending implementation plan.
+> Related: [ROADMAP.md](../../ROADMAP.md), [03-BOUNDED-CONTEXTS.md](../../03-BOUNDED-CONTEXTS.md),
+> [SEO-BACKLINK-STRATEGY.md](../../SEO-BACKLINK-STRATEGY.md), [12-DESIGN-SYSTEM.md](../../12-DESIGN-SYSTEM.md).
+
+## Goal
+
+Ship a technical blog to drive SEO/backlink authority (per `SEO-BACKLINK-STRATEGY.md`), as fast
+as possible, without blocking on a backoffice/admin UI. Content is authored as MDX files
+committed to git and reviewed via PR — same workflow already used for project content.
+
+A backoffice (`apps/admin`) for authoring posts via a database-backed UI is a deliberate
+**future phase**, not part of this design. The architecture below is chosen so that phase is a
+pure infra swap.
+
+## 1. Scope
+
+**In scope now:**
+- `apps/blog`, a dedicated Next.js app, served at `wallace-ferreira.dev/blog` via Vercel
+  multi-zone rewrite from `apps/site`.
+- Content authored as MDX in git, no database.
+- Full i18n from day one: every published post ships in `en-US`, `pt-BR`, and `es` — no partial
+  translations, `en-US` is the runtime fallback only for locale-negotiation edge cases, never an
+  excuse to skip a translation.
+- SEO: per-post metadata, OG images, sitemap.
+- Syntax highlighting for code blocks (posts are technical write-ups).
+
+**Explicitly out of scope (future phases, tracked in ROADMAP.md):**
+- Backoffice/admin authoring UI backed by a database.
+- Tags/categories as a navigation/filtering feature (tags are stored in `meta.json` now, but no
+  tag index pages yet).
+- RSS feed.
+- Comments, newsletter, reading analytics.
+
+## 2. Architecture
+
+The Blog bounded context follows the same Dependency Rule as Portfolio
+(`core ← application ← infra ← apps`), even though there is no database yet. This means the
+future migration to a backoffice is an **infra swap only** — no changes to domain, use cases, or
+pages.
+
+- **`packages/core`** — `BlogPost` entity and `Tag` value object. Invariants via `Validator`
+  (kebab-case slug, `publishedAt` present, at least one `LocalizedText` for title/description).
+  Zero framework dependencies.
+- **`packages/application`** — `IBlogPostRepository` port (`findAll()`, `findBySlug(slug)`) and
+  use cases `ListBlogPosts`, `GetBlogPostBySlug`.
+- **`packages/infra`** — `FileSystemBlogPostRepository`: reads `content/posts/<slug>/*`, parses
+  frontmatter (Zod schema, edge validation per `06-VALIDATION.md`), constructs `BlogPost`
+  entities. No Prisma/Supabase involved in this phase.
+- **`apps/blog`** — Server Components call `ListBlogPosts` / `GetBlogPostBySlug` directly at
+  build time (SSG), same pattern as Portfolio.
+
+When the backoffice phase happens: implement `PrismaBlogPostRepository`, wire it in the DI
+container instead of `FileSystemBlogPostRepository`. `core`, `application`, and `apps/blog`
+pages are untouched.
+
+## 3. Content model
+
+```
+content/posts/<slug>/
+  meta.json       # shared across locales — immutable metadata
+  en-US.mdx
+  pt-BR.mdx
+  es.mdx
+  cover.png       # optional, referenced by meta.json
+```
+
+`meta.json`:
+```json
+{
+  "slug": "abstracting-gatsby-functions-as-an-api",
+  "publishedAt": "2026-08-01",
+  "tags": ["nextjs", "architecture"],
+  "coverImage": "/content/posts/<slug>/cover.png"
+}
+```
+
+Each `.mdx` file carries only the locale-specific `title`, `description` (frontmatter) and body.
+Immutable metadata (slug, date, tags) is not duplicated per locale.
+
+**Validation:** a `BlogPostFrontmatterSchema` (Zod) validates `meta.json` and every `.mdx`
+frontmatter at build time. A missing locale file, malformed frontmatter, or invalid slug fails
+the build — never ships a broken post to production.
+
+## 4. Rendering & SEO
+
+- **MDX compilation**: `next-mdx-remote/rsc` — Server Components, SSG. Not `TextRich` from
+  `@repo/ui`, which is client-side and designed for markdown coming from the database (e.g.
+  project descriptions); blog posts render server-side for performance and SEO.
+- **Syntax highlighting**: `rehype-pretty-code` (Shiki) at build time — no client JS shipped for
+  highlighting.
+- **Custom MDX components**: map to `@repo/ui` components (`Badge`, `SectionHeader`, etc.) where
+  it makes sense inside post bodies.
+- **Per-post SEO**: `generateMetadata` (title/description/canonical per locale),
+  `generateStaticParams` (SSG per slug × locale), dynamic `opengraph-image.tsx` (from
+  `coverImage` or generated from the title), `sitemap.ts` covering all posts × locales.
+
+## 5. Cross-app routing (Vercel multi-zone)
+
+- `apps/site`: `next.config.mjs` `rewrites()` sends `/blog` and `/blog/:path*` to the `apps/blog`
+  Vercel deployment URL.
+- `apps/blog`: `basePath: '/blog'`, its own `[locale]` routing via next-intl, reusing
+  `LOCALES`/`DEFAULT_LOCALE` from `@repo/core/shared`. Deployed as an independent Vercel project.
+- Final URLs: `wallace-ferreira.dev/blog`, `wallace-ferreira.dev/blog/pt-BR/<slug>`, etc. — path
+  on the primary domain, not a subdomain, to keep domain authority/link equity unified (per
+  `SEO-BACKLINK-STRATEGY.md` findings on paulie.dev's backlink profile).
+
+## 6. Testing
+
+- **`core`**: invariant tests for `BlogPost`/`Tag` (invalid slug, missing `publishedAt`, etc.) —
+  Either pattern, no mocks.
+- **`infra`**: `FileSystemBlogPostRepository` tests against a test fixture `content/posts/`
+  directory (valid post, post missing a locale file → build error, malformed frontmatter → Zod
+  error).
+- **`apps/blog`**: detail page renders correct title/OG/canonical from a mocked
+  `IBlogPostRepository` (no integration with real files).
+
+## Open questions for implementation planning
+
+- First post topic(s) and publishing cadence — not decided here, tracked separately.
+- Exact DI container wiring pattern for `apps/blog` (mirrors how `apps/site` wires Portfolio use
+  cases today — to confirm during planning).


### PR DESCRIPTION
## Summary
- Adds `docs/superpowers/specs/2026-07-24-blog-mdx-design.md`: design for `apps/blog` as a content-as-code (MDX-in-git) blog, following the Blog bounded context's Dependency Rule so a future database-backed backoffice is a pure infra swap.
- Scope: dedicated `apps/blog` app served under `/blog` via Vercel multi-zone rewrite, full i18n (en-US/pt-BR/es required per post), syntax highlighting, per-post SEO metadata/OG/sitemap, tags (as data), and per-locale RSS feeds.
- Explicitly deferred: backoffice/admin authoring UI, tag index/listing pages, comments, newsletter, reading analytics.

## Test plan
- [ ] Docs-only change; no code affected. Reviewed for internal consistency (scope vs. architecture vs. testing sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)