### PR TITLE
feat(blog): implement per-locale RSS feeds as Route Handlers

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1174,8 +1174,9 @@
           "15",
           "17"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-08-17T02:07:39.994Z"
       },
       {
         "id": "21",
@@ -1209,9 +1210,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-08-17T01:50:02.976Z",
+      "lastModified": "2026-08-17T02:07:39.994Z",
       "taskCount": 22,
-      "completedCount": 19,
+      "completedCount": 20,
       "tags": [
         "master"
       ]

--- a/apps/blog/src/app/[locale]/layout.tsx
+++ b/apps/blog/src/app/[locale]/layout.tsx
@@ -1,7 +1,10 @@
-import { LOCALES } from '@repo/core/shared';
+import { type Locale, LOCALES } from '@repo/core/shared';
+import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { Inter } from 'next/font/google';
+
+import { buildAlternates } from '~/lib/seo/alternates';
 
 import '@repo/tailwind-config/tailwind.css';
 import '@repo/ui/globals.css';
@@ -10,6 +13,18 @@ const inter = Inter({ subsets: ['latin'], display: 'swap' });
 
 export function generateStaticParams() {
   return LOCALES.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+
+  return {
+    alternates: buildAlternates('', locale as Locale),
+  };
 }
 
 export default async function RootLayout({

--- a/apps/blog/src/app/[locale]/rss.xml/route.ts
+++ b/apps/blog/src/app/[locale]/rss.xml/route.ts
@@ -1,0 +1,72 @@
+import { ListBlogPosts } from '@repo/application/blog';
+import type { Locale } from '@repo/core/shared';
+import { LOCALES } from '@repo/core/shared';
+import { getTranslations } from 'next-intl/server';
+
+import { env } from '~/config/env';
+import { getServerContainer } from '~/lib/server/container';
+
+export const dynamic = 'force-static';
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function generateStaticParams() {
+  return LOCALES.map((locale) => ({ locale }));
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ locale: string }> },
+): Promise<Response> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Metadata' });
+
+  const result = await new ListBlogPosts(
+    getServerContainer().blogPostRepository,
+  ).execute({ locale: locale as Locale });
+
+  if (result.isLeft()) {
+    return new Response('Failed to generate RSS feed', { status: 500 });
+  }
+
+  const posts = result.value;
+
+  const items = posts
+    .map(
+      (post) => `
+    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${env.siteUrl}/blog/${locale}/${escapeXml(post.slug)}</link>
+      <description>${escapeXml(post.description)}</description>
+      <guid isPermaLink="true">${env.siteUrl}/blog/${locale}/${escapeXml(post.slug)}</guid>
+      <pubDate>${new Date(post.publishedAt).toUTCString()}</pubDate>
+    </item>`,
+    )
+    .join('');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Wallace Ferreira — Blog</title>
+    <link>${env.siteUrl}/blog/${locale}</link>
+    <description>${escapeXml(t('description'))}</description>
+    <language>${locale}</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${env.siteUrl}/blog/${locale}/rss.xml" rel="self" type="application/rss+xml"/>
+    ${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+}

--- a/apps/blog/src/app/robots.ts
+++ b/apps/blog/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+import { env } from '~/config/env';
+
+export const dynamic = 'force-static';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: `${env.siteUrl}/blog/sitemap.xml`,
+  };
+}

--- a/apps/blog/src/lib/seo/alternates.ts
+++ b/apps/blog/src/lib/seo/alternates.ts
@@ -3,17 +3,24 @@ import { DEFAULT_LOCALE, LOCALES } from '@repo/core/shared';
 
 import { env } from '~/config/env';
 
-import type { HreflangMap, Pathname } from './types';
+import type { HreflangMap, Pathname, RssTypeMap } from './types';
 
 /**
  * `basePath: '/blog'` in next.config.mjs only prefixes framework-relative
  * URLs (Link, redirect, static assets) — absolute URLs built manually for
  * metadata (canonical, alternates, openGraph) need '/blog' applied here.
+ *
+ * The RSS `types` entry lives here, not in a separate call site, because
+ * Next.js does not deep-merge `alternates` between layout and page
+ * metadata — whichever generateMetadata runs last fully replaces it. Every
+ * page calls buildAlternates for canonical/hreflang anyway, so folding the
+ * feed link in here guarantees it survives regardless of which metadata
+ * "wins".
  */
 export function buildAlternates(
   pathname: Pathname,
   locale: Locale,
-): { canonical: string; languages: HreflangMap } {
+): { canonical: string; languages: HreflangMap; types: RssTypeMap } {
   const languages = LOCALES.reduce<HreflangMap>(
     (acc, loc) => {
       acc[loc] = `${env.siteUrl}/blog/${loc}${pathname}`;
@@ -27,5 +34,13 @@ export function buildAlternates(
   return {
     canonical: `${env.siteUrl}/blog/${locale}${pathname}`,
     languages,
+    types: {
+      'application/rss+xml': [
+        {
+          url: `${env.siteUrl}/blog/${locale}/rss.xml`,
+          title: 'Wallace Ferreira — Blog',
+        },
+      ],
+    },
   };
 }

--- a/apps/blog/src/lib/seo/types.ts
+++ b/apps/blog/src/lib/seo/types.ts
@@ -2,9 +2,14 @@ import type { Locale } from '@repo/core/shared';
 
 /**
  * Locale-agnostic path used to build alternates/canonical URLs,
- * e.g. '', '/hello-blog'. Does not include the '/blog' basePath — that's
- * prepended by buildAlternates/buildOpenGraph.
+ * e.g. '', '/the-either-pattern-in-typescript'. Does not include the
+ * '/blog' basePath — that's prepended by buildAlternates/buildOpenGraph.
  */
 export type Pathname = string;
 
 export type HreflangMap = Record<Locale | 'x-default', string>;
+
+export type RssTypeMap = Record<
+  'application/rss+xml',
+  { url: string; title: string }[]
+>;

--- a/apps/blog/test/app/[locale]/rss.xml/route.test.ts
+++ b/apps/blog/test/app/[locale]/rss.xml/route.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BlogPost } from '@repo/core/blog';
+
+import { GET } from '~/app/[locale]/rss.xml/route';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async () => (key: string) =>
+    ({ description: 'Technical articles.' })[key],
+}));
+
+const findAll = vi.fn();
+
+vi.mock('~/lib/server/container', () => ({
+  getServerContainer: () => ({
+    blogPostRepository: { findAll: () => findAll(), findBySlug: vi.fn() },
+  }),
+}));
+
+function makePost(slug: string, title: string, publishedAt: string): BlogPost {
+  const localized = (value: string) => ({
+    'en-US': value,
+    'pt-BR': value,
+    es: value,
+  });
+  const result = BlogPost.create({
+    slug,
+    title: localized(title),
+    description: localized(`${title} description`),
+    content: { 'en-US': '# Body', 'pt-BR': '# Corpo', es: '# Cuerpo' },
+    tags: ['nextjs'],
+    publishedAt,
+  });
+  if (result.isLeft()) throw result.value;
+  return result.value;
+}
+
+function makeRequest(locale: string): {
+  request: Request;
+  context: { params: Promise<{ locale: string }> };
+} {
+  return {
+    request: new Request(`http://localhost:3002/blog/${locale}/rss.xml`),
+    context: { params: Promise.resolve({ locale }) },
+  };
+}
+
+describe('GET /blog/[locale]/rss.xml', () => {
+  it('should return valid RSS 2.0 XML with an item per post', async () => {
+    findAll.mockResolvedValue([
+      makePost('hello', 'Hello', '2026-08-01'),
+    ]);
+
+    const { request, context } = makeRequest('en-US');
+    const response = await GET(request, context);
+    const xml = await response.text();
+
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/xml; charset=utf-8',
+    );
+    expect(xml).toContain('<rss version="2.0"');
+    expect(xml).toContain('<title>Hello</title>');
+    expect(xml).toContain(
+      '<link>http://localhost:3002/blog/en-US/hello</link>',
+    );
+    expect(xml).toContain('<pubDate>');
+  });
+
+  it('should only include posts for the requested locale', async () => {
+    findAll.mockResolvedValue([makePost('only-en', 'Only EN', '2026-08-01')]);
+
+    const { request, context } = makeRequest('pt-BR');
+    const response = await GET(request, context);
+    const xml = await response.text();
+
+    expect(xml).toContain('<language>pt-BR</language>');
+    expect(xml).toContain(
+      '<link>http://localhost:3002/blog/pt-BR/only-en</link>',
+    );
+  });
+
+  it('should escape XML-unsafe characters in post fields', async () => {
+    findAll.mockResolvedValue([
+      makePost('amp-post', 'A & B <Test>', '2026-08-01'),
+    ]);
+
+    const { request, context } = makeRequest('en-US');
+    const response = await GET(request, context);
+    const xml = await response.text();
+
+    expect(xml).toContain('<title>A &amp; B &lt;Test&gt;</title>');
+  });
+
+  it('should return a 500 response when the use case fails', async () => {
+    findAll.mockRejectedValue(new Error('fs error'));
+
+    const { request, context } = makeRequest('en-US');
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- `apps/blog/src/app/[locale]/rss.xml/route.ts`: `GET` Route Handler generates RSS 2.0 XML from `ListBlogPosts`, one feed per locale, XML-escaping post fields, using `env.siteUrl` (not a hardcoded domain) — consistent with the existing `lib/seo/*` utils.
- `apps/blog/src/app/robots.ts`: minimal permissive robots referencing `sitemap.xml`, mirroring `apps/site`'s.
- `buildAlternates()` now folds the RSS `<link rel="alternate" type="application/rss+xml">` into its return value, instead of a separate call site in the layout — see below for why.

## Why the RSS link moved into buildAlternates
Next.js does **not** deep-merge `alternates` between layout and page metadata — the same limitation this codebase already documents for `openGraph`. My first attempt added the RSS link only in `[locale]/layout.tsx`'s `generateMetadata`, and it silently disappeared on every page because the listing/detail pages' own `generateMetadata` (which they need, for canonical/hreflang) fully replaced it. Confirmed `apps/site` has this exact same latent gap — its own RSS `<link>` never renders either (verified against its built HTML output); it relies on a visible "RSS Feed" nav link instead, which isn't an option here yet (no blog UI design exists). Since every page already calls `buildAlternates()` for canonical/hreflang, folding the feed link in there guarantees it survives regardless of which metadata "wins".

## Test plan
- [x] `pnpm --filter blog test` — 14/14 passing (4 new: valid RSS XML, locale isolation, XML-escaping, 500 on use-case failure)
- [x] `pnpm --filter blog lint:check` — clean (pre-existing warning patterns)
- [x] `pnpm --filter blog types` — clean
- [x] `pnpm --filter blog build` — SSG succeeds for rss.xml × 3 locales + robots.txt
- [x] Manually verified in the browser (`next dev -p 3002`):
  - `GET /blog/en-US/rss.xml` → valid RSS 2.0 XML with the real post
  - `GET /blog/robots.txt` → correct rules + sitemap reference
  - `<link rel="alternate" type="application/rss+xml">` present in `<head>` on both the listing and detail pages
  - No console errors

Refs #958