### PR TITLE
docs(blog): triage Loiane Groner-inspired features into MVP vs Post-MVP

### DIFF
--- a/.taskmaster/docs/prd-blog-mdx-design.md
+++ b/.taskmaster/docs/prd-blog-mdx-design.md
@@ -28,10 +28,14 @@ pure infra swap.
 - Tags: stored in `meta.json`, displayed on the post as metadata/badges.
 - RSS: one feed per locale (`/blog/<locale>/rss.xml`).
 
-**Explicitly out of scope (future phases, tracked in ROADMAP.md):**
+**Explicitly out of scope (future phases, tracked in [ROADMAP.md](../../docs/ROADMAP.md)):**
 - Backoffice/admin authoring UI backed by a database.
 - Tag listing/index pages (e.g. `/blog/[locale]/tag/[tag]`) — tags exist as data now, but no
   dedicated navigation/filtering pages yet.
+- `/archives` page (year-grouped post timeline).
+- "Recently updated" and "trending tags" sidebar widgets.
+- Sticky table of contents on post pages.
+- Reading-time estimate on post pages.
 - Comments, newsletter, reading analytics.
 
 ## 2. Architecture
@@ -112,8 +116,11 @@ the build — never ships a broken post to production.
   Vercel deployment URL.
 - `apps/blog`: `basePath: '/blog'`, its own `[locale]` routing via next-intl, reusing
   `LOCALES`/`DEFAULT_LOCALE` from `@repo/core/shared`. Deployed as an independent Vercel project.
-- Final URLs: `wallace-ferreira.dev/blog`, `wallace-ferreira.dev/blog/pt-BR/<slug>`, etc. — path
-  on the primary domain, not a subdomain, to keep domain authority/link equity unified (per
+- Post URLs embed the publication year/month (`/blog/<locale>/<yyyy>/<mm>/<slug>`), derived from
+  `BlogPost.publishedAt`. Decided in the MVP (not deferred) because changing URL structure later
+  breaks already-indexed links and SEO equity — cheap to do now, expensive to retrofit.
+- Final URLs: `wallace-ferreira.dev/blog`, `wallace-ferreira.dev/blog/pt-BR/2026/08/<slug>`, etc.
+  — path on the primary domain, not a subdomain, to keep domain authority/link equity unified (per
   `SEO-BACKLINK-STRATEGY.md` findings on paulie.dev's backlink profile).
 
 ## 7. Testing

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,6 +78,14 @@ Items required before MVP launch, using [Paul Scanlon's portfolio](https://www.p
 ## Post-MVP
 
 - [ ] **Blog** (`apps/blog`) — `BlogPost`, `Tag`, public API, listing and detail pages
+  ([design spec](../.taskmaster/docs/prd-blog-mdx-design.md)). Post-MVP items deferred from the
+  initial launch:
+  - [ ] `/archives` page — reverse-chronological listing grouped by year
+  - [ ] Tag index pages (`/blog/[locale]/tag/[tag]`)
+  - [ ] "Recently updated" and "Trending tags" sidebar widgets
+  - [ ] Sticky table of contents on post pages (heading extraction + scroll-spy)
+  - [ ] Reading-time estimate on post pages
+  - [ ] Comments, newsletter, reading analytics
 - [ ] **`IAuthenticationGateway`** — pluggable Supabase gateway, `authSubject`, `EnsureAppUserForAuthSession`
 - [ ] **Dedicated backend** — REST API in a separate repository; `apps/site` remains a pure SSG consumer
 - [ ] **Playwright E2E** — end-to-end tests for critical flows


### PR DESCRIPTION
## Summary
- Reviewed loiane.com (Chirpy Jekyll theme) for blog UX ideas, per user request.
- Locked date-based post URLs (`/blog/<locale>/<yyyy>/<mm>/<slug>`) into the MVP design spec — retrofitting URL structure later would break indexed links/SEO equity.
- Deferred everything else (archives page, tag index pages, sidebar widgets, sticky TOC, reading time) to the Blog Post-MVP backlog in `ROADMAP.md`.

## Test plan
- [x] Docs only, no code touched — `format:check`/`build` hooks passed on commit/push.
- [x] Reviewer confirms MVP/Post-MVP split matches intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)