### PR TITLE
fix(infra): include test files in tsconfig.json

### DIFF
--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -8,6 +8,6 @@
       "~/*": ["*"]
     }
   },
-  "include": ["src/**/*.ts", "prisma/**/*.ts"],
+  "include": ["src/**/*.ts", "prisma/**/*.ts", "test/**/*.ts"],
   "exclude": ["node_modules", "dist", "build"]
 }


### PR DESCRIPTION
## Summary
- `packages/infra/tsconfig.json` was missing `test/**/*.ts` in `include`, unlike `packages/core` and `packages/application`, which both include it.
- Editors (Cursor/VS Code) open files outside any tsconfig's `include` as an inferred/orphan project without the package's compiler options or `@types`, which surfaced as false "cannot find module" errors on Node builtin imports in `packages/infra/test/**`.
- `tsc --build`/CLI type-checking was never affected (it uses `tsconfig.build.json`, which is unaffected) — this is purely an editor-experience fix.

## Test plan
- [x] `pnpm --filter @repo/infra lint:check` — clean
- [x] `pnpm --filter @repo/infra types` — clean
- [x] `pnpm --filter @repo/infra test` — clean
- [x] Pre-commit hooks (format, lint, test, types, commitlint) passed