### PR TITLE
feat(blog): pin explicit rehype-pretty-code theme and keepBackground

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1159,8 +1159,9 @@
         "dependencies": [
           "18"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-08-17T01:50:02.976Z"
       },
       {
         "id": "20",
@@ -1208,9 +1209,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-08-17T01:04:18.158Z",
+      "lastModified": "2026-08-17T01:50:02.976Z",
       "taskCount": 22,
-      "completedCount": 18,
+      "completedCount": 19,
       "tags": [
         "master"
       ]

--- a/apps/blog/src/app/[locale]/[slug]/page.tsx
+++ b/apps/blog/src/app/[locale]/[slug]/page.tsx
@@ -13,9 +13,14 @@ import { buildOpenGraph } from '~/lib/seo/openGraph';
 import { getServerContainer } from '~/lib/server/container';
 import { mdxComponents } from '~/mdx-components';
 
+const rehypePrettyCodePlugin: [
+  typeof rehypePrettyCode,
+  { theme: string; keepBackground: boolean },
+] = [rehypePrettyCode, { theme: 'github-dark', keepBackground: true }];
+
 const MDX_OPTIONS = {
   mdxOptions: {
-    rehypePlugins: [rehypePrettyCode],
+    rehypePlugins: [rehypePrettyCodePlugin],
   },
 };
 


### PR DESCRIPTION
## Summary
- Most of Task Master task 19's scope already shipped in #954 (PR #955): `next-mdx-remote`, `rehype-pretty-code`, `shiki` installed; `rehypePrettyCode` wired into `MDXRemote`; `FileSystemBlogPostRepository` already stores raw (uncompiled) MDX in `BlogPost.content`.
- The one remaining gap: `rehypePrettyCode` ran with implicit library defaults, no pinned theme. Now explicit `{ theme: 'github-dark', keepBackground: true }`, so rendering doesn't silently change if the dependency's default theme changes on a future bump.

## Test plan
- [x] `pnpm --filter blog test` — 10/10 passing
- [x] `pnpm --filter blog lint:check` — clean (pre-existing warning patterns)
- [x] `pnpm --filter blog types` — clean
- [x] `pnpm --filter blog build` — SSG succeeds
- [x] Manually verified in the browser (`next dev -p 3002`): `/blog/en-US/the-either-pattern-in-typescript` still renders every code block with syntax highlighting, no console errors

Refs #956