### PR TITLE
[T-14] Define IBlogPostRepository port in packages/application

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1088,8 +1088,9 @@
         "dependencies": [
           "13"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "in-progress",
+        "subtasks": [],
+        "updatedAt": "2026-08-12T01:34:01.808Z"
       },
       {
         "id": "15",
@@ -1203,7 +1204,7 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-08-11T05:17:06.967Z",
+      "lastModified": "2026-08-12T01:34:01.808Z",
       "taskCount": 22,
       "completedCount": 13,
       "tags": [

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1088,9 +1088,9 @@
         "dependencies": [
           "13"
         ],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-08-12T01:34:01.808Z"
+        "updatedAt": "2026-08-12T01:42:39.028Z"
       },
       {
         "id": "15",
@@ -1204,9 +1204,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-08-12T01:34:01.808Z",
+      "lastModified": "2026-08-12T01:42:39.029Z",
       "taskCount": 22,
-      "completedCount": 13,
+      "completedCount": 14,
       "tags": [
         "master"
       ]

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "exports": {
     ".": { "types": "./dist/types/index.d.ts", "default": "./src/index.ts" },
+    "./blog": { "types": "./dist/types/blog/index.d.ts", "default": "./src/blog/index.ts" },
     "./identity": { "types": "./dist/types/identity/index.d.ts", "default": "./src/identity/index.ts" },
     "./portfolio": { "types": "./dist/types/portfolio/index.d.ts", "default": "./src/portfolio/index.ts" },
     "./contact": { "types": "./dist/types/contact/index.d.ts", "default": "./src/contact/index.ts" },

--- a/packages/application/src/blog/index.ts
+++ b/packages/application/src/blog/index.ts
@@ -1,0 +1,1 @@
+export * from './ports';

--- a/packages/application/src/blog/ports/IBlogPostRepository.ts
+++ b/packages/application/src/blog/ports/IBlogPostRepository.ts
@@ -1,0 +1,7 @@
+import { BlogPost } from '@repo/core/blog';
+import { Slug } from '@repo/core/shared';
+
+export interface IBlogPostRepository {
+  findAll(): Promise<BlogPost[]>;
+  findBySlug(slug: Slug): Promise<BlogPost | null>;
+}

--- a/packages/application/src/blog/ports/index.ts
+++ b/packages/application/src/blog/ports/index.ts
@@ -1,0 +1,1 @@
+export * from './IBlogPostRepository';

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,4 +1,5 @@
 export * from './shared';
+export * from './blog';
 export * from './contact';
 export * from './identity';
 export * from './portfolio';


### PR DESCRIPTION
## Summary
- Adds `IBlogPostRepository` (`findAll()`, `findBySlug(slug)`) to `packages/application/src/blog/ports/`, following the existing `<context>/ports/<Interface>.ts` pattern used by `IEmailService`/`IAuthenticationGateway`.
- No dedicated test: a bare interface has no runtime behavior — it's exercised indirectly by the Blog use case tests (task #15) via mocks, same precedent as the other application ports.
- Wires the new `./blog` subpath export in `packages/application/package.json` and the top-level barrel.

Refs #942

## Test plan
- [x] `pnpm --filter @repo/application types` — clean
- [x] `pnpm --filter @repo/application lint:check` / `format:check` — clean
- [x] `pnpm --filter @repo/application test` — 168/168 passing (no new tests expected, interface only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)