### PR TITLE
docs: update Validator usage examples to omit optional error messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,12 +87,11 @@ class Slug extends ValueObject<string> {
 
   static create(raw?: string): Either<ValidationError, Slug> {
     const normalized = raw?.trim().toLowerCase() ?? '';
-    const { error, isValid } = Validator.of(normalized)
-      .length(3, 100, 'Slug must be at least 3 characters.')
-      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case.')
+    const { isValid } = Validator.of(normalized)
+      .length(3, 100)
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
       .validate();
-    if (!isValid && error)
-      return left(new ValidationError({ code: Slug.ERROR_CODE, message: error }));
+    if (!isValid) return left(new ValidationError({ code: Slug.ERROR_CODE }));
     return right(new Slug(normalized));
   }
 }
@@ -125,14 +124,15 @@ class Project extends Entity<Project, IProjectProps> {
 - Chain rules (chain of responsibility); `.validate()` returns the **first** error — one single `left` per validation flow.
 - **Do not** use manual `if` guards for domain invariants. Express each rule with `.refine()` (or `.length()`, `.regex()`, `.in()`, etc.) and end with a single `if (!isValid && error) return left(...)` after `.validate()`.
 
+- The `error` message parameter on rule methods (`.refine()`, `.length()`, `.regex()`, `.in()`, etc.) is **optional** — omit it in domain and application code. `ValidationError` carries only the `code`; the user-facing message is resolved later at the application layer via `ERROR_MESSAGE`, keyed by that code. See [docs/06-VALIDATION.md](./docs/06-VALIDATION.md#domain-invariants) for the full convention, including the one exception (HTTP boundary code may supply a message directly).
+
 ```typescript
 // ✅ correct
-const { error, isValid } = Validator.of(value)
-  .refine((v) => someRule(v), 'Rule A message.')
-  .refine((v) => anotherRule(v), 'Rule B message.')
+const { isValid } = Validator.of(value)
+  .refine((v) => someRule(v))
+  .refine((v) => anotherRule(v))
   .validate();
-if (!isValid && error)
-  return left(new ValidationError({ code: Foo.ERROR_CODE, message: error }));
+if (!isValid) return left(new ValidationError({ code: Foo.ERROR_CODE }));
 
 // ❌ avoid
 if (!someRule(value)) return left(new ValidationError({ ... }));
@@ -162,11 +162,10 @@ public readonly period: DateRange;   // DateRange.create(start, end)
 public readonly status: ProjectStatus;
 // in create():
 {
-  const { error, isValid } = Validator.of(props.status)
-    .in(Object.values(ProjectStatus), 'Invalid status.')
+  const { isValid } = Validator.of(props.status)
+    .in(Object.values(ProjectStatus))
     .validate();
-  if (!isValid && error)
-    return left(new ValidationError({ code: Project.ERROR_CODE, message: error }));
+  if (!isValid) return left(new ValidationError({ code: Project.ERROR_CODE }));
 }
 
 // ❌ avoid — no VO and no Validator check for a domain-meaningful value

--- a/docs/06-VALIDATION.md
+++ b/docs/06-VALIDATION.md
@@ -50,35 +50,42 @@ The domain enforces invariants via `Validator` from `@repo/utils` and returns er
 // VO using Validator
 static create(raw?: string): Either<ValidationError, Slug> {
   const normalized = raw?.trim().toLowerCase() ?? '';
-  const { error, isValid } = Validator.of(normalized)
-    .length(3, 100, 'Slug must be at least 3 characters.')
-    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Slug must be kebab-case.')
+  const { isValid } = Validator.of(normalized)
+    .length(3, 100)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
     .validate();
-  if (!isValid && error)
-    return left(new ValidationError({ code: Slug.ERROR_CODE, message: error }));
+  if (!isValid) return left(new ValidationError({ code: Slug.ERROR_CODE }));
   return right(new Slug(normalized));
 }
 ```
 
+**The `error` message parameter on rule methods (`.length()`, `.regex()`, `.refine()`, etc.) is optional** — omit it in domain and application code:
+
+- **Domain layer** (`@repo/core`): omit the message. `ValidationError` carries only the `code`; the user-facing message is resolved later at the application layer via `ERROR_MESSAGE` (`packages/core/src/shared/i18n/ERROR_MESSAGE.ts`), keyed by that code and localized per request.
+- **Application layer**: omit the message for the same reason — it stays a pass-through of the domain's `code`.
+- **HTTP boundary** (route handlers): may supply an explicit message where a direct, user-facing error is being built outside the domain/application `ERROR_MESSAGE` resolution flow.
+
 `Validator` methods:
+
+`error` is an optional message parameter on every rule method — see the convention above for when to supply it.
 
 | Method | Description |
 |--------|-------------|
-| `.length(min, max, error)` | String length between `min` and `max` |
-| `.notEmpty(error)` | Non-empty string |
-| `.empty(error)` | Empty string |
-| `.alpha(error)` | Alphabetic characters only (supports accents) |
-| `.string(error)` | Valid string type |
-| `.regex(pattern, error)` | Matches regular expression |
-| `.url(error)` | Valid URL |
-| `.uuid(error)` | Valid UUID |
-| `.datetime(error)` | Valid ISO 8601 datetime |
-| `.in(values, error)` | Value must be one of the allowed values |
-| `.gt(n, error)` / `.gte(n, error)` | Number greater than / greater than or equal to `n` |
-| `.lt(n, error)` / `.lte(n, error)` | Number less than / less than or equal to `n` |
-| `.nil(error)` | Value is `null` or `undefined` |
-| `.notNil(error)` | Value is not `null` or `undefined` |
-| `.refine(predicate, error)` | Arbitrary predicate function |
+| `.length(min, max, error?)` | String length between `min` and `max` |
+| `.notEmpty(error?)` | Non-empty string |
+| `.empty(error?)` | Empty string |
+| `.alpha(error?)` | Alphabetic characters only (supports accents) |
+| `.string(error?)` | Valid string type |
+| `.regex(pattern, error?)` | Matches regular expression |
+| `.url(error?)` | Valid URL |
+| `.uuid(error?)` | Valid UUID |
+| `.datetime(error?)` | Valid ISO 8601 datetime |
+| `.in(values, error?)` | Value must be one of the allowed values |
+| `.gt(n, error?)` / `.gte(n, error?)` | Number greater than / greater than or equal to `n` |
+| `.lt(n, error?)` / `.lte(n, error?)` | Number less than / less than or equal to `n` |
+| `.nil(error?)` | Value is `null` or `undefined` |
+| `.notNil(error?)` | Value is not `null` or `undefined` |
+| `.refine(predicate, error?)` | Arbitrary predicate function |
 
 ---
 
@@ -89,11 +96,10 @@ For simple enum or primitive properties that do not warrant a dedicated VO, vali
 ```typescript
 // ✅ enum validated in entity create() — no VO needed
 {
-  const { error, isValid } = Validator.of(props.status)
-    .in(Object.values(ProjectStatus), 'Invalid status.')
+  const { isValid } = Validator.of(props.status)
+    .in(Object.values(ProjectStatus))
     .validate();
-  if (!isValid && error)
-    return left(new ValidationError({ code: Project.ERROR_CODE, message: error }));
+  if (!isValid) return left(new ValidationError({ code: Project.ERROR_CODE }));
 }
 ```
 

--- a/docs/09-PATTERNS.md
+++ b/docs/09-PATTERNS.md
@@ -50,12 +50,11 @@ class Slug extends ValueObject<string> {
 
   static create(raw?: string): Either<ValidationError, Slug> {
     const normalized = raw?.trim().toLowerCase() ?? '';
-    const { error, isValid } = Validator.of(normalized)
-      .length(3, 100, 'Slug must be at least 3 characters.')
-      .regex(Slug.SLUG_REGEX, 'Slug must be kebab-case.')
+    const { isValid } = Validator.of(normalized)
+      .length(3, 100)
+      .regex(Slug.SLUG_REGEX)
       .validate();
-    if (!isValid && error)
-      return left(new ValidationError({ code: Slug.ERROR_CODE, message: error }));
+    if (!isValid) return left(new ValidationError({ code: Slug.ERROR_CODE }));
     return right(new Slug(normalized));
   }
 
@@ -68,6 +67,7 @@ class Slug extends ValueObject<string> {
 - Must provide `equals()` (inherited from `ValueObject` base)
 - Use `Validator` from `@repo/utils` for all validation
 - Use stable `ERROR_CODE` constants
+- Omit the optional `error` message on rule methods — the domain layer carries only the `code`; see [06-VALIDATION](./06-VALIDATION.md#domain-invariants)
 
 ---
 


### PR DESCRIPTION
## Summary
- `docs/06-VALIDATION.md`: updated the Domain Invariants and enum-in-entity examples to omit the optional `error` message, and documented the convention explicitly — domain/application code omits it (`ValidationError` carries only `code`, resolved via `ERROR_MESSAGE` later), HTTP boundary code may supply one directly.
- `docs/09-PATTERNS.md`: updated the Value Object template to match, and added the convention as an explicit VO rule.
- `CLAUDE.md`: updated both Validator examples (the top-level VO template and the "Domain Validation (core)" section) to drop hardcoded messages.

## Test plan
- [x] Confirmed the new examples match current real code (`packages/core/src/shared/vo/Slug.ts`, `Name.ts`) — both already omit messages
- [x] Grepped `docs/` and `CLAUDE.md` for remaining `message: error` / hardcoded rule-method message strings — none left outside `docs/ISSUES-FOLLOWUP.md` (a historical audit snapshot, out of scope)
- [x] `pnpm lint:check`, `pnpm format:check`, `pnpm test:ci`, `pnpm types:ci` — all passing (docs-only change, no code touched)

Refs #613