### PR TITLE
docs: fix gh issue develop base + add issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,31 @@
+---
+name: Bug
+about: Defect found in existing code — during review, testing, or production
+title: ""
+---
+
+## Problem
+
+<!-- What's wrong, and where. Quote the relevant code/behavior. -->
+
+## Evidence
+
+<!-- How this was found: failing test, grep output, review of a specific PR, a
+     reproduction snippet. Include concrete examples (input → wrong output). -->
+
+## Fix
+
+<!-- Concrete proposed fix — file(s) to touch, pattern to follow (mirror an
+     existing correct example when one exists). Include test-coverage plan. -->
+
+## Context
+
+<!-- Where this was discovered (e.g. "surfaced during review of PR #NNN"),
+     whether it blocks other work, and any scope boundary (e.g. "not specific
+     to X — also affects Y" or "filed as a follow-up, not blocking"). -->
+
+---
+<!--
+Apply labels manually from `gh label list` — at minimum `type: fix` plus the
+relevant `layer: *`/`context: *` label, and `priority: *` if urgency is known.
+-->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,13 +1,12 @@
 ---
 name: Task
-about: Feature, refactor, fix, or chore tracked by Task Master
+about: Planned feature, refactor, or chore tracked by Task Master
 title: "[T-XX] "
-labels: "mvp, priority: medium"
 ---
 
 ## Context
 
-<!-- Why does this task exist? What motivates the change? -->
+<!-- Why does this task exist? What motivates the change? Link the Task Master task ID and/or parent PRD issue if any. -->
 
 ## Acceptance criteria
 
@@ -21,5 +20,12 @@ labels: "mvp, priority: medium"
 
 ## Dependencies
 
-<!-- Issues or PRs that must be completed before this one -->
+<!-- Issues or PRs that must be completed before this one, or "None - can start immediately" -->
 - #
+
+---
+<!--
+Apply labels manually from `gh label list` — there is no single correct default:
+at minimum a `type: *` and a `layer: *`/`context: *` label; add `priority: *` and
+`mvp`/`post-mvp` when scope/urgency is known. Do not rely on a fixed label set.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+<!-- 1-3 bullet points: what changed and why, not a file-by-file diff narration -->
+-
+
+## Test plan
+<!-- Checklist of commands actually run for this PR, e.g.:
+- [ ] `pnpm --filter <pkg> test` — passing
+- [ ] `pnpm --filter <pkg> lint:check` — clean
+- [ ] `pnpm --filter <pkg> types` — clean
+-->
+-
+
+<!-- Refs #<issue-number> for PRs targeting develop (this repo's default flow).
+     Closes #<issue-number> only for PRs targeting main/master. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,14 @@
 -
 
 ## Test plan
-<!-- Checklist of commands actually run for this PR, e.g.:
+<!-- Not just automated commands — whatever combination actually verifies this
+     change: commands run, manual/browser verification when there's a UI or
+     user-facing flow involved, and anything else needed to confirm it works.
+     e.g.:
 - [ ] `pnpm --filter <pkg> test` — passing
 - [ ] `pnpm --filter <pkg> lint:check` — clean
 - [ ] `pnpm --filter <pkg> types` — clean
+- [ ] Manually verified in the browser: <flow/page tested, what was checked>
 -->
 -
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ interface IProjectRepository {
 2. **Verify work not done** — check: (a) `gh issue view <n>` — if closed, stop; (b) merged PRs; (c) git log; (d) existing branches
 3. **Set Task Master to In Progress**: `task-master set-status --id=<id> --status=in-progress`
 4. **Move GitHub issue to "In Progress"** in all linked Project boards
-5. **Create branch from issue**: `gh issue develop <issue-number> --checkout` — **immediately rebase onto develop**: `git rebase origin/develop` (`gh issue develop` uses the repo default branch, not `develop`)
+5. **Create branch from issue**: `gh issue develop <issue-number> --base develop --checkout` — always pass `--base develop` explicitly; without it, `gh issue develop` bases the branch on the repo's default branch (`master`), not `develop`. If a branch was already created without `--base develop` and has diverged from its remote after a manual rebase, do **not** force-push — delete the remote branch and push the local one fresh (`git push origin --delete <branch>` then `git push -u origin <branch>`), but note this breaks the issue's linked-branch relationship, so prefer `--base develop` from the start
 6. **Implement** — code, tests, commits
 7. **Open PR against `develop`**: `gh pr create --base develop`
 8. **Set Task Master to Done**: `task-master set-status --id=<id> --status=done`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,13 +188,14 @@ interface IProjectRepository {
 
 ### Issue → Branch → PR Protocol
 
+0. **If no GitHub issue exists yet** for this work (e.g. a defect surfaced during review, or a Task Master task never turned into an issue), create one first with `gh issue create`, following `.github/ISSUE_TEMPLATE/task.md` (planned feature/refactor/chore) or `.github/ISSUE_TEMPLATE/bug.md` (defect found in existing code) — do not free-form the body structure. Apply labels from `gh label list` (at minimum a `type: *` and a `layer: *`/`context: *` label); there is no fixed default set, judge per issue.
 1. **Confirm task** — ensure it exists in Task Master under the correct Sprint tag
 2. **Verify work not done** — check: (a) `gh issue view <n>` — if closed, stop; (b) merged PRs; (c) git log; (d) existing branches
 3. **Set Task Master to In Progress**: `task-master set-status --id=<id> --status=in-progress`
 4. **Move GitHub issue to "In Progress"** in all linked Project boards
 5. **Create branch from issue**: `gh issue develop <issue-number> --base develop --checkout` — always pass `--base develop` explicitly; without it, `gh issue develop` bases the branch on the repo's default branch (`master`), not `develop`. If a branch was already created without `--base develop` and has diverged from its remote after a manual rebase, do **not** force-push — delete the remote branch and push the local one fresh (`git push origin --delete <branch>` then `git push -u origin <branch>`), but note this breaks the issue's linked-branch relationship, so prefer `--base develop` from the start
 6. **Implement** — code, tests, commits
-7. **Open PR against `develop`**: `gh pr create --base develop`
+7. **Open PR against `develop`**: `gh pr create --base develop`, following the structure in `.github/PULL_REQUEST_TEMPLATE.md` (`## Summary` bullets + `## Test plan` checklist of commands actually run + `Refs #N` trailer)
 8. **Set Task Master to Done**: `task-master set-status --id=<id> --status=done`
 9. **Commit Task Master status to git**: create branch `chore/update-task-<N>-status-done` from `develop`, commit `.taskmaster/tasks/tasks.json`, open PR against `develop`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ interface IProjectRepository {
 4. **Move GitHub issue to "In Progress"** in all linked Project boards
 5. **Create branch from issue**: `gh issue develop <issue-number> --base develop --checkout` — always pass `--base develop` explicitly; without it, `gh issue develop` bases the branch on the repo's default branch (`master`), not `develop`. If a branch was already created without `--base develop` and has diverged from its remote after a manual rebase, do **not** force-push — delete the remote branch and push the local one fresh (`git push origin --delete <branch>` then `git push -u origin <branch>`), but note this breaks the issue's linked-branch relationship, so prefer `--base develop` from the start
 6. **Implement** — code, tests, commits
-7. **Open PR against `develop`**: `gh pr create --base develop`, following the structure in `.github/PULL_REQUEST_TEMPLATE.md` (`## Summary` bullets + `## Test plan` checklist of commands actually run + `Refs #N` trailer)
+7. **Open PR against `develop`**: `gh pr create --base develop`, following the structure in `.github/PULL_REQUEST_TEMPLATE.md` (`## Summary` bullets + `## Test plan` — commands actually run **and**, when there's a UI/user-facing flow, manual/browser verification, not automated commands alone — + `Refs #N` trailer)
 8. **Set Task Master to Done**: `task-master set-status --id=<id> --status=done`
 9. **Commit Task Master status to git**: create branch `chore/update-task-<N>-status-done` from `develop`, commit `.taskmaster/tasks/tasks.json`, open PR against `develop`
 

--- a/docs/01-GETTING-STARTED.md
+++ b/docs/01-GETTING-STARTED.md
@@ -103,7 +103,7 @@ Follow this sequence for every piece of work, without exception:
 2. **Verify the work hasn't already been done** — check the issue state, merged PRs, and existing branches before writing any code.
 3. **Set Task Master status to In Progress**: `task-master set-status --id=<id> --status=in-progress`
 4. **Move the GitHub issue to "In Progress"** in all linked Project boards.
-5. **Create the branch from the issue**: `gh issue develop <issue-number> --checkout` — **immediately rebase onto develop**: `git rebase origin/develop` (`gh issue develop` uses the repo default branch, not `develop`)
+5. **Create the branch from the issue**: `gh issue develop <issue-number> --base develop --checkout` — always pass `--base develop` explicitly; without it, `gh issue develop` bases the branch on the repo's default branch (`master`), not `develop`
 6. **Implement** — code, tests, commits.
 7. **Open PR against `develop`**: `gh pr create --base develop`
 8. **Set Task Master status to Done**: `task-master set-status --id=<id> --status=done`

--- a/docs/01-GETTING-STARTED.md
+++ b/docs/01-GETTING-STARTED.md
@@ -99,13 +99,14 @@ Turborepo handles this automatically via `dependsOn` in `turbo.json`.
 
 Follow this sequence for every piece of work, without exception:
 
+0. **If no GitHub issue exists yet**, create one with `gh issue create` following `.github/ISSUE_TEMPLATE/task.md` (planned work) or `.github/ISSUE_TEMPLATE/bug.md` (defect found in existing code) — don't free-form the body. Apply labels from `gh label list`.
 1. **Confirm the task exists in Task Master** under the correct Sprint tag (`task-master tags use sprint-X`).
 2. **Verify the work hasn't already been done** — check the issue state, merged PRs, and existing branches before writing any code.
 3. **Set Task Master status to In Progress**: `task-master set-status --id=<id> --status=in-progress`
 4. **Move the GitHub issue to "In Progress"** in all linked Project boards.
 5. **Create the branch from the issue**: `gh issue develop <issue-number> --base develop --checkout` — always pass `--base develop` explicitly; without it, `gh issue develop` bases the branch on the repo's default branch (`master`), not `develop`
 6. **Implement** — code, tests, commits.
-7. **Open PR against `develop`**: `gh pr create --base develop`
+7. **Open PR against `develop`**: `gh pr create --base develop`, following `.github/PULL_REQUEST_TEMPLATE.md` (`## Summary` + `## Test plan` + `Refs #N`)
 8. **Set Task Master status to Done**: `task-master set-status --id=<id> --status=done`
 9. **Commit Task Master status to git**: create branch `chore/update-task-<N>-status-done` from `develop`, commit `.taskmaster/tasks/tasks.json`, open PR against `develop`
 

--- a/docs/01-GETTING-STARTED.md
+++ b/docs/01-GETTING-STARTED.md
@@ -106,7 +106,7 @@ Follow this sequence for every piece of work, without exception:
 4. **Move the GitHub issue to "In Progress"** in all linked Project boards.
 5. **Create the branch from the issue**: `gh issue develop <issue-number> --base develop --checkout` — always pass `--base develop` explicitly; without it, `gh issue develop` bases the branch on the repo's default branch (`master`), not `develop`
 6. **Implement** — code, tests, commits.
-7. **Open PR against `develop`**: `gh pr create --base develop`, following `.github/PULL_REQUEST_TEMPLATE.md` (`## Summary` + `## Test plan` + `Refs #N`)
+7. **Open PR against `develop`**: `gh pr create --base develop`, following `.github/PULL_REQUEST_TEMPLATE.md` (`## Summary` + `## Test plan` — commands run plus manual/browser verification when there's a UI flow involved + `Refs #N`)
 8. **Set Task Master status to Done**: `task-master set-status --id=<id> --status=done`
 9. **Commit Task Master status to git**: create branch `chore/update-task-<N>-status-done` from `develop`, commit `.taskmaster/tasks/tasks.json`, open PR against `develop`
 


### PR DESCRIPTION
## Summary
- Step 5 of the Issue → Branch → PR protocol now uses `gh issue develop <n> --base develop --checkout`. Without `--base develop`, the branch is created from the repo's default branch (`master`), forcing a rebase onto `develop` afterward; that rebase can diverge the local branch from its remote counterpart, and the previous fix (delete + recreate the remote branch) silently breaks the issue's GitHub "linked branch" relationship — confirmed via `gh api graphql` on issue #951, whose branch lost its `linkedBranches` entry after a delete+recreate.
- `.github/ISSUE_TEMPLATE/task.md`: dropped the hardcoded default labels (`mvp, priority: medium`), which didn't fit most issues — labels are now applied per issue from `gh label list`.
- New `.github/ISSUE_TEMPLATE/bug.md`: for defects found in existing code (Problem/Evidence/Fix/Context) — issues #948 and #951 both used ad-hoc headers instead of any template because `task.md`'s Context/Acceptance-criteria shape doesn't fit a "bug found during review" report.
- New `.github/PULL_REQUEST_TEMPLATE.md`: captures the Summary/Test-plan/Refs shape every PR in this repo already converges on by habit, so `gh pr create` picks it up as the default body.
- `CLAUDE.md` and `docs/01-GETTING-STARTED.md` updated to reference both templates explicitly in the protocol.

## Test plan
- Docs-only change, no code affected.

Refs #951