### PR TITLE
chore: remove unused per-package script shortcuts from root package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,6 @@ pnpm dev
 | `pnpm types` | Run type checks |
 | `pnpm test` | Run test tasks |
 | `pnpm test:ci` | Run CI test command |
-| `pnpm test:core` | Run core package tests |
-| `pnpm test:utils` | Run utils package tests |
-| `pnpm test:site` | Run site app tests |
 | `pnpm seed` | Seed data through `@repo/infra` |
 
 ---

--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
     "test": "turbo test",
     "test:ci": "pnpm -r --filter=!@repo/infra test",
     "types:ci": "pnpm -r types",
-    "test:core": "pnpm -C packages/core test",
-    "test:utils": "pnpm -C packages/utils test",
-    "test:site": "pnpm -C apps/site test",
-    "seed": "pnpm --filter @repo/infra db:seed",
-    "dev:site": "pnpm --filter site dev",
-    "dev:site:clean": "pnpm --filter site dev:clean"
+    "seed": "pnpm --filter @repo/infra db:seed"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",


### PR DESCRIPTION
## Summary
- Removed `test:core`, `test:utils`, `test:site` from root `package.json` — arbitrary shortcuts covering only 3 of the monorepo's 9 packages/apps; fully redundant with `pnpm --filter <pkg> test`.
- Removed `dev:site`, `dev:site:clean` — not referenced anywhere, not even in `README.md`'s scripts table; redundant with `pnpm --filter site dev` / `pnpm --filter site dev:clean`.
- Updated `README.md`'s scripts table to drop the 3 removed rows.
- Confirmed `lefthook.yml` only depends on `build`, `format:check`, `lint:check`, `types:ci`, `test:ci` — none of the removed scripts.

## Test plan
- [x] `pnpm build` — 9/9 successful
- [x] `pnpm lint:check` — clean
- [x] `pnpm types:ci` — clean
- [x] `pnpm test:ci` — all passing
- [x] Grepped `lefthook.yml`, `.github/workflows/`, `docs/`, `CLAUDE.md`, `.taskmaster/CLAUDE.md` for references to the 5 removed scripts — none found

Refs #975