### PR TITLE
[T-15] Implement blog use cases (ListBlogPosts, GetBlogPostBySlug)

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1102,9 +1102,9 @@
         "dependencies": [
           "14"
         ],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-08-12T01:57:11.885Z"
+        "updatedAt": "2026-08-12T02:12:34.390Z"
       },
       {
         "id": "16",
@@ -1205,9 +1205,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-08-12T01:57:11.885Z",
+      "lastModified": "2026-08-12T02:12:34.390Z",
       "taskCount": 22,
-      "completedCount": 14,
+      "completedCount": 15,
       "tags": [
         "master"
       ]

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1102,8 +1102,9 @@
         "dependencies": [
           "14"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "in-progress",
+        "subtasks": [],
+        "updatedAt": "2026-08-12T01:57:11.885Z"
       },
       {
         "id": "16",
@@ -1204,7 +1205,7 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-08-12T01:42:39.029Z",
+      "lastModified": "2026-08-12T01:57:11.885Z",
       "taskCount": 22,
       "completedCount": 14,
       "tags": [

--- a/packages/application/src/blog/dtos/BlogPostDetailDTO.ts
+++ b/packages/application/src/blog/dtos/BlogPostDetailDTO.ts
@@ -1,0 +1,5 @@
+import { BlogPostSummaryDTO } from './BlogPostSummaryDTO';
+
+export type BlogPostDetailDTO = BlogPostSummaryDTO & {
+  content: string;
+};

--- a/packages/application/src/blog/dtos/BlogPostSummaryDTO.ts
+++ b/packages/application/src/blog/dtos/BlogPostSummaryDTO.ts
@@ -1,0 +1,8 @@
+export type BlogPostSummaryDTO = {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  tags: string[];
+  coverImage?: string;
+};

--- a/packages/application/src/blog/dtos/index.ts
+++ b/packages/application/src/blog/dtos/index.ts
@@ -1,0 +1,2 @@
+export * from './BlogPostSummaryDTO';
+export * from './BlogPostDetailDTO';

--- a/packages/application/src/blog/index.ts
+++ b/packages/application/src/blog/index.ts
@@ -1,1 +1,3 @@
+export * from './dtos';
 export * from './ports';
+export * from './use-cases';

--- a/packages/application/src/blog/use-cases/GetBlogPostBySlug.ts
+++ b/packages/application/src/blog/use-cases/GetBlogPostBySlug.ts
@@ -1,0 +1,68 @@
+import { BlogPost } from '@repo/core/blog';
+import {
+  DomainError,
+  Either,
+  Locale,
+  NotFoundError,
+  Slug,
+  ValidationError,
+  left,
+  right,
+} from '@repo/core/shared';
+
+import { UseCase } from '../../shared/UseCase';
+import { BlogPostDetailDTO } from '../dtos/BlogPostDetailDTO';
+import { IBlogPostRepository } from '../ports';
+
+export type GetBlogPostBySlugInput = {
+  slug: string;
+  locale: Locale;
+};
+
+export class GetBlogPostBySlug extends UseCase<
+  GetBlogPostBySlugInput,
+  BlogPostDetailDTO,
+  NotFoundError | ValidationError | DomainError
+> {
+  constructor(private readonly repository: IBlogPostRepository) {
+    super();
+  }
+
+  async execute(
+    input: GetBlogPostBySlugInput,
+  ): Promise<
+    Either<NotFoundError | ValidationError | DomainError, BlogPostDetailDTO>
+  > {
+    const slugResult = Slug.create(input.slug);
+    if (slugResult.isLeft()) return left(slugResult.value);
+
+    let post: BlogPost | null;
+    try {
+      post = await this.repository.findBySlug(slugResult.value);
+    } catch {
+      return left(
+        new DomainError('FETCH_FAILED', {
+          message: 'Failed to fetch blog post',
+        }),
+      );
+    }
+
+    if (!post) {
+      return left(new NotFoundError({ slug: input.slug }));
+    }
+
+    return right(this.toDTO(post, input.locale));
+  }
+
+  private toDTO(post: BlogPost, locale: Locale): BlogPostDetailDTO {
+    return {
+      slug: post.slug.value,
+      title: post.title.get(locale),
+      description: post.description.get(locale),
+      publishedAt: post.publishedAt.value,
+      tags: post.tags.map((tag) => tag.value),
+      coverImage: post.coverImage?.value,
+      content: post.content.get(locale),
+    };
+  }
+}

--- a/packages/application/src/blog/use-cases/ListBlogPosts.ts
+++ b/packages/application/src/blog/use-cases/ListBlogPosts.ts
@@ -1,0 +1,45 @@
+import { BlogPost } from '@repo/core/blog';
+import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
+
+import { UseCase } from '../../shared/UseCase';
+import { BlogPostSummaryDTO } from '../dtos/BlogPostSummaryDTO';
+import { IBlogPostRepository } from '../ports';
+
+export type ListBlogPostsInput = {
+  locale: Locale;
+};
+
+export class ListBlogPosts extends UseCase<
+  ListBlogPostsInput,
+  BlogPostSummaryDTO[]
+> {
+  constructor(private readonly repository: IBlogPostRepository) {
+    super();
+  }
+
+  async execute(
+    input: ListBlogPostsInput,
+  ): Promise<Either<DomainError, BlogPostSummaryDTO[]>> {
+    try {
+      const posts = await this.repository.findAll();
+      return right(posts.map((post) => this.toDTO(post, input.locale)));
+    } catch {
+      return left(
+        new DomainError('FETCH_FAILED', {
+          message: 'Failed to fetch blog posts',
+        }),
+      );
+    }
+  }
+
+  private toDTO(post: BlogPost, locale: Locale): BlogPostSummaryDTO {
+    return {
+      slug: post.slug.value,
+      title: post.title.get(locale),
+      description: post.description.get(locale),
+      publishedAt: post.publishedAt.value,
+      tags: post.tags.map((tag) => tag.value),
+      coverImage: post.coverImage?.value,
+    };
+  }
+}

--- a/packages/application/src/blog/use-cases/index.ts
+++ b/packages/application/src/blog/use-cases/index.ts
@@ -1,0 +1,2 @@
+export * from './ListBlogPosts';
+export * from './GetBlogPostBySlug';

--- a/packages/application/test/blog/GetBlogPostBySlug.test.ts
+++ b/packages/application/test/blog/GetBlogPostBySlug.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BlogPost, IBlogPostProps } from '@repo/core/blog';
+import { NotFoundError } from '@repo/core/shared';
+
+import { IBlogPostRepository } from '~/blog/ports';
+import { GetBlogPostBySlug } from '~/blog/use-cases/GetBlogPostBySlug';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_PROPS: IBlogPostProps = {
+  slug: 'my-first-post',
+  title: {
+    'en-US': 'My First Post',
+    'pt-BR': 'Meu Primeiro Post',
+    es: 'Mi Primer Post',
+  },
+  description: {
+    'en-US': 'A short description.',
+    'pt-BR': 'Uma descrição curta.',
+    es: 'Una descripción corta.',
+  },
+  content: {
+    'en-US': 'Full content.',
+    'pt-BR': 'Conteúdo completo.',
+    es: 'Contenido completo.',
+  },
+  tags: ['nextjs', 'architecture'],
+  publishedAt: '2026-08-01T00:00:00.000Z',
+};
+
+function makeBlogPost(overrides: Partial<IBlogPostProps> = {}): BlogPost {
+  const result = BlogPost.create({ ...BASE_PROPS, ...overrides });
+  if (result.isLeft())
+    throw new Error(`makeBlogPost failed: ${result.value.message}`);
+  return result.value;
+}
+
+function makeRepository(
+  overrides: Partial<IBlogPostRepository> = {},
+): IBlogPostRepository {
+  return {
+    findAll: vi.fn(),
+    findBySlug: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GetBlogPostBySlug', () => {
+  describe('execute()', () => {
+    it('should return Right with BlogPostDetailDTO when the post is found', async () => {
+      const post = makeBlogPost();
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(post),
+      });
+      const useCase = new GetBlogPostBySlug(repo);
+
+      const result = await useCase.execute({
+        slug: 'my-first-post',
+        locale: 'pt-BR',
+      });
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value).toEqual({
+        slug: 'my-first-post',
+        title: 'Meu Primeiro Post',
+        description: 'Uma descrição curta.',
+        publishedAt: '2026-08-01T00:00:00.000Z',
+        tags: ['nextjs', 'architecture'],
+        coverImage: undefined,
+        content: 'Conteúdo completo.',
+      });
+    });
+
+    it('should return Left(NotFoundError) when the post does not exist', async () => {
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockResolvedValue(null),
+      });
+      const useCase = new GetBlogPostBySlug(repo);
+
+      const result = await useCase.execute({
+        slug: 'missing-post',
+        locale: 'en-US',
+      });
+
+      expect(result.isLeft()).toBe(true);
+      if (!result.isLeft()) return;
+      expect(result.value).toBeInstanceOf(NotFoundError);
+    });
+
+    it('should return Left(ValidationError) for an invalid slug', async () => {
+      const repo = makeRepository();
+      const useCase = new GetBlogPostBySlug(repo);
+
+      const result = await useCase.execute({
+        slug: 'Not A Slug',
+        locale: 'en-US',
+      });
+
+      expect(result.isLeft()).toBe(true);
+      expect(repo.findBySlug).not.toHaveBeenCalled();
+    });
+
+    it('should return Left(DomainError) when the repository throws', async () => {
+      const repo = makeRepository({
+        findBySlug: vi.fn().mockRejectedValue(new Error('db down')),
+      });
+      const useCase = new GetBlogPostBySlug(repo);
+
+      const result = await useCase.execute({
+        slug: 'my-first-post',
+        locale: 'en-US',
+      });
+
+      expect(result.isLeft()).toBe(true);
+      if (!result.isLeft()) return;
+      expect(result.value.code).toBe('FETCH_FAILED');
+    });
+  });
+});

--- a/packages/application/test/blog/ListBlogPosts.test.ts
+++ b/packages/application/test/blog/ListBlogPosts.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BlogPost, IBlogPostProps } from '@repo/core/blog';
+
+import { IBlogPostRepository } from '~/blog/ports';
+import { ListBlogPosts } from '~/blog/use-cases/ListBlogPosts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_PROPS: IBlogPostProps = {
+  slug: 'my-first-post',
+  title: {
+    'en-US': 'My First Post',
+    'pt-BR': 'Meu Primeiro Post',
+    es: 'Mi Primer Post',
+  },
+  description: {
+    'en-US': 'A short description.',
+    'pt-BR': 'Uma descrição curta.',
+    es: 'Una descripción corta.',
+  },
+  content: {
+    'en-US': 'Full content.',
+    'pt-BR': 'Conteúdo completo.',
+    es: 'Contenido completo.',
+  },
+  tags: ['nextjs', 'architecture'],
+  publishedAt: '2026-08-01T00:00:00.000Z',
+};
+
+function makeBlogPost(overrides: Partial<IBlogPostProps> = {}): BlogPost {
+  const result = BlogPost.create({ ...BASE_PROPS, ...overrides });
+  if (result.isLeft())
+    throw new Error(`makeBlogPost failed: ${result.value.message}`);
+  return result.value;
+}
+
+function makeRepository(
+  overrides: Partial<IBlogPostRepository> = {},
+): IBlogPostRepository {
+  return {
+    findAll: vi.fn(),
+    findBySlug: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ListBlogPosts', () => {
+  describe('execute()', () => {
+    it('should return Right with BlogPostSummaryDTO[] mapped to the requested locale', async () => {
+      const post = makeBlogPost();
+      const repo = makeRepository({
+        findAll: vi.fn().mockResolvedValue([post]),
+      });
+      const useCase = new ListBlogPosts(repo);
+
+      const result = await useCase.execute({ locale: 'pt-BR' });
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value).toEqual([
+        {
+          slug: 'my-first-post',
+          title: 'Meu Primeiro Post',
+          description: 'Uma descrição curta.',
+          publishedAt: '2026-08-01T00:00:00.000Z',
+          tags: ['nextjs', 'architecture'],
+          coverImage: undefined,
+        },
+      ]);
+    });
+
+    it('should return an empty array when there are no posts', async () => {
+      const repo = makeRepository({ findAll: vi.fn().mockResolvedValue([]) });
+      const useCase = new ListBlogPosts(repo);
+
+      const result = await useCase.execute({ locale: 'en-US' });
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value).toEqual([]);
+    });
+
+    it('should include coverImage when the post has one', async () => {
+      const post = makeBlogPost({
+        coverImage: 'https://example.com/cover.png',
+      });
+      const repo = makeRepository({
+        findAll: vi.fn().mockResolvedValue([post]),
+      });
+      const useCase = new ListBlogPosts(repo);
+
+      const result = await useCase.execute({ locale: 'en-US' });
+
+      expect(result.isRight()).toBe(true);
+      if (!result.isRight()) return;
+      expect(result.value[0].coverImage).toBe('https://example.com/cover.png');
+    });
+
+    it('should return Left(DomainError) when the repository throws', async () => {
+      const repo = makeRepository({
+        findAll: vi.fn().mockRejectedValue(new Error('db down')),
+      });
+      const useCase = new ListBlogPosts(repo);
+
+      const result = await useCase.execute({ locale: 'en-US' });
+
+      expect(result.isLeft()).toBe(true);
+      if (!result.isLeft()) return;
+      expect(result.value.code).toBe('FETCH_FAILED');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `BlogPostSummaryDTO`/`BlogPostDetailDTO` and `ListBlogPosts`/`GetBlogPostBySlug` use cases to `packages/application/src/blog/`, following the `GetPublishedProjects`/`GetProjectBySlug` pattern.
- `ListBlogPosts`: maps `IBlogPostRepository.findAll()` to `BlogPostSummaryDTO[]` for a given locale; repository failure → `DomainError('FETCH_FAILED')`.
- `GetBlogPostBySlug`: validates the slug via `Slug.create()` before hitting the repository, `NotFoundError` when the post doesn't exist, otherwise `BlogPostDetailDTO`.

Refs #944

## Test plan
- [x] `pnpm --filter @repo/application types` — clean
- [x] `pnpm --filter @repo/application lint:check` / `format:check` — clean
- [x] `pnpm --filter @repo/application test` — 176/176 passing (8 new: success/not-found/invalid-slug/repository-failure paths, mocked `IBlogPostRepository`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)