### PR TITLE
docs: add cross-app code reuse protocol to General Standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ interface IProjectRepository {
 - Import order: external libs → internal packages → relative imports
 - Test naming: `should <expected behavior> when <context>`
 - **Tests are mandatory for every implementation** — never commit a new class, port, adapter, use case, or gateway without accompanying tests in the same branch/PR. A PR without tests for new production code is incomplete. See [docs/08-TESTING.md](./docs/08-TESTING.md) for strategy and naming.
+- **Evaluate cross-app reuse when adding new code to any `apps/*`** — before finishing a new util, config pattern, middleware, or DI wiring inside one app, check whether another app (`site`/`blog`/`admin`) is likely to need the same thing. If so, extract it into a shared `packages/*` at that point rather than letting duplication accumulate for a later audit. `packages/seo` (issue #960, PR #961) is the concrete precedent: framework-agnostic logic parameterized per app, depending only on `@repo/core` (never `@repo/utils`, which `core` itself depends on — that would be circular).
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a bullet to `CLAUDE.md`'s General Standards: when adding new code to any `apps/*`, evaluate at that moment whether another app is likely to need it too, rather than letting duplication accumulate for a later audit (like #962).
- References `packages/seo` (#960/PR #961) as the concrete precedent for how/where that extraction should happen.

## Test plan
- Docs-only change, no code affected.