### PR TITLE
fix(core): add missing DomainError codes to ERROR_MESSAGE dictionary

### DIFF
--- a/packages/core/src/shared/i18n/ERROR_MESSAGE.ts
+++ b/packages/core/src/shared/i18n/ERROR_MESSAGE.ts
@@ -56,6 +56,30 @@ export const ERROR_MESSAGE: Record<Locale, ErrorMessageMap> = {
     INTERNAL_ERROR: {
       message: 'An unexpected error occurred. Please try again later.',
     },
+
+    // Operation failures (repository / use case level)
+    FETCH_FAILED: { message: 'Failed to fetch the requested data.' },
+    SAVE_FAILED: { message: 'Failed to save the data.' },
+    DELETE_FAILED: { message: 'Failed to delete the resource.' },
+    INVALID_INPUT: { message: 'Invalid input.' },
+
+    // Identity / auth session
+    INVALID_AUTH_SUBJECT: { message: 'Invalid authentication subject.' },
+    ENSURE_USER_FAILED: { message: 'Failed to ensure the user account.' },
+    USER_CREATION_FAILED: { message: 'Failed to create the user account.' },
+    AUTH_UNEXPECTED_ERROR: {
+      message: 'An unexpected authentication error occurred.',
+    },
+    INVALID_CREDENTIALS: { message: 'Invalid email or password.' },
+    INVALID_ACCESS_TOKEN: { message: 'Access token is invalid or expired.' },
+    INVALID_REFRESH_TOKEN: {
+      message: 'Refresh token is invalid or expired.',
+    },
+    NO_ACCESS_TOKEN: { message: 'No access token found in the session.' },
+    NO_REFRESH_TOKEN: { message: 'No refresh token found in the session.' },
+
+    // Notifications
+    EMAIL_SEND_FAILED: { message: 'Failed to send the email.' },
   },
 
   'pt-BR': {
@@ -117,6 +141,36 @@ export const ERROR_MESSAGE: Record<Locale, ErrorMessageMap> = {
     INTERNAL_ERROR: {
       message: 'Ocorreu um erro inesperado. Por favor, tente novamente.',
     },
+
+    // Operation failures (repository / use case level)
+    FETCH_FAILED: { message: 'Falha ao buscar os dados solicitados.' },
+    SAVE_FAILED: { message: 'Falha ao salvar os dados.' },
+    DELETE_FAILED: { message: 'Falha ao excluir o recurso.' },
+    INVALID_INPUT: { message: 'Entrada inválida.' },
+
+    // Identity / auth session
+    INVALID_AUTH_SUBJECT: { message: 'Sujeito de autenticação inválido.' },
+    ENSURE_USER_FAILED: { message: 'Falha ao garantir a conta do usuário.' },
+    USER_CREATION_FAILED: { message: 'Falha ao criar a conta do usuário.' },
+    AUTH_UNEXPECTED_ERROR: {
+      message: 'Ocorreu um erro inesperado de autenticação.',
+    },
+    INVALID_CREDENTIALS: { message: 'E-mail ou senha inválidos.' },
+    INVALID_ACCESS_TOKEN: {
+      message: 'Token de acesso inválido ou expirado.',
+    },
+    INVALID_REFRESH_TOKEN: {
+      message: 'Token de atualização inválido ou expirado.',
+    },
+    NO_ACCESS_TOKEN: {
+      message: 'Nenhum token de acesso encontrado na sessão.',
+    },
+    NO_REFRESH_TOKEN: {
+      message: 'Nenhum token de atualização encontrado na sessão.',
+    },
+
+    // Notifications
+    EMAIL_SEND_FAILED: { message: 'Falha ao enviar o e-mail.' },
   },
 
   es: {
@@ -179,6 +233,40 @@ export const ERROR_MESSAGE: Record<Locale, ErrorMessageMap> = {
     INTERNAL_ERROR: {
       message: 'Ocurrió un error inesperado. Por favor, inténtelo de nuevo.',
     },
+
+    // Operation failures (repository / use case level)
+    FETCH_FAILED: { message: 'Error al obtener los datos solicitados.' },
+    SAVE_FAILED: { message: 'Error al guardar los datos.' },
+    DELETE_FAILED: { message: 'Error al eliminar el recurso.' },
+    INVALID_INPUT: { message: 'Entrada inválida.' },
+
+    // Identity / auth session
+    INVALID_AUTH_SUBJECT: { message: 'Sujeto de autenticación inválido.' },
+    ENSURE_USER_FAILED: {
+      message: 'Error al garantizar la cuenta del usuario.',
+    },
+    USER_CREATION_FAILED: { message: 'Error al crear la cuenta del usuario.' },
+    AUTH_UNEXPECTED_ERROR: {
+      message: 'Ocurrió un error de autenticación inesperado.',
+    },
+    INVALID_CREDENTIALS: {
+      message: 'Correo electrónico o contraseña inválidos.',
+    },
+    INVALID_ACCESS_TOKEN: {
+      message: 'El token de acceso es inválido o ha expirado.',
+    },
+    INVALID_REFRESH_TOKEN: {
+      message: 'El token de actualización es inválido o ha expirado.',
+    },
+    NO_ACCESS_TOKEN: {
+      message: 'No se encontró un token de acceso en la sesión.',
+    },
+    NO_REFRESH_TOKEN: {
+      message: 'No se encontró un token de actualización en la sesión.',
+    },
+
+    // Notifications
+    EMAIL_SEND_FAILED: { message: 'Error al enviar el correo electrónico.' },
   },
 };
 

--- a/packages/core/test/shared/i18n/ERROR_MESSAGE.test.ts
+++ b/packages/core/test/shared/i18n/ERROR_MESSAGE.test.ts
@@ -1,6 +1,42 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { ERROR_MESSAGE, getErrorMessage } from '../../../src/shared/i18n/ERROR_MESSAGE';
+
+import {
+  ERROR_MESSAGE,
+  getErrorMessage,
+} from '../../../src/shared/i18n/ERROR_MESSAGE';
 import { LOCALES } from '../../../src/shared/i18n/Locale';
+
+const DOMAIN_ERROR_SRC_ROOTS = [
+  join(__dirname, '../../../src'),
+  join(__dirname, '../../../../application/src'),
+  join(__dirname, '../../../../infra/src'),
+];
+
+function collectTsFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) return collectTsFiles(fullPath);
+    return entry.name.endsWith('.ts') ? [fullPath] : [];
+  });
+}
+
+function findDomainErrorCodesInUse(): Set<string> {
+  const codes = new Set<string>();
+  const pattern = /new DomainError\(\s*'([A-Z_]+)'/g;
+
+  for (const root of DOMAIN_ERROR_SRC_ROOTS) {
+    for (const file of collectTsFiles(root)) {
+      const content = readFileSync(file, 'utf-8');
+      for (const match of content.matchAll(pattern)) {
+        codes.add(match[1]!);
+      }
+    }
+  }
+
+  return codes;
+}
 
 const ALL_CODES = [
   'INVALID_SLUG',
@@ -30,9 +66,37 @@ const ALL_CODES = [
   'AUTH_INVALID_CREDENTIALS',
   'AUTH_SUBJECT_CONFLICT',
   'INTERNAL_ERROR',
+  'FETCH_FAILED',
+  'SAVE_FAILED',
+  'DELETE_FAILED',
+  'INVALID_INPUT',
+  'INVALID_AUTH_SUBJECT',
+  'ENSURE_USER_FAILED',
+  'USER_CREATION_FAILED',
+  'AUTH_UNEXPECTED_ERROR',
+  'INVALID_CREDENTIALS',
+  'INVALID_ACCESS_TOKEN',
+  'INVALID_REFRESH_TOKEN',
+  'NO_ACCESS_TOKEN',
+  'NO_REFRESH_TOKEN',
+  'EMAIL_SEND_FAILED',
 ] as const;
 
 describe('ERROR_MESSAGE', () => {
+  describe('regression guard', () => {
+    it('should have a dictionary entry for every DomainError code thrown in core/application/infra source', () => {
+      const codesInUse = findDomainErrorCodesInUse();
+      const missing = [...codesInUse].filter(
+        (code) => !ERROR_MESSAGE['en-US'][code],
+      );
+
+      expect(
+        missing,
+        `Codes thrown via "new DomainError(...)" but missing from ERROR_MESSAGE: ${missing.join(', ')}`,
+      ).toEqual([]);
+    });
+  });
+
   describe('dictionary completeness', () => {
     it.each(LOCALES)('should have entries for all codes in %s', (locale) => {
       for (const code of ALL_CODES) {


### PR DESCRIPTION
## Summary
- `toErrorDTO` (`packages/application/src/shared/ErrorDTO.ts`) falls back to the raw `error.message` (hardcoded English at the throw site) whenever a `DomainError` code has no entry in `ERROR_MESSAGE`. Several codes thrown across `packages/application` and `packages/infra` had no entry, so pt-BR/es API responses could leak untranslated English.
- Adds 14 missing codes to `ERROR_MESSAGE.ts` (en-US/pt-BR/es): `FETCH_FAILED`, `SAVE_FAILED`, `DELETE_FAILED`, `INVALID_INPUT`, `INVALID_AUTH_SUBJECT`, `ENSURE_USER_FAILED`, `USER_CREATION_FAILED`, `AUTH_UNEXPECTED_ERROR`, `INVALID_CREDENTIALS`, `INVALID_ACCESS_TOKEN`, `INVALID_REFRESH_TOKEN`, `NO_ACCESS_TOKEN`, `NO_REFRESH_TOKEN`, `EMAIL_SEND_FAILED`.
- Adds a regression-guard test in `ERROR_MESSAGE.test.ts` that statically scans `core`/`application`/`infra` source for `new DomainError('CODE'` usages and fails if any code is missing from the dictionary, so this can't silently reappear.

## Test plan
- [x] `pnpm --filter @repo/core exec vitest run test/shared/i18n/ERROR_MESSAGE.test.ts` — 11/11 passing (including new regression guard)
- [x] `pnpm --filter @repo/application exec vitest run` — 176/176 passing
- [x] `pnpm format:check` / `pnpm lint:check` / `pnpm types` — clean across the monorepo
- [x] Pre-commit/pre-push hooks passed

Refs #948