### PR TITLE
fix(build): add missing build script to core/application/utils/infra/seo

### DIFF
--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
     "build": "tsc --build tsconfig.build.json",
-    "types": "tsc --build tsconfig.build.json"
+    "types": "tsc -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
     "@repo/core": "workspace:*",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -19,7 +19,7 @@
     "lint:check": "eslint --ext .ts ./src",
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
-    "build:types": "tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "types": "tsc --build tsconfig.build.json"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "lint:check": "eslint --ext .ts ./src",
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
-    "build:types": "tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "types": "tsc --build tsconfig.build.json"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
     "build": "tsc --build tsconfig.build.json",
-    "types": "tsc --build tsconfig.build.json"
+    "types": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@repo/utils": "workspace:*",

--- a/packages/core/test/globals.d.ts
+++ b/packages/core/test/globals.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest/globals" />

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -19,7 +19,7 @@
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
     "postinstall": "prisma generate",
-    "build:types": "tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "types": "tsc --build tsconfig.build.json",
     "db:generate": "prisma generate",
     "db:migrate": "node scripts/assert-safe-db.mjs && prisma migrate dev",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -20,7 +20,7 @@
     "format:check": "prettier --check ./src/**/*.ts",
     "postinstall": "prisma generate",
     "build": "tsc --build tsconfig.build.json",
-    "types": "tsc --build tsconfig.build.json",
+    "types": "tsc -p tsconfig.build.json --noEmit",
     "db:generate": "prisma generate",
     "db:migrate": "node scripts/assert-safe-db.mjs && prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",

--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -20,7 +20,7 @@
     "lint:check": "eslint --ext .ts ./src",
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
-    "build:types": "tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "types": "tsc --build tsconfig.build.json"
   },
   "devDependencies": {

--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -21,7 +21,7 @@
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
     "build": "tsc --build tsconfig.build.json",
-    "types": "tsc --build tsconfig.build.json"
+    "types": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/seo/test/globals.d.ts
+++ b/packages/seo/test/globals.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest/globals" />

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,7 @@
     "lint:check": "eslint --ext .ts ./src",
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
-    "build:types": "tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "types": "tsc --build tsconfig.build.json"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,7 +33,7 @@
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
     "build": "tsc --build tsconfig.build.json",
-    "types": "tsc --build tsconfig.build.json"
+    "types": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/utils/test/globals.d.ts
+++ b/packages/utils/test/globals.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest/globals" />

--- a/turbo.json
+++ b/turbo.json
@@ -44,8 +44,7 @@
       "dependsOn": ["^format:check"]
     },
     "types": {
-      "dependsOn": ["^types"],
-      "outputs": ["dist/types/**"]
+      "dependsOn": ["^build"]
     },
     "test": {
       "dependsOn": ["^test"]


### PR DESCRIPTION
## Summary
- `turbo.json`'s `build` task depends on `^build`, but `packages/core`, `application`, `utils`, `infra` and `seo` only defined `build:types`/`types` (never a plain `build` script), so Turbo silently skipped building them — their `dist/types/**` were never generated before `site#build`/`admin#build`/`blog#build` ran on a clean checkout (reproduced locally and confirmed already failing on `develop` HEAD/Vercel).
- Added `"build": "tsc --build tsconfig.build.json"` to those 5 packages (mirrors `@repo/ui`, whose `build` already differs from `types`), and dropped the now-redundant `build:types` script instead of keeping a third identical entry.
- The implicit-`any`/type errors previously reported in `apps/site` turned out to be downstream symptoms of the same broken project references, not separate bugs — they disappeared once `dist/types` built correctly, so no `apps/site` source changes were needed.
- Follow-up: decoupled `types` from declaration emission. `turbo.json`'s `types` task now depends on `^build` (reusing `build`'s output) instead of re-running its own `tsc --build` via `^types`. `core`/`utils`/`seo`'s `types` now run `tsc -p tsconfig.json --noEmit` (matches `apps/*`'s convention, and now also covers `test/**` — added `test/globals.d.ts` for vitest globals, same pattern as `apps/*/tests/globals.d.ts`). `application`/`infra` stay on `tsconfig.build.json` (src-only, no emit) because including `test/**` there surfaces ~30 pre-existing type errors in test mocks, out of scope here — tracked in #973.

## Test plan
- [x] Reproduced the failure locally: cleared all `dist/`, `.tsbuildinfo` and turbo cache, ran `turbo run build --filter=site` exactly as Vercel's build command does — confirmed `TS6305`/`TS7006`/`TS2322` errors, then confirmed the fix resolves them with the same clean-checkout procedure.
- [x] `pnpm turbo build` (root, all 13 packages/apps) — 9/9 successful
- [x] `pnpm turbo types` (root, all 16 workspace projects, `--continue`) — all clean
- [x] `pnpm test:ci` — all passing (`@repo/infra`'s pre-existing local env-dependent auth-gateway failures are excluded by this same script and confirmed pre-existing via `git stash`, unrelated to this change)
- [x] `pnpm lint:check` — 0 errors (pre-existing warnings only)

Refs #971