### PR TITLE
feat(infra): implement FileSystemBlogPostRepository in packages/infra

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1117,9 +1117,9 @@
           "13",
           "14"
         ],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [],
-        "updatedAt": "2026-08-14T02:40:50.137Z"
+        "updatedAt": "2026-08-14T22:48:00.031Z"
       },
       {
         "id": "17",
@@ -1206,9 +1206,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-08-14T02:40:50.137Z",
+      "lastModified": "2026-08-14T22:48:00.032Z",
       "taskCount": 22,
-      "completedCount": 15,
+      "completedCount": 16,
       "tags": [
         "master"
       ]

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1117,8 +1117,9 @@
           "13",
           "14"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "in-progress",
+        "subtasks": [],
+        "updatedAt": "2026-08-14T02:40:50.137Z"
       },
       {
         "id": "17",
@@ -1205,7 +1206,7 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-08-12T02:12:34.390Z",
+      "lastModified": "2026-08-14T02:40:50.137Z",
       "taskCount": 22,
       "completedCount": 15,
       "tags": [

--- a/docs/superpowers/specs/2026-07-24-blog-mdx-design.md
+++ b/docs/superpowers/specs/2026-07-24-blog-mdx-design.md
@@ -25,12 +25,13 @@ pure infra swap.
   excuse to skip a translation.
 - SEO: per-post metadata, OG images, sitemap.
 - Syntax highlighting for code blocks (posts are technical write-ups).
+- Tags: stored in `meta.json`, displayed on the post as metadata/badges.
+- RSS: one feed per locale (`/blog/<locale>/rss.xml`).
 
 **Explicitly out of scope (future phases, tracked in ROADMAP.md):**
 - Backoffice/admin authoring UI backed by a database.
-- Tags/categories as a navigation/filtering feature (tags are stored in `meta.json` now, but no
-  tag index pages yet).
-- RSS feed.
+- Tag listing/index pages (e.g. `/blog/[locale]/tag/[tag]`) — tags exist as data now, but no
+  dedicated navigation/filtering pages yet.
 - Comments, newsletter, reading analytics.
 
 ## 2. Architecture
@@ -96,7 +97,16 @@ the build — never ships a broken post to production.
   `generateStaticParams` (SSG per slug × locale), dynamic `opengraph-image.tsx` (from
   `coverImage` or generated from the title), `sitemap.ts` covering all posts × locales.
 
-## 5. Cross-app routing (Vercel multi-zone)
+## 5. RSS feeds
+
+- One feed per locale: `apps/blog/src/app/[locale]/rss.xml/route.ts` (Route Handler), reachable
+  as `wallace-ferreira.dev/blog/<locale>/rss.xml`.
+- Each feed calls `ListBlogPosts` (same use case as the listing page) and renders title,
+  description, link, and `publishedAt` for that locale only — no mixing locales in one feed.
+- Feed link (`<link rel="alternate" type="application/rss+xml">`) added per locale in the blog
+  layout `<head>`, and referenced in `robots.txt`/footer for discoverability.
+
+## 6. Cross-app routing (Vercel multi-zone)
 
 - `apps/site`: `next.config.mjs` `rewrites()` sends `/blog` and `/blog/:path*` to the `apps/blog`
   Vercel deployment URL.
@@ -106,7 +116,7 @@ the build — never ships a broken post to production.
   on the primary domain, not a subdomain, to keep domain authority/link equity unified (per
   `SEO-BACKLINK-STRATEGY.md` findings on paulie.dev's backlink profile).
 
-## 6. Testing
+## 7. Testing
 
 - **`core`**: invariant tests for `BlogPost`/`Tag` (invalid slug, missing `publishedAt`, etc.) —
   Either pattern, no mocks.
@@ -114,7 +124,8 @@ the build — never ships a broken post to production.
   directory (valid post, post missing a locale file → build error, malformed frontmatter → Zod
   error).
 - **`apps/blog`**: detail page renders correct title/OG/canonical from a mocked
-  `IBlogPostRepository` (no integration with real files).
+  `IBlogPostRepository` (no integration with real files); RSS route returns valid XML with only
+  the requested locale's posts, from the same mocked repository.
 
 ## Open questions for implementation planning
 

--- a/docs/superpowers/specs/2026-07-24-blog-mdx-design.md
+++ b/docs/superpowers/specs/2026-07-24-blog-mdx-design.md
@@ -1,0 +1,123 @@
+# Blog (`apps/blog`) — MDX-in-Git Design
+
+> Status: approved design, pending implementation plan.
+> Related: [ROADMAP.md](../../ROADMAP.md), [03-BOUNDED-CONTEXTS.md](../../03-BOUNDED-CONTEXTS.md),
+> [SEO-BACKLINK-STRATEGY.md](../../SEO-BACKLINK-STRATEGY.md), [12-DESIGN-SYSTEM.md](../../12-DESIGN-SYSTEM.md).
+
+## Goal
+
+Ship a technical blog to drive SEO/backlink authority (per `SEO-BACKLINK-STRATEGY.md`), as fast
+as possible, without blocking on a backoffice/admin UI. Content is authored as MDX files
+committed to git and reviewed via PR — same workflow already used for project content.
+
+A backoffice (`apps/admin`) for authoring posts via a database-backed UI is a deliberate
+**future phase**, not part of this design. The architecture below is chosen so that phase is a
+pure infra swap.
+
+## 1. Scope
+
+**In scope now:**
+- `apps/blog`, a dedicated Next.js app, served at `wallace-ferreira.dev/blog` via Vercel
+  multi-zone rewrite from `apps/site`.
+- Content authored as MDX in git, no database.
+- Full i18n from day one: every published post ships in `en-US`, `pt-BR`, and `es` — no partial
+  translations, `en-US` is the runtime fallback only for locale-negotiation edge cases, never an
+  excuse to skip a translation.
+- SEO: per-post metadata, OG images, sitemap.
+- Syntax highlighting for code blocks (posts are technical write-ups).
+
+**Explicitly out of scope (future phases, tracked in ROADMAP.md):**
+- Backoffice/admin authoring UI backed by a database.
+- Tags/categories as a navigation/filtering feature (tags are stored in `meta.json` now, but no
+  tag index pages yet).
+- RSS feed.
+- Comments, newsletter, reading analytics.
+
+## 2. Architecture
+
+The Blog bounded context follows the same Dependency Rule as Portfolio
+(`core ← application ← infra ← apps`), even though there is no database yet. This means the
+future migration to a backoffice is an **infra swap only** — no changes to domain, use cases, or
+pages.
+
+- **`packages/core`** — `BlogPost` entity and `Tag` value object. Invariants via `Validator`
+  (kebab-case slug, `publishedAt` present, at least one `LocalizedText` for title/description).
+  Zero framework dependencies.
+- **`packages/application`** — `IBlogPostRepository` port (`findAll()`, `findBySlug(slug)`) and
+  use cases `ListBlogPosts`, `GetBlogPostBySlug`.
+- **`packages/infra`** — `FileSystemBlogPostRepository`: reads `content/posts/<slug>/*`, parses
+  frontmatter (Zod schema, edge validation per `06-VALIDATION.md`), constructs `BlogPost`
+  entities. No Prisma/Supabase involved in this phase.
+- **`apps/blog`** — Server Components call `ListBlogPosts` / `GetBlogPostBySlug` directly at
+  build time (SSG), same pattern as Portfolio.
+
+When the backoffice phase happens: implement `PrismaBlogPostRepository`, wire it in the DI
+container instead of `FileSystemBlogPostRepository`. `core`, `application`, and `apps/blog`
+pages are untouched.
+
+## 3. Content model
+
+```
+content/posts/<slug>/
+  meta.json       # shared across locales — immutable metadata
+  en-US.mdx
+  pt-BR.mdx
+  es.mdx
+  cover.png       # optional, referenced by meta.json
+```
+
+`meta.json`:
+```json
+{
+  "slug": "abstracting-gatsby-functions-as-an-api",
+  "publishedAt": "2026-08-01",
+  "tags": ["nextjs", "architecture"],
+  "coverImage": "/content/posts/<slug>/cover.png"
+}
+```
+
+Each `.mdx` file carries only the locale-specific `title`, `description` (frontmatter) and body.
+Immutable metadata (slug, date, tags) is not duplicated per locale.
+
+**Validation:** a `BlogPostFrontmatterSchema` (Zod) validates `meta.json` and every `.mdx`
+frontmatter at build time. A missing locale file, malformed frontmatter, or invalid slug fails
+the build — never ships a broken post to production.
+
+## 4. Rendering & SEO
+
+- **MDX compilation**: `next-mdx-remote/rsc` — Server Components, SSG. Not `TextRich` from
+  `@repo/ui`, which is client-side and designed for markdown coming from the database (e.g.
+  project descriptions); blog posts render server-side for performance and SEO.
+- **Syntax highlighting**: `rehype-pretty-code` (Shiki) at build time — no client JS shipped for
+  highlighting.
+- **Custom MDX components**: map to `@repo/ui` components (`Badge`, `SectionHeader`, etc.) where
+  it makes sense inside post bodies.
+- **Per-post SEO**: `generateMetadata` (title/description/canonical per locale),
+  `generateStaticParams` (SSG per slug × locale), dynamic `opengraph-image.tsx` (from
+  `coverImage` or generated from the title), `sitemap.ts` covering all posts × locales.
+
+## 5. Cross-app routing (Vercel multi-zone)
+
+- `apps/site`: `next.config.mjs` `rewrites()` sends `/blog` and `/blog/:path*` to the `apps/blog`
+  Vercel deployment URL.
+- `apps/blog`: `basePath: '/blog'`, its own `[locale]` routing via next-intl, reusing
+  `LOCALES`/`DEFAULT_LOCALE` from `@repo/core/shared`. Deployed as an independent Vercel project.
+- Final URLs: `wallace-ferreira.dev/blog`, `wallace-ferreira.dev/blog/pt-BR/<slug>`, etc. — path
+  on the primary domain, not a subdomain, to keep domain authority/link equity unified (per
+  `SEO-BACKLINK-STRATEGY.md` findings on paulie.dev's backlink profile).
+
+## 6. Testing
+
+- **`core`**: invariant tests for `BlogPost`/`Tag` (invalid slug, missing `publishedAt`, etc.) —
+  Either pattern, no mocks.
+- **`infra`**: `FileSystemBlogPostRepository` tests against a test fixture `content/posts/`
+  directory (valid post, post missing a locale file → build error, malformed frontmatter → Zod
+  error).
+- **`apps/blog`**: detail page renders correct title/OG/canonical from a mocked
+  `IBlogPostRepository` (no integration with real files).
+
+## Open questions for implementation planning
+
+- First post topic(s) and publishing cadence — not decided here, tracked separately.
+- Exact DI container wiring pattern for `apps/blog` (mirrors how `apps/site` wires Portfolio use
+  cases today — to confirm during planning).

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -47,6 +47,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/prettier-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@types/node": "^20.19.43",
     "@vitest/coverage-v8": "^3.0.0",
     "prisma": "^6.0.0",
     "tsx": "^4.0.0",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -39,7 +39,9 @@
     "@repo/utils": "workspace:*",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",
-    "resend": "^6.9.4"
+    "gray-matter": "^4.0.3",
+    "resend": "^6.9.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -16,6 +16,17 @@ export { ResendEmailService } from './services/ResendEmailService';
 export type { IResendEmailServiceConfig } from './services/ResendEmailService';
 export { UserMapper } from './repositories/user/UserMapper';
 export { PrismaUserRepository } from './repositories/user/PrismaUserRepository';
+export { BlogPostMapper } from './repositories/blog/BlogPostMapper';
+export type {
+  IParsedLocaleFile,
+  ParsedLocaleFiles,
+} from './repositories/blog/BlogPostMapper';
+export { FileSystemBlogPostRepository } from './repositories/blog/FileSystemBlogPostRepository';
+export {
+  MetaJsonSchema,
+  MdxFrontmatterSchema,
+} from './repositories/blog/schemas';
+export type { MetaJson, MdxFrontmatter } from './repositories/blog/schemas';
 export {
   SupabaseAuthenticationGateway,
   SUPABASE_ACCESS_TOKEN_COOKIE,

--- a/packages/infra/src/repositories/blog/BlogPostMapper.ts
+++ b/packages/infra/src/repositories/blog/BlogPostMapper.ts
@@ -1,0 +1,48 @@
+import { BlogPost, IBlogPostProps } from '@repo/core/blog';
+import { ILocalizedTextInput, Locale } from '@repo/core/shared';
+
+import { InfrastructureError } from '../../errors/InfrastructureError';
+import { MetaJson } from './schemas';
+
+export interface IParsedLocaleFile {
+  title: string;
+  description: string;
+  content: string;
+}
+
+export type ParsedLocaleFiles = Record<Locale, IParsedLocaleFile>;
+
+function toLocalizedInput(
+  locales: ParsedLocaleFiles,
+  field: keyof IParsedLocaleFile,
+): ILocalizedTextInput {
+  return {
+    'en-US': locales['en-US'][field],
+    'pt-BR': locales['pt-BR'][field],
+    es: locales.es[field],
+  };
+}
+
+export class BlogPostMapper {
+  static toDomain(meta: MetaJson, locales: ParsedLocaleFiles): BlogPost {
+    const props: IBlogPostProps = {
+      slug: meta.slug,
+      title: toLocalizedInput(locales, 'title'),
+      description: toLocalizedInput(locales, 'description'),
+      content: toLocalizedInput(locales, 'content'),
+      tags: meta.tags,
+      publishedAt: meta.publishedAt,
+      coverImage: meta.coverImage,
+    };
+
+    const result = BlogPost.create(props);
+    if (result.isLeft()) {
+      throw new InfrastructureError(
+        `Failed to map blog post ${meta.slug} to domain: ${result.value.message}`,
+        result.value,
+      );
+    }
+
+    return result.value;
+  }
+}

--- a/packages/infra/src/repositories/blog/FileSystemBlogPostRepository.ts
+++ b/packages/infra/src/repositories/blog/FileSystemBlogPostRepository.ts
@@ -1,0 +1,119 @@
+import { IBlogPostRepository } from '@repo/application/blog';
+import { BlogPost } from '@repo/core/blog';
+import { Locale, LOCALES, Slug } from '@repo/core/shared';
+import matter from 'gray-matter';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { InfrastructureError } from '../../errors/InfrastructureError';
+import { BlogPostMapper, ParsedLocaleFiles } from './BlogPostMapper';
+import { MdxFrontmatterSchema, MetaJsonSchema } from './schemas';
+
+const META_FILENAME = 'meta.json';
+
+export class FileSystemBlogPostRepository implements IBlogPostRepository {
+  constructor(private readonly contentDir: string) {}
+
+  async findAll(): Promise<BlogPost[]> {
+    const entries = await fs.readdir(this.contentDir, { withFileTypes: true });
+    const slugs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+
+    const posts = await Promise.all(slugs.map((slug) => this.readPost(slug)));
+
+    return posts.sort((a, b) => b.publishedAt.ms - a.publishedAt.ms);
+  }
+
+  async findBySlug(slug: Slug): Promise<BlogPost | null> {
+    const postDir = path.join(this.contentDir, slug.value);
+
+    try {
+      await fs.access(postDir);
+    } catch {
+      return null;
+    }
+
+    return this.readPost(slug.value);
+  }
+
+  private async readPost(slug: string): Promise<BlogPost> {
+    const postDir = path.join(this.contentDir, slug);
+
+    const meta = await this.readMeta(postDir, slug);
+    const locales = await this.readLocaleFiles(postDir, slug);
+
+    return BlogPostMapper.toDomain(meta, locales);
+  }
+
+  private async readMeta(postDir: string, slug: string) {
+    const metaPath = path.join(postDir, META_FILENAME);
+    const raw = await this.readFile(metaPath, slug);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new InfrastructureError(
+        `Malformed ${META_FILENAME} for blog post "${slug}": invalid JSON`,
+        err,
+      );
+    }
+
+    const result = MetaJsonSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new InfrastructureError(
+        `Malformed ${META_FILENAME} for blog post "${slug}": ${result.error.message}`,
+        result.error,
+      );
+    }
+
+    return result.data;
+  }
+
+  private async readLocaleFiles(
+    postDir: string,
+    slug: string,
+  ): Promise<ParsedLocaleFiles> {
+    const entries = await Promise.all(
+      LOCALES.map(async (locale) => {
+        const filePath = path.join(postDir, `${locale}.mdx`);
+        const raw = await this.readFile(filePath, slug, locale);
+
+        const { data, content } = matter(raw);
+
+        const result = MdxFrontmatterSchema.safeParse(data);
+        if (!result.success) {
+          throw new InfrastructureError(
+            `Malformed frontmatter in "${locale}.mdx" for blog post "${slug}": ${result.error.message}`,
+            result.error,
+          );
+        }
+
+        return [
+          locale,
+          {
+            title: result.data.title,
+            description: result.data.description,
+            content,
+          },
+        ] as const;
+      }),
+    );
+
+    return Object.fromEntries(entries) as ParsedLocaleFiles;
+  }
+
+  private async readFile(
+    filePath: string,
+    slug: string,
+    locale?: Locale,
+  ): Promise<string> {
+    try {
+      return await fs.readFile(filePath, 'utf-8');
+    } catch {
+      const target = locale ? `locale file "${locale}.mdx"` : META_FILENAME;
+      throw new InfrastructureError(
+        `Missing ${target} for blog post "${slug}" — full i18n (en-US, pt-BR, es) is required.`,
+      );
+    }
+  }
+}

--- a/packages/infra/src/repositories/blog/index.ts
+++ b/packages/infra/src/repositories/blog/index.ts
@@ -1,0 +1,5 @@
+export { BlogPostMapper } from './BlogPostMapper';
+export type { IParsedLocaleFile, ParsedLocaleFiles } from './BlogPostMapper';
+export { FileSystemBlogPostRepository } from './FileSystemBlogPostRepository';
+export { MetaJsonSchema, MdxFrontmatterSchema } from './schemas';
+export type { MetaJson, MdxFrontmatter } from './schemas';

--- a/packages/infra/src/repositories/blog/schemas.ts
+++ b/packages/infra/src/repositories/blog/schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const MetaJsonSchema = z.object({
+  slug: z.string(),
+  publishedAt: z.string(),
+  tags: z.array(z.string()),
+  coverImage: z.string().optional(),
+});
+
+export type MetaJson = z.infer<typeof MetaJsonSchema>;
+
+export const MdxFrontmatterSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+});
+
+export type MdxFrontmatter = z.infer<typeof MdxFrontmatterSchema>;

--- a/packages/infra/test/fixtures/posts-malformed-frontmatter/malformed-frontmatter-post/en-US.mdx
+++ b/packages/infra/test/fixtures/posts-malformed-frontmatter/malformed-frontmatter-post/en-US.mdx
@@ -1,0 +1,7 @@
+---
+title: Malformed Frontmatter Post
+---
+
+# Malformed Frontmatter Post
+
+Missing the required `description` frontmatter field.

--- a/packages/infra/test/fixtures/posts-malformed-frontmatter/malformed-frontmatter-post/es.mdx
+++ b/packages/infra/test/fixtures/posts-malformed-frontmatter/malformed-frontmatter-post/es.mdx
@@ -1,0 +1,8 @@
+---
+title: Publicación con Frontmatter Inválido
+description: Frontmatter válido en español.
+---
+
+# Publicación con Frontmatter Inválido
+
+Cuerpo en español.

--- a/packages/infra/test/fixtures/posts-malformed-frontmatter/malformed-frontmatter-post/meta.json
+++ b/packages/infra/test/fixtures/posts-malformed-frontmatter/malformed-frontmatter-post/meta.json
@@ -1,0 +1,5 @@
+{
+  "slug": "malformed-frontmatter-post",
+  "publishedAt": "2026-08-03",
+  "tags": ["frontmatter"]
+}

--- a/packages/infra/test/fixtures/posts-malformed-frontmatter/malformed-frontmatter-post/pt-BR.mdx
+++ b/packages/infra/test/fixtures/posts-malformed-frontmatter/malformed-frontmatter-post/pt-BR.mdx
@@ -1,0 +1,8 @@
+---
+title: Post com Frontmatter Inválido
+description: Frontmatter válido em português.
+---
+
+# Post com Frontmatter Inválido
+
+Corpo em português.

--- a/packages/infra/test/fixtures/posts-malformed-meta/malformed-meta-post/meta.json
+++ b/packages/infra/test/fixtures/posts-malformed-meta/malformed-meta-post/meta.json
@@ -1,0 +1,4 @@
+{
+  "slug": "malformed-meta-post",
+  "tags": "not-an-array"
+}

--- a/packages/infra/test/fixtures/posts-missing-locale/missing-locale-post/en-US.mdx
+++ b/packages/infra/test/fixtures/posts-missing-locale/missing-locale-post/en-US.mdx
@@ -1,0 +1,8 @@
+---
+title: Missing Locale Post
+description: This post is missing its es.mdx translation.
+---
+
+# Missing Locale Post
+
+English body only.

--- a/packages/infra/test/fixtures/posts-missing-locale/missing-locale-post/meta.json
+++ b/packages/infra/test/fixtures/posts-missing-locale/missing-locale-post/meta.json
@@ -1,0 +1,5 @@
+{
+  "slug": "missing-locale-post",
+  "publishedAt": "2026-08-02",
+  "tags": ["i18n"]
+}

--- a/packages/infra/test/fixtures/posts-missing-locale/missing-locale-post/pt-BR.mdx
+++ b/packages/infra/test/fixtures/posts-missing-locale/missing-locale-post/pt-BR.mdx
@@ -1,0 +1,8 @@
+---
+title: Post Sem Locale
+description: Este post não tem a tradução es.mdx.
+---
+
+# Post Sem Locale
+
+Corpo apenas em português.

--- a/packages/infra/test/fixtures/posts/older-post/en-US.mdx
+++ b/packages/infra/test/fixtures/posts/older-post/en-US.mdx
@@ -1,0 +1,8 @@
+---
+title: Older Post
+description: An older post used to test findAll ordering.
+---
+
+# Older Post
+
+Older English body.

--- a/packages/infra/test/fixtures/posts/older-post/es.mdx
+++ b/packages/infra/test/fixtures/posts/older-post/es.mdx
@@ -1,0 +1,8 @@
+---
+title: Publicación Antigua
+description: Una publicación antigua usada para probar el orden de findAll.
+---
+
+# Publicación Antigua
+
+Cuerpo antiguo en español.

--- a/packages/infra/test/fixtures/posts/older-post/meta.json
+++ b/packages/infra/test/fixtures/posts/older-post/meta.json
@@ -1,0 +1,5 @@
+{
+  "slug": "older-post",
+  "publishedAt": "2026-01-01",
+  "tags": ["ddd"]
+}

--- a/packages/infra/test/fixtures/posts/older-post/pt-BR.mdx
+++ b/packages/infra/test/fixtures/posts/older-post/pt-BR.mdx
@@ -1,0 +1,8 @@
+---
+title: Post Antigo
+description: Um post antigo usado para testar a ordenação do findAll.
+---
+
+# Post Antigo
+
+Corpo antigo em português.

--- a/packages/infra/test/fixtures/posts/test-post/en-US.mdx
+++ b/packages/infra/test/fixtures/posts/test-post/en-US.mdx
@@ -1,0 +1,8 @@
+---
+title: Test Post
+description: A test post used as a fixture.
+---
+
+# Test Post
+
+This is the English body.

--- a/packages/infra/test/fixtures/posts/test-post/es.mdx
+++ b/packages/infra/test/fixtures/posts/test-post/es.mdx
@@ -1,0 +1,8 @@
+---
+title: Publicación de Prueba
+description: Una publicación de prueba usada como fixture.
+---
+
+# Publicación de Prueba
+
+Este es el cuerpo en español.

--- a/packages/infra/test/fixtures/posts/test-post/meta.json
+++ b/packages/infra/test/fixtures/posts/test-post/meta.json
@@ -1,0 +1,6 @@
+{
+  "slug": "test-post",
+  "publishedAt": "2026-08-01",
+  "tags": ["nextjs", "architecture"],
+  "coverImage": "https://wallace-ferreira.dev/content/posts/test-post/cover.png"
+}

--- a/packages/infra/test/fixtures/posts/test-post/pt-BR.mdx
+++ b/packages/infra/test/fixtures/posts/test-post/pt-BR.mdx
@@ -1,0 +1,8 @@
+---
+title: Post de Teste
+description: Um post de teste usado como fixture.
+---
+
+# Post de Teste
+
+Este é o corpo em português.

--- a/packages/infra/test/repositories/blog/BlogPostMapper.test.ts
+++ b/packages/infra/test/repositories/blog/BlogPostMapper.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { InfrastructureError } from '../../../src/errors/InfrastructureError';
+import {
+  BlogPostMapper,
+  ParsedLocaleFiles,
+} from '../../../src/repositories/blog/BlogPostMapper';
+import { MetaJson } from '../../../src/repositories/blog/schemas';
+
+function buildMeta(overrides: Partial<MetaJson> = {}): MetaJson {
+  return {
+    slug: 'test-post',
+    publishedAt: '2026-08-01',
+    tags: ['nextjs', 'architecture'],
+    ...overrides,
+  };
+}
+
+function buildLocales(
+  overrides: Partial<ParsedLocaleFiles> = {},
+): ParsedLocaleFiles {
+  return {
+    'en-US': {
+      title: 'Test Post',
+      description: 'Test description',
+      content: '# Test Post\n\nEnglish body.',
+    },
+    'pt-BR': {
+      title: 'Post de Teste',
+      description: 'Descrição de teste',
+      content: '# Post de Teste\n\nCorpo em português.',
+    },
+    es: {
+      title: 'Publicación de Prueba',
+      description: 'Descripción de prueba',
+      content: '# Publicación de Prueba\n\nCuerpo en español.',
+    },
+    ...overrides,
+  };
+}
+
+describe('BlogPostMapper', () => {
+  describe('toDomain', () => {
+    it('should map meta and parsed locale files to a domain BlogPost', () => {
+      const meta = buildMeta({
+        coverImage:
+          'https://wallace-ferreira.dev/content/posts/test-post/cover.png',
+      });
+      const locales = buildLocales();
+
+      const post = BlogPostMapper.toDomain(meta, locales);
+
+      expect(post.slug.value).toBe('test-post');
+      expect(post.title.get('en-US')).toBe('Test Post');
+      expect(post.title.get('pt-BR')).toBe('Post de Teste');
+      expect(post.title.get('es')).toBe('Publicación de Prueba');
+      expect(post.description.get('en-US')).toBe('Test description');
+      expect(post.content.get('en-US')).toContain('English body.');
+      expect(post.tags.map((t) => t.value)).toEqual(['nextjs', 'architecture']);
+      expect(post.publishedAt.value).toBe('2026-08-01');
+      expect(post.coverImage?.value).toBe(
+        'https://wallace-ferreira.dev/content/posts/test-post/cover.png',
+      );
+    });
+
+    it('should throw InfrastructureError when meta and locale data produce an invalid domain object', () => {
+      const meta = buildMeta({ slug: '' });
+      const locales = buildLocales();
+
+      expect(() => BlogPostMapper.toDomain(meta, locales)).toThrow(
+        InfrastructureError,
+      );
+    });
+  });
+});

--- a/packages/infra/test/repositories/blog/FileSystemBlogPostRepository.test.ts
+++ b/packages/infra/test/repositories/blog/FileSystemBlogPostRepository.test.ts
@@ -1,0 +1,95 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { Slug } from '@repo/core/shared';
+
+import { InfrastructureError } from '../../../src/errors/InfrastructureError';
+import { FileSystemBlogPostRepository } from '../../../src/repositories/blog/FileSystemBlogPostRepository';
+
+const FIXTURES_DIR = path.join(__dirname, '../../fixtures');
+
+function unwrapSlug(raw: string): Slug {
+  const result = Slug.create(raw);
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+describe('FileSystemBlogPostRepository', () => {
+  describe('findAll', () => {
+    it('should return all posts sorted by publishedAt desc when the content directory has valid posts', async () => {
+      const repo = new FileSystemBlogPostRepository(
+        path.join(FIXTURES_DIR, 'posts'),
+      );
+
+      const posts = await repo.findAll();
+
+      expect(posts.map((p) => p.slug.value)).toEqual([
+        'test-post',
+        'older-post',
+      ]);
+      expect(posts[0].title.get('en-US')).toBe('Test Post');
+      expect(posts[0].tags.map((t) => t.value)).toEqual([
+        'nextjs',
+        'architecture',
+      ]);
+    });
+  });
+
+  describe('findBySlug', () => {
+    it('should return the matching post when the slug exists', async () => {
+      const repo = new FileSystemBlogPostRepository(
+        path.join(FIXTURES_DIR, 'posts'),
+      );
+
+      const post = await repo.findBySlug(unwrapSlug('test-post'));
+
+      expect(post).not.toBeNull();
+      expect(post?.title.get('pt-BR')).toBe('Post de Teste');
+      expect(post?.description.get('es')).toBe(
+        'Una publicación de prueba usada como fixture.',
+      );
+      expect(post?.content.get('en-US')).toContain('This is the English body.');
+    });
+
+    it('should return null when the slug does not exist', async () => {
+      const repo = new FileSystemBlogPostRepository(
+        path.join(FIXTURES_DIR, 'posts'),
+      );
+
+      const post = await repo.findBySlug(unwrapSlug('non-existent-post'));
+
+      expect(post).toBeNull();
+    });
+
+    it('should throw InfrastructureError when a locale file is missing', async () => {
+      const repo = new FileSystemBlogPostRepository(
+        path.join(FIXTURES_DIR, 'posts-missing-locale'),
+      );
+
+      await expect(
+        repo.findBySlug(unwrapSlug('missing-locale-post')),
+      ).rejects.toThrow(InfrastructureError);
+    });
+
+    it('should throw InfrastructureError when meta.json is malformed', async () => {
+      const repo = new FileSystemBlogPostRepository(
+        path.join(FIXTURES_DIR, 'posts-malformed-meta'),
+      );
+
+      await expect(
+        repo.findBySlug(unwrapSlug('malformed-meta-post')),
+      ).rejects.toThrow(InfrastructureError);
+    });
+
+    it('should throw InfrastructureError when frontmatter is malformed', async () => {
+      const repo = new FileSystemBlogPostRepository(
+        path.join(FIXTURES_DIR, 'posts-malformed-frontmatter'),
+      );
+
+      await expect(
+        repo.findBySlug(unwrapSlug('malformed-frontmatter-post')),
+      ).rejects.toThrow(InfrastructureError);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,7 +336,7 @@ importers:
         version: 9.1.2(eslint@8.57.1)
       eslint-config-turbo:
         specifier: ^2.0.0
-        version: 2.9.18(eslint@8.57.1)(turbo@2.10.9)
+        version: 2.9.18(eslint@8.57.1)(turbo@2.10.10)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
         version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
@@ -419,6 +419,9 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@types/node':
+        specifier: ^20.19.43
+        version: 20.19.43
       '@vitest/coverage-v8':
         specifier: ^3.0.0
         version: 3.2.6(vitest@3.2.6)
@@ -2993,8 +2996,8 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@turbo/darwin-64@2.10.9:
-    resolution: {integrity: sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA==}
+  /@turbo/darwin-64@2.10.10:
+    resolution: {integrity: sha512-gFDD+wRP5hWxBRghGyEbjpbLOY7aIU/wvsnKdMM7odQcp/wHMrnI83p0FyxxMRZnFH9ZD+S59MvcpOC5b+nrCA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -3009,8 +3012,8 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/darwin-arm64@2.10.9:
-    resolution: {integrity: sha512-aqtpPkiIC4IUas8Vv27oJ3aDfTuP1d5wofd01dZ7gfhHRrIKuFdqQb4imvNnVFahcOViF9Jh8Oi7feDoz8/ciA==}
+  /@turbo/darwin-arm64@2.10.10:
+    resolution: {integrity: sha512-VZYsxZ6yjyDosUqtiroAVSXPLmx/qBxdHJgIxdMH9RyNmLdOLOWtJnYMnI4qckwCgQMK85G3fu94/xk5+iBCgw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -3025,8 +3028,8 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/linux-64@2.10.9:
-    resolution: {integrity: sha512-XyAneUBsS5uNOUOjBSs81zyigMVwwhVUd3u7F2JFMKGQk6F7eNAiOEBASJ+aHLldjYsOEjhfW+5gWIqwziyFFw==}
+  /@turbo/linux-64@2.10.10:
+    resolution: {integrity: sha512-lAvW+yEnmsCKMEIwNugjozawvYytHKPhU0kfLBizu83MIs8OUb9KobYvkZ56L5akSM6K7+gBFLEIfQkaceh90g==}
     cpu: [x64]
     os: [android, linux]
     requiresBuild: true
@@ -3041,8 +3044,8 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/linux-arm64@2.10.9:
-    resolution: {integrity: sha512-5jAcldLnkuWIjujGhCn2MGIeUwW8IVNOq9Sce4EEzzgLcxmhTasbV0RiW6ZkaRdOjmOCGzeNXPLkDJEOIucOLw==}
+  /@turbo/linux-arm64@2.10.10:
+    resolution: {integrity: sha512-MSJ+NkRTd79Z9+YEZpUV9VOWVOOigFhE+v/ETNYJEuTJp3r00y9YgFvDXrmM+DP8Kal6tk3U6xSugD2/Ojh+Jg==}
     cpu: [arm64]
     os: [android, linux]
     requiresBuild: true
@@ -3057,8 +3060,8 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/windows-64@2.10.9:
-    resolution: {integrity: sha512-u1xGpGlefzuhBedbt/VR2nWdftfFVZwPeDg9e5uZl68sV1fL3HNYTNr5VyHkzgtPK2VTYg1x4OKZuGrh1Gvhtg==}
+  /@turbo/windows-64@2.10.10:
+    resolution: {integrity: sha512-ycWpXDkUfnDFDY9d+4Qna/UZotDB0wj+s9agrlmNt0Q7a3XHORhK8GPKJdzgzeutXu9EW5P/jyabTEHlohuDXw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -3073,8 +3076,8 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/windows-arm64@2.10.9:
-    resolution: {integrity: sha512-W2Ub165Qv0iMFljbYKxxbZN+2dVSngnzEjQNEFXtnz5oJVx9XSypmNmUvMtuYMeZ3kdVC1zI7yd/rtuX+SDnbg==}
+  /@turbo/windows-arm64@2.10.10:
+    resolution: {integrity: sha512-PMk6zQN0csUFklLe+1hz/5G9uU1YmV0cEIey2R/bSeA6o69qcBTlN4A3jOqkgenOO5dOpMHmq2sEUZo8r1+Ssg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -5100,15 +5103,15 @@ packages:
       eslint: 8.57.1
     dev: true
 
-  /eslint-config-turbo@2.9.18(eslint@8.57.1)(turbo@2.10.9):
+  /eslint-config-turbo@2.9.18(eslint@8.57.1)(turbo@2.10.10):
     resolution: {integrity: sha512-zgbFkvM7+qoWxL/JJ7ytEEE5DHg/xsAv1qzzIAyQEYkROIMKk/0mBb3sjxF/qjHjOuwVF8ZYX2P014qLG/Ng9g==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
     dependencies:
       eslint: 8.57.1
-      eslint-plugin-turbo: 2.9.18(eslint@8.57.1)(turbo@2.10.9)
-      turbo: 2.10.9
+      eslint-plugin-turbo: 2.9.18(eslint@8.57.1)(turbo@2.10.10)
+      turbo: 2.10.10
     dev: true
 
   /eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0):
@@ -5520,7 +5523,7 @@ packages:
       '@microsoft/tsdoc-config': 0.16.2
     dev: true
 
-  /eslint-plugin-turbo@2.9.18(eslint@8.57.1)(turbo@2.10.9):
+  /eslint-plugin-turbo@2.9.18(eslint@8.57.1)(turbo@2.10.10):
     resolution: {integrity: sha512-WbvNDtwxyNQnX6ODtWs39EutD8a2Eoh25EgGkSqbqRpw8llHG/waCgBUwUUG7i1yh73d6p4HNBWEk+C+mvx9Xw==}
     peerDependencies:
       eslint: '>6.6.0'
@@ -5528,7 +5531,7 @@ packages:
     dependencies:
       dotenv: 16.0.3
       eslint: 8.57.1
-      turbo: 2.10.9
+      turbo: 2.10.10
     dev: true
 
   /eslint-plugin-unicorn@48.0.1(eslint@8.57.1):
@@ -9573,16 +9576,16 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /turbo@2.10.9:
-    resolution: {integrity: sha512-Yl9+ukxH+UmPtKidpDkjn82tvPoEvFNb9UACd9vUomN1Ft0cwl3rx0P8yC1D93W9EOsWRMjllvIDG8y25sFOog==}
+  /turbo@2.10.10:
+    resolution: {integrity: sha512-/90KTW+USzvYOPmafRZHVKLBsHXQ5810Ao/HdtJYAqguIhZ+XruS6eIUjqJUDtrSxaZYynNFht68qckGKAOWTA==}
     hasBin: true
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.9
-      '@turbo/darwin-arm64': 2.10.9
-      '@turbo/linux-64': 2.10.9
-      '@turbo/linux-arm64': 2.10.9
-      '@turbo/windows-64': 2.10.9
-      '@turbo/windows-arm64': 2.10.9
+      '@turbo/darwin-64': 2.10.10
+      '@turbo/darwin-arm64': 2.10.10
+      '@turbo/linux-64': 2.10.10
+      '@turbo/linux-arm64': 2.10.10
+      '@turbo/windows-64': 2.10.10
+      '@turbo/windows-arm64': 2.10.10
     dev: true
 
   /turbo@2.9.18:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,7 +336,7 @@ importers:
         version: 9.1.2(eslint@8.57.1)
       eslint-config-turbo:
         specifier: ^2.0.0
-        version: 2.9.18(eslint@8.57.1)(turbo@2.10.2)
+        version: 2.9.18(eslint@8.57.1)(turbo@2.10.9)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
         version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
@@ -400,9 +400,15 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.103.0
         version: 2.108.1
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       resend:
         specifier: ^6.9.4
         version: 6.12.4
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -2987,8 +2993,8 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@turbo/darwin-64@2.10.2:
-    resolution: {integrity: sha512-wBM3ObqOWnKUDmg7QfUFDkDHPFUAJmrYlYqmEM8jMPAPA/I6wRJIbWimeQUqhOiQ8xPKhzyWM+xaiUP0wz8FEQ==}
+  /@turbo/darwin-64@2.10.9:
+    resolution: {integrity: sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -3003,8 +3009,8 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/darwin-arm64@2.10.2:
-    resolution: {integrity: sha512-/Cq0joWnuMjDPfhjbFP4sv+C/7gkQ415zlaO4XUzD5EZxbtrKgXKvuuydMvogG8GeUnN1aDltW71RlmEfpjbyw==}
+  /@turbo/darwin-arm64@2.10.9:
+    resolution: {integrity: sha512-aqtpPkiIC4IUas8Vv27oJ3aDfTuP1d5wofd01dZ7gfhHRrIKuFdqQb4imvNnVFahcOViF9Jh8Oi7feDoz8/ciA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -3019,10 +3025,10 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/linux-64@2.10.2:
-    resolution: {integrity: sha512-mMsf5IIhiKuceEXNstd25IbadjBXZ0amxzFOqliEzJX6HyeeHdBQPVSY583PWqYDyqM/FB8d5ZjkthfBSeuH3Q==}
+  /@turbo/linux-64@2.10.9:
+    resolution: {integrity: sha512-XyAneUBsS5uNOUOjBSs81zyigMVwwhVUd3u7F2JFMKGQk6F7eNAiOEBASJ+aHLldjYsOEjhfW+5gWIqwziyFFw==}
     cpu: [x64]
-    os: [linux]
+    os: [android, linux]
     requiresBuild: true
     dev: true
     optional: true
@@ -3035,10 +3041,10 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/linux-arm64@2.10.2:
-    resolution: {integrity: sha512-Wcng1i2kaKmXutmwxT9MUoYZvdaIekXAdlGr4+0TpgbhGLw7nDuEcRBFrxb5BbRoX1d1q8SpdRxLc45TvDZIdQ==}
+  /@turbo/linux-arm64@2.10.9:
+    resolution: {integrity: sha512-5jAcldLnkuWIjujGhCn2MGIeUwW8IVNOq9Sce4EEzzgLcxmhTasbV0RiW6ZkaRdOjmOCGzeNXPLkDJEOIucOLw==}
     cpu: [arm64]
-    os: [linux]
+    os: [android, linux]
     requiresBuild: true
     dev: true
     optional: true
@@ -3051,8 +3057,8 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/windows-64@2.10.2:
-    resolution: {integrity: sha512-SsNhM7Ho7EpAdwtrJKBOic9Hso23vu6Dp0gAfLOvUFjPzurr/sGQlXZEvr6z89ne4RDOypTwz5CBDrixpMKtXw==}
+  /@turbo/windows-64@2.10.9:
+    resolution: {integrity: sha512-u1xGpGlefzuhBedbt/VR2nWdftfFVZwPeDg9e5uZl68sV1fL3HNYTNr5VyHkzgtPK2VTYg1x4OKZuGrh1Gvhtg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -3067,8 +3073,8 @@ packages:
     dev: true
     optional: true
 
-  /@turbo/windows-arm64@2.10.2:
-    resolution: {integrity: sha512-Gf+S7ICAdimT/n02bOuVWKvhHnct/HYjZg3oBNIz5hZ9ZyWHbQim9J3P5Qip8WpX0ksxF7eaBVziJCuLnjhqDg==}
+  /@turbo/windows-arm64@2.10.9:
+    resolution: {integrity: sha512-W2Ub165Qv0iMFljbYKxxbZN+2dVSngnzEjQNEFXtnz5oJVx9XSypmNmUvMtuYMeZ3kdVC1zI7yd/rtuX+SDnbg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -3848,7 +3854,7 @@ packages:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)
+      vitest: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4023,6 +4029,12 @@ packages:
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
     dev: true
+
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: false
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -5088,15 +5100,15 @@ packages:
       eslint: 8.57.1
     dev: true
 
-  /eslint-config-turbo@2.9.18(eslint@8.57.1)(turbo@2.10.2):
+  /eslint-config-turbo@2.9.18(eslint@8.57.1)(turbo@2.10.9):
     resolution: {integrity: sha512-zgbFkvM7+qoWxL/JJ7ytEEE5DHg/xsAv1qzzIAyQEYkROIMKk/0mBb3sjxF/qjHjOuwVF8ZYX2P014qLG/Ng9g==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
     dependencies:
       eslint: 8.57.1
-      eslint-plugin-turbo: 2.9.18(eslint@8.57.1)(turbo@2.10.2)
-      turbo: 2.10.2
+      eslint-plugin-turbo: 2.9.18(eslint@8.57.1)(turbo@2.10.9)
+      turbo: 2.10.9
     dev: true
 
   /eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0):
@@ -5508,7 +5520,7 @@ packages:
       '@microsoft/tsdoc-config': 0.16.2
     dev: true
 
-  /eslint-plugin-turbo@2.9.18(eslint@8.57.1)(turbo@2.10.2):
+  /eslint-plugin-turbo@2.9.18(eslint@8.57.1)(turbo@2.10.9):
     resolution: {integrity: sha512-WbvNDtwxyNQnX6ODtWs39EutD8a2Eoh25EgGkSqbqRpw8llHG/waCgBUwUUG7i1yh73d6p4HNBWEk+C+mvx9Xw==}
     peerDependencies:
       eslint: '>6.6.0'
@@ -5516,7 +5528,7 @@ packages:
     dependencies:
       dotenv: 16.0.3
       eslint: 8.57.1
-      turbo: 2.10.2
+      turbo: 2.10.9
     dev: true
 
   /eslint-plugin-unicorn@48.0.1(eslint@8.57.1):
@@ -5626,6 +5638,12 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
+  /esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
   /esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -5672,6 +5690,13 @@ packages:
 
   /exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  /extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extendable: 0.1.1
+    dev: false
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -6057,6 +6082,16 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+    dependencies:
+      js-yaml: 3.15.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+    dev: false
+
   /has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -6429,6 +6464,11 @@ packages:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
     dev: false
 
+  /is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -6684,6 +6724,14 @@ packages:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
     dev: true
 
+  /js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: false
+
   /js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -6789,6 +6837,11 @@ packages:
     dependencies:
       json-buffer: 3.0.1
     dev: true
+
+  /kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -8756,6 +8809,14 @@ packages:
   /scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  /section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+    dev: false
+
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -8961,6 +9022,10 @@ packages:
     engines: {node: '>= 10.x'}
     dev: true
 
+  /sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: false
+
   /stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
     dev: true
@@ -9094,6 +9159,11 @@ packages:
     dependencies:
       ansi-regex: 6.2.2
     dev: true
+
+  /strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -9503,16 +9573,16 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /turbo@2.10.2:
-    resolution: {integrity: sha512-wTExrNrRjB8qzIcg+ZLm0A3GFNLDsWNwdS/RBXB0FPrBDyzk3i96Yx+TxWZC7a0k1SIreFB8ciUbxjmEqTH8IQ==}
+  /turbo@2.10.9:
+    resolution: {integrity: sha512-Yl9+ukxH+UmPtKidpDkjn82tvPoEvFNb9UACd9vUomN1Ft0cwl3rx0P8yC1D93W9EOsWRMjllvIDG8y25sFOog==}
     hasBin: true
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.2
-      '@turbo/darwin-arm64': 2.10.2
-      '@turbo/linux-64': 2.10.2
-      '@turbo/linux-arm64': 2.10.2
-      '@turbo/windows-64': 2.10.2
-      '@turbo/windows-arm64': 2.10.2
+      '@turbo/darwin-64': 2.10.9
+      '@turbo/darwin-arm64': 2.10.9
+      '@turbo/linux-64': 2.10.9
+      '@turbo/linux-arm64': 2.10.9
+      '@turbo/windows-64': 2.10.9
+      '@turbo/windows-arm64': 2.10.9
     dev: true
 
   /turbo@2.9.18:


### PR DESCRIPTION
## Summary
- Implements `FileSystemBlogPostRepository` and `BlogPostMapper` in `packages/infra`, reading blog posts from a `content/posts/<slug>/` directory structure (`meta.json` + per-locale `.mdx` frontmatter/content), validated with Zod schemas and mapped to the domain `BlogPost` aggregate.
- Constructor accepts an arbitrary `contentDir`, so `apps/blog` (task 17) can wire in the real content path without any repository changes, and tests can run against fixtures in isolation.
- Adds fixture-directory-based integration tests covering `findAll` sort order and `findBySlug` happy path plus error cases (missing locale, malformed meta.json, malformed frontmatter).

## Test plan
- [x] `pnpm --filter @repo/infra exec vitest run test/repositories/blog` — 8/8 tests passing
- [x] `pnpm --filter @repo/infra lint:check` — clean
- [x] `pnpm --filter @repo/infra types` — clean
- [x] Pre-commit/pre-push hooks (format, lint, types, build) passed

Refs #946