### PR TITLE
refactor(seo): add buildRobots() to @repo/seo, dedupe apps/site and apps/blog robots.ts

### DIFF
--- a/apps/blog/src/app/robots.ts
+++ b/apps/blog/src/app/robots.ts
@@ -1,12 +1,9 @@
 import type { MetadataRoute } from 'next';
 
-import { env } from '~/config/env';
+import { buildRobots } from '~/lib/seo/robots';
 
 export const dynamic = 'force-static';
 
 export default function robots(): MetadataRoute.Robots {
-  return {
-    rules: { userAgent: '*', allow: '/' },
-    sitemap: `${env.siteUrl}/blog/sitemap.xml`,
-  };
+  return buildRobots();
 }

--- a/apps/blog/src/lib/seo/builders.ts
+++ b/apps/blog/src/lib/seo/builders.ts
@@ -2,9 +2,10 @@ import { createSeoBuilders } from '@repo/seo';
 
 import { env } from '~/config/env';
 
-export const { buildAlternates, buildOpenGraph } = createSeoBuilders({
-  siteUrl: env.siteUrl,
-  basePath: '/blog',
-  siteName: 'Wallace Ferreira — Blog',
-  rssFeed: { filename: 'rss.xml', title: 'Wallace Ferreira — Blog' },
-});
+export const { buildAlternates, buildOpenGraph, buildRobots } =
+  createSeoBuilders({
+    siteUrl: env.siteUrl,
+    basePath: '/blog',
+    siteName: 'Wallace Ferreira — Blog',
+    rssFeed: { filename: 'rss.xml', title: 'Wallace Ferreira — Blog' },
+  });

--- a/apps/blog/src/lib/seo/robots.ts
+++ b/apps/blog/src/lib/seo/robots.ts
@@ -1,0 +1,1 @@
+export { buildRobots } from './builders';

--- a/apps/site/src/app/robots.ts
+++ b/apps/site/src/app/robots.ts
@@ -1,12 +1,9 @@
 import type { MetadataRoute } from 'next';
 
-import { env } from '~/config/env';
+import { buildRobots } from '~/lib/seo/robots';
 
 export const dynamic = 'force-static';
 
 export default function robots(): MetadataRoute.Robots {
-  return {
-    rules: { userAgent: '*', allow: '/' },
-    sitemap: `${env.siteUrl}/sitemap.xml`,
-  };
+  return buildRobots();
 }

--- a/apps/site/src/lib/seo/builders.ts
+++ b/apps/site/src/lib/seo/builders.ts
@@ -2,8 +2,9 @@ import { createSeoBuilders } from '@repo/seo';
 
 import { env } from '~/config/env';
 
-export const { buildAlternates, buildOpenGraph } = createSeoBuilders({
-  siteUrl: env.siteUrl,
-  siteName: 'Wallace Ferreira',
-  rssFeed: { filename: 'feed.xml', title: 'Wallace Ferreira' },
-});
+export const { buildAlternates, buildOpenGraph, buildRobots } =
+  createSeoBuilders({
+    siteUrl: env.siteUrl,
+    siteName: 'Wallace Ferreira',
+    rssFeed: { filename: 'feed.xml', title: 'Wallace Ferreira' },
+  });

--- a/apps/site/src/lib/seo/robots.ts
+++ b/apps/site/src/lib/seo/robots.ts
@@ -1,0 +1,1 @@
+export { buildRobots } from './builders';

--- a/packages/seo/src/createSeoBuilders.ts
+++ b/packages/seo/src/createSeoBuilders.ts
@@ -4,6 +4,7 @@ import type {
   IAlternatesResult,
   HreflangMap,
   IOpenGraphResult,
+  IRobotsResult,
   Pathname,
   ISeoBuilders,
   ISeoBuildersConfig,
@@ -73,5 +74,12 @@ export function createSeoBuilders(config: ISeoBuildersConfig): ISeoBuilders {
     };
   }
 
-  return { buildAlternates, buildOpenGraph };
+  function buildRobots(): IRobotsResult {
+    return {
+      rules: { userAgent: '*', allow: '/' },
+      sitemap: `${siteUrl}${basePath}/sitemap.xml`,
+    };
+  }
+
+  return { buildAlternates, buildOpenGraph, buildRobots };
 }

--- a/packages/seo/src/index.ts
+++ b/packages/seo/src/index.ts
@@ -3,6 +3,7 @@ export type {
   IAlternatesResult,
   HreflangMap,
   IOpenGraphResult,
+  IRobotsResult,
   Pathname,
   IRssFeedConfig,
   RssTypeMap,

--- a/packages/seo/src/types.ts
+++ b/packages/seo/src/types.ts
@@ -39,6 +39,11 @@ export interface IOpenGraphResult {
   siteName: string;
 }
 
+export interface IRobotsResult {
+  rules: { userAgent: string; allow: string };
+  sitemap: string;
+}
+
 export interface ISeoBuilders {
   buildAlternates(pathname: Pathname, locale: Locale): IAlternatesResult;
   buildOpenGraph(
@@ -46,4 +51,5 @@ export interface ISeoBuilders {
     pathname: Pathname,
     type?: 'website' | 'article',
   ): IOpenGraphResult;
+  buildRobots(): IRobotsResult;
 }

--- a/packages/seo/test/createSeoBuilders.test.ts
+++ b/packages/seo/test/createSeoBuilders.test.ts
@@ -104,4 +104,35 @@ describe('createSeoBuilders', () => {
       });
     });
   });
+
+  describe('buildRobots', () => {
+    it('should build the sitemap URL without a basePath', () => {
+      const { buildRobots } = createSeoBuilders({
+        siteUrl: 'https://example.com',
+        siteName: 'Example',
+      });
+
+      const result = buildRobots();
+
+      expect(result).toEqual({
+        rules: { userAgent: '*', allow: '/' },
+        sitemap: 'https://example.com/sitemap.xml',
+      });
+    });
+
+    it('should prefix the sitemap URL with basePath when configured', () => {
+      const { buildRobots } = createSeoBuilders({
+        siteUrl: 'https://example.com',
+        basePath: '/blog',
+        siteName: 'Example Blog',
+      });
+
+      const result = buildRobots();
+
+      expect(result).toEqual({
+        rules: { userAgent: '*', allow: '/' },
+        sitemap: 'https://example.com/blog/sitemap.xml',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add `buildRobots()` to `@repo/seo`'s `createSeoBuilders`, following the same `siteUrl`/`basePath`-aware pattern already used by `buildAlternates`/`buildOpenGraph`
- `apps/site/src/app/robots.ts` and `apps/blog/src/app/robots.ts` now delegate to `buildRobots()` instead of duplicating the `{ rules, sitemap }` object literal (which only differed by the `basePath` prefix on the sitemap URL)

## Test plan
- [x] `pnpm --filter @repo/seo test` — 8/8 passing (2 new `buildRobots` cases: with and without `basePath`)
- [x] `pnpm --filter @repo/seo types` / `lint:check` — clean
- [x] `pnpm --filter site test` — 229/229 passing
- [x] `pnpm --filter site types` / `lint:check` — clean (only pre-existing warnings)
- [x] `pnpm --filter blog test` — 14/14 passing
- [x] `pnpm --filter blog types` / `lint:check` — clean (only pre-existing warnings)
- [x] `turbo build` for `@repo/seo`, `site`, `blog` — all succeed
- [x] Inspected built output: `apps/site/.next/server/app/robots.txt.body` → `Sitemap: http://localhost:3000/sitemap.xml`; `apps/blog/.next/server/app/robots.txt.body` → `Sitemap: http://localhost:3002/blog/sitemap.xml` (basePath correctly applied)

Refs #964