### PR TITLE
fix(test): fix pre-existing type errors in application/infra tests, include test/** in types check

### DIFF
--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write ./src/**/*.ts",
     "format:check": "prettier --check ./src/**/*.ts",
     "build": "tsc --build tsconfig.build.json",
-    "types": "tsc -p tsconfig.build.json --noEmit"
+    "types": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@repo/core": "workspace:*",

--- a/packages/application/test/blog/ListBlogPosts.test.ts
+++ b/packages/application/test/blog/ListBlogPosts.test.ts
@@ -100,7 +100,8 @@ describe('ListBlogPosts', () => {
 
       expect(result.isRight()).toBe(true);
       if (!result.isRight()) return;
-      expect(result.value[0].coverImage).toBe('https://example.com/cover.png');
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]?.coverImage).toBe('https://example.com/cover.png');
     });
 
     it('should return Left(DomainError) when the repository throws', async () => {

--- a/packages/application/test/globals.d.ts
+++ b/packages/application/test/globals.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest/globals" />

--- a/packages/application/test/identity/EnsureAdmin.test.ts
+++ b/packages/application/test/identity/EnsureAdmin.test.ts
@@ -30,6 +30,7 @@ function makeRepository(overrides: Partial<IUserRepository> = {}): IUserReposito
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
     ...overrides,
   };
 }

--- a/packages/application/test/identity/GetCurrentUser.test.ts
+++ b/packages/application/test/identity/GetCurrentUser.test.ts
@@ -30,6 +30,7 @@ function makeRepository(overrides: Partial<IUserRepository> = {}): IUserReposito
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
     ...overrides,
   };
 }

--- a/packages/application/test/portfolio/use-cases/ArchiveProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/ArchiveProject.test.ts
@@ -58,6 +58,7 @@ function makeUserRepo(user: User | null): IUserRepository {
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
   };
 }
 

--- a/packages/application/test/portfolio/use-cases/DeleteExperience.test.ts
+++ b/packages/application/test/portfolio/use-cases/DeleteExperience.test.ts
@@ -27,6 +27,7 @@ function makeUserRepo(user: User | null): IUserRepository {
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
   };
 }
 

--- a/packages/application/test/portfolio/use-cases/DeleteProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/DeleteProject.test.ts
@@ -32,6 +32,7 @@ function makeUserRepo(user: User | null): IUserRepository {
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
   };
 }
 

--- a/packages/application/test/portfolio/use-cases/PublishProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/PublishProject.test.ts
@@ -58,6 +58,7 @@ function makeUserRepo(user: User | null): IUserRepository {
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
   };
 }
 

--- a/packages/application/test/portfolio/use-cases/SaveExperience.test.ts
+++ b/packages/application/test/portfolio/use-cases/SaveExperience.test.ts
@@ -49,6 +49,7 @@ function makeUserRepo(user: User | null): IUserRepository {
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
   };
 }
 

--- a/packages/application/test/portfolio/use-cases/SaveProject.test.ts
+++ b/packages/application/test/portfolio/use-cases/SaveProject.test.ts
@@ -55,6 +55,7 @@ function makeUserRepo(user: User | null): IUserRepository {
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
   };
 }
 

--- a/packages/application/test/portfolio/use-cases/UpdateProfile.test.ts
+++ b/packages/application/test/portfolio/use-cases/UpdateProfile.test.ts
@@ -42,6 +42,7 @@ function makeUserRepo(user: User | null): IUserRepository {
     findByEmail: vi.fn(),
     findByAuthSubject: vi.fn(),
     linkAuthSubject: vi.fn(),
+    save: vi.fn(),
   };
 }
 

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -20,7 +20,7 @@
     "format:check": "prettier --check ./src/**/*.ts",
     "postinstall": "prisma generate",
     "build": "tsc --build tsconfig.build.json",
-    "types": "tsc -p tsconfig.build.json --noEmit",
+    "types": "tsc -p tsconfig.json --noEmit",
     "db:generate": "prisma generate",
     "db:migrate": "node scripts/assert-safe-db.mjs && prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",

--- a/packages/infra/test/globals.d.ts
+++ b/packages/infra/test/globals.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest/globals" />

--- a/packages/infra/test/identity/SupabaseAuthenticationGateway.integration.test.ts
+++ b/packages/infra/test/identity/SupabaseAuthenticationGateway.integration.test.ts
@@ -140,7 +140,7 @@ describe.skipIf(missingEnv)(
     // -----------------------------------------------------------------------
 
     describe('signOut', () => {
-      it('should return Right(void) and remove cookies when tokens are present', async () => {
+      it('should return Right(void) when tokens are present', async () => {
         const signInResult = await makeGateway().signInWithPassword({
           email: TEST_EMAIL,
           password: TEST_PASSWORD,
@@ -151,20 +151,14 @@ describe.skipIf(missingEnv)(
           accessToken: string;
           refreshToken: string;
         };
-        const cookies = makeCookieApi({
-          [SUPABASE_ACCESS_TOKEN_COOKIE]: accessToken,
-          [SUPABASE_REFRESH_TOKEN_COOKIE]: refreshToken,
-        });
 
-        const result = await makeGateway().signOut(cookies);
+        const result = await makeGateway().signOut(accessToken, refreshToken);
 
         expect(result.isRight()).toBe(true);
-        expect(cookies.store[SUPABASE_ACCESS_TOKEN_COOKIE]).toBeUndefined();
-        expect(cookies.store[SUPABASE_REFRESH_TOKEN_COOKIE]).toBeUndefined();
       });
 
-      it('should return Right(void) even when cookies are absent (no-op)', async () => {
-        const result = await makeGateway().signOut(makeCookieApi());
+      it('should return Right(void) even when tokens are absent (no-op)', async () => {
+        const result = await makeGateway().signOut('', '');
 
         expect(result.isRight()).toBe(true);
       });
@@ -183,11 +177,8 @@ describe.skipIf(missingEnv)(
         expect(signInResult.isRight()).toBe(true);
 
         const { refreshToken } = signInResult.value as { refreshToken: string };
-        const cookies = makeCookieApi({
-          [SUPABASE_REFRESH_TOKEN_COOKIE]: refreshToken,
-        });
 
-        const result = await makeGateway().refreshSession(cookies);
+        const result = await makeGateway().refreshSession(refreshToken);
 
         expect(result.isRight()).toBe(true);
         const newSession = result.value as {
@@ -198,19 +189,17 @@ describe.skipIf(missingEnv)(
         expect(newSession.accessToken.length).toBeGreaterThan(0);
       });
 
-      it('should return Left(NO_REFRESH_TOKEN) when cookie is absent', async () => {
-        const result = await makeGateway().refreshSession(makeCookieApi());
+      it('should return Left(NO_REFRESH_TOKEN) when refresh token is absent', async () => {
+        const result = await makeGateway().refreshSession('');
 
         expect(result.isLeft()).toBe(true);
         expect((result.value as DomainError).code).toBe('NO_REFRESH_TOKEN');
       });
 
       it('should return Left(INVALID_REFRESH_TOKEN) when token is bogus', async () => {
-        const cookies = makeCookieApi({
-          [SUPABASE_REFRESH_TOKEN_COOKIE]: 'totally-invalid-refresh-token',
-        });
-
-        const result = await makeGateway().refreshSession(cookies);
+        const result = await makeGateway().refreshSession(
+          'totally-invalid-refresh-token',
+        );
 
         expect(result.isLeft()).toBe(true);
         expect((result.value as DomainError).code).toBe('INVALID_REFRESH_TOKEN');

--- a/packages/infra/test/identity/SupabaseAuthenticationGateway.test.ts
+++ b/packages/infra/test/identity/SupabaseAuthenticationGateway.test.ts
@@ -53,7 +53,9 @@ function makeAuthMock(overrides: Record<string, ReturnType<typeof vi.fn>> = {}) 
 
 function mockClient(authOverrides: Record<string, ReturnType<typeof vi.fn>> = {}) {
   const auth = makeAuthMock(authOverrides);
-  vi.mocked(createClient).mockReturnValue({ auth } as ReturnType<typeof createClient>);
+  vi.mocked(createClient).mockReturnValue(
+    { auth } as unknown as ReturnType<typeof createClient>,
+  );
   return auth;
 }
 
@@ -141,27 +143,21 @@ describe('SupabaseAuthenticationGateway — signInWithPassword', () => {
 describe('SupabaseAuthenticationGateway — signOut', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('should return Right(void) and delete cookies when tokens are present', async () => {
+  it('should return Right(void) when tokens are present', async () => {
     mockClient({
       setSession: vi.fn().mockResolvedValue({ data: {}, error: null }),
       signOut: vi.fn().mockResolvedValue({ error: null }),
     });
-    const cookies = makeCookieApi({
-      [SUPABASE_ACCESS_TOKEN_COOKIE]: 'access-jwt',
-      [SUPABASE_REFRESH_TOKEN_COOKIE]: 'refresh-token',
-    });
 
-    const result = await makeGateway().signOut(cookies);
+    const result = await makeGateway().signOut('access-jwt', 'refresh-token');
 
     expect(result.isRight()).toBe(true);
-    expect(cookies.store[SUPABASE_ACCESS_TOKEN_COOKIE]).toBeUndefined();
-    expect(cookies.store[SUPABASE_REFRESH_TOKEN_COOKIE]).toBeUndefined();
   });
 
-  it('should return Right(void) even when cookies are already absent', async () => {
+  it('should return Right(void) even when tokens are absent', async () => {
     mockClient();
 
-    const result = await makeGateway().signOut(makeCookieApi());
+    const result = await makeGateway().signOut('', '');
 
     expect(result.isRight()).toBe(true);
   });
@@ -171,12 +167,8 @@ describe('SupabaseAuthenticationGateway — signOut', () => {
       setSession: vi.fn().mockResolvedValue({ data: {}, error: null }),
       signOut: vi.fn().mockRejectedValue(new Error('Supabase unreachable')),
     });
-    const cookies = makeCookieApi({
-      [SUPABASE_ACCESS_TOKEN_COOKIE]: 'access-jwt',
-      [SUPABASE_REFRESH_TOKEN_COOKIE]: 'refresh-token',
-    });
 
-    const result = await makeGateway().signOut(cookies);
+    const result = await makeGateway().signOut('access-jwt', 'refresh-token');
 
     expect(result.isLeft()).toBe(true);
     expect((result.value as DomainError).code).toBe('AUTH_UNEXPECTED_ERROR');
@@ -195,9 +187,8 @@ describe('SupabaseAuthenticationGateway — refreshSession', () => {
     mockClient({
       refreshSession: vi.fn().mockResolvedValue({ data: { session: newSession }, error: null }),
     });
-    const cookies = makeCookieApi({ [SUPABASE_REFRESH_TOKEN_COOKIE]: 'old-refresh' });
 
-    const result = await makeGateway().refreshSession(cookies);
+    const result = await makeGateway().refreshSession('old-refresh');
 
     expect(result.isRight()).toBe(true);
     expect(result.value).toMatchObject({
@@ -206,10 +197,10 @@ describe('SupabaseAuthenticationGateway — refreshSession', () => {
     });
   });
 
-  it('should return Left(DomainError NO_REFRESH_TOKEN) when cookie is absent', async () => {
+  it('should return Left(DomainError NO_REFRESH_TOKEN) when refresh token is absent', async () => {
     mockClient();
 
-    const result = await makeGateway().refreshSession(makeCookieApi());
+    const result = await makeGateway().refreshSession('');
 
     expect(result.isLeft()).toBe(true);
     expect((result.value as DomainError).code).toBe('NO_REFRESH_TOKEN');
@@ -222,9 +213,8 @@ describe('SupabaseAuthenticationGateway — refreshSession', () => {
         error: { message: 'Refresh token already used' },
       }),
     });
-    const cookies = makeCookieApi({ [SUPABASE_REFRESH_TOKEN_COOKIE]: 'stale-token' });
 
-    const result = await makeGateway().refreshSession(cookies);
+    const result = await makeGateway().refreshSession('stale-token');
 
     expect(result.isLeft()).toBe(true);
     expect((result.value as DomainError).code).toBe('INVALID_REFRESH_TOKEN');
@@ -235,9 +225,8 @@ describe('SupabaseAuthenticationGateway — refreshSession', () => {
     mockClient({
       refreshSession: vi.fn().mockRejectedValue(new Error('Network timeout')),
     });
-    const cookies = makeCookieApi({ [SUPABASE_REFRESH_TOKEN_COOKIE]: 'some-token' });
 
-    const result = await makeGateway().refreshSession(cookies);
+    const result = await makeGateway().refreshSession('some-token');
 
     expect(result.isLeft()).toBe(true);
     expect((result.value as DomainError).code).toBe('AUTH_UNEXPECTED_ERROR');

--- a/packages/infra/test/repositories/blog/FileSystemBlogPostRepository.test.ts
+++ b/packages/infra/test/repositories/blog/FileSystemBlogPostRepository.test.ts
@@ -28,8 +28,8 @@ describe('FileSystemBlogPostRepository', () => {
         'test-post',
         'older-post',
       ]);
-      expect(posts[0].title.get('en-US')).toBe('Test Post');
-      expect(posts[0].tags.map((t) => t.value)).toEqual([
+      expect(posts[0]?.title.get('en-US')).toBe('Test Post');
+      expect(posts[0]?.tags.map((t) => t.value)).toEqual([
         'nextjs',
         'architecture',
       ]);

--- a/packages/infra/test/repositories/experience/PrismaExperienceRepository.test.ts
+++ b/packages/infra/test/repositories/experience/PrismaExperienceRepository.test.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { seedExperiences } from '../../../prisma/seeders';
@@ -25,12 +25,12 @@ async function seedExperience(
   await db.experience.create({
     data: {
       id: raw.id,
-      company: raw.company,
-      position: raw.position,
-      location: raw.location,
-      description: raw.description,
+      company: raw.company as Prisma.InputJsonValue,
+      position: raw.position as Prisma.InputJsonValue,
+      location: raw.location as Prisma.InputJsonValue,
+      description: raw.description as Prisma.InputJsonValue,
       logoUrl: raw.logoUrl,
-      logoAlt: raw.logoAlt,
+      logoAlt: raw.logoAlt as Prisma.InputJsonValue,
       employmentType: raw.employmentType,
       locationType: raw.locationType,
       skillIds: raw.skillIds,

--- a/packages/infra/test/repositories/profile/PrismaProfileRepository.test.ts
+++ b/packages/infra/test/repositories/profile/PrismaProfileRepository.test.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { seedProfile } from '../../../prisma/seeders';
@@ -38,10 +38,10 @@ describe('PrismaProfileRepository', () => {
         data: {
           id: raw.id,
           name: raw.name,
-          headline: raw.headline,
-          bio: raw.bio,
+          headline: raw.headline as Prisma.InputJsonValue,
+          bio: raw.bio as Prisma.InputJsonValue,
           photoUrl: raw.photoUrl,
-          photoAlt: raw.photoAlt,
+          photoAlt: raw.photoAlt as Prisma.InputJsonValue,
           stats: {
             create: [
               {

--- a/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
+++ b/packages/infra/test/repositories/project/PrismaProjectRepository.test.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { ProjectStatus } from '@repo/core/portfolio';
@@ -30,16 +30,16 @@ async function seedProject(overrides?: Partial<ReturnType<typeof buildPrismaProj
       id: raw.id,
       slug: raw.slug,
       coverImageUrl: raw.coverImageUrl,
-      coverImageAlt: raw.coverImageAlt,
+      coverImageAlt: raw.coverImageAlt as Prisma.InputJsonValue,
       thumbnailImageUrl: raw.thumbnailImageUrl,
-      thumbnailImageAlt: raw.thumbnailImageAlt,
-      title: raw.title,
-      caption: raw.caption,
-      content: raw.content,
-      theme: raw.theme ?? undefined,
-      summary: raw.summary ?? undefined,
-      objectives: raw.objectives ?? undefined,
-      role: raw.role ?? undefined,
+      thumbnailImageAlt: raw.thumbnailImageAlt as Prisma.InputJsonValue,
+      title: raw.title as Prisma.InputJsonValue,
+      caption: raw.caption as Prisma.InputJsonValue,
+      content: raw.content as Prisma.InputJsonValue,
+      theme: (raw.theme as Prisma.InputJsonValue | null) ?? undefined,
+      summary: (raw.summary as Prisma.InputJsonValue | null) ?? undefined,
+      objectives: (raw.objectives as Prisma.InputJsonValue | null) ?? undefined,
+      role: (raw.role as Prisma.InputJsonValue | null) ?? undefined,
       periodStart: raw.periodStart,
       periodEnd: raw.periodEnd,
       featured: raw.featured,

--- a/packages/infra/test/services/ResendEmailService.test.ts
+++ b/packages/infra/test/services/ResendEmailService.test.ts
@@ -62,7 +62,8 @@ describe('ResendEmailService', () => {
       await service.send(validMessage);
 
       const [call] = sendMock.mock.calls;
-      const html = call[0].html as string;
+      expect(call).toBeDefined();
+      const html = call?.[0].html as string;
       expect(html).toContain(validMessage.name);
       expect(html).toContain(validMessage.email);
       expect(html).toContain(validMessage.message);


### PR DESCRIPTION
## Summary
- `@repo/application` and `@repo/infra`'s `types` script was left scoped to `tsconfig.build.json` (src-only) in #971 specifically to avoid pulling ~30 pre-existing type errors in their `test/**` files into that PR's scope. This finishes the job: fixes the errors, then switches both to `tsc -p tsconfig.json --noEmit`, matching `core`/`utils`/`seo` and `apps/*`.
- `application` (9 errors, all missing `IUserRepository.save` on mocks): added `save: vi.fn()` to the mock-repository helpers in `EnsureAdmin`, `GetCurrentUser`, and all 7 `portfolio/use-cases` tests. `ListBlogPosts.test.ts` had an unguarded `result.value[0]` under `noUncheckedIndexedAccess` — added a length assertion and optional chaining.
- `infra` (~21 errors): the real finding here — `SupabaseAuthenticationGateway.test.ts`/`.integration.test.ts` were calling `signOut`/`refreshSession` with a cookie-API object, but the actual `IAuthenticationGateway` interface takes raw token strings. The gateway's signature had drifted from its tests at some point and this was never caught (types never checked `test/**` before). Rewrote both to pass tokens directly and dropped assertions about the gateway deleting cookies (it doesn't — that's the caller's responsibility per the interface doc). Also fixed an unsafe mock-to-`SupabaseClient` cast. The Prisma repository tests needed `Prisma.InputJsonValue` casts at their `create()` call sites (Prisma's write type excludes plain `null`, unlike the `JsonValue` read type the factories/mappers use) — cast at the call site rather than loosening the factory types, since the mapper tests need the read-shape type. Two more `noUncheckedIndexedAccess` spots fixed the same way as `application`.
- Added `test/globals.d.ts` (vitest/globals ambient types) to both packages, same pattern already used by `core`/`utils`/`seo`/`apps/*`.

## Test plan
- [x] `pnpm turbo build` (root, all 13 packages/apps) — 9/9 successful
- [x] `pnpm turbo types` (root, all 16 workspace projects, `--continue`, from a clean `dist`/`.tsbuildinfo`/turbo-cache checkout) — all clean
- [x] `pnpm --filter @repo/application test` — 22/22 files, 176/176 tests passing
- [x] `pnpm --filter @repo/infra test` — confirmed via `git stash` that the SupabaseAuthenticationGateway fix actually resolves 3 previously-failing tests (6 failed files/3 failed tests → 5 failed files/0 failed tests; the remaining 5 failing files are pre-existing local Postgres-connection failures, unrelated, same as before this change)
- [x] `pnpm test:ci` — all passing
- [x] `pnpm lint:check` — 0 errors (pre-existing warnings only)

Refs #973