### PR TITLE
refactor(application): extract FETCH_FAILED/SAVE_FAILED into error code constants

### DIFF
--- a/packages/application/src/blog/use-cases/GetBlogPostBySlug.ts
+++ b/packages/application/src/blog/use-cases/GetBlogPostBySlug.ts
@@ -10,6 +10,7 @@ import {
   right,
 } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { BlogPostDetailDTO } from '../dtos/BlogPostDetailDTO';
 import { IBlogPostRepository } from '../ports';
@@ -41,7 +42,7 @@ export class GetBlogPostBySlug extends UseCase<
       post = await this.repository.findBySlug(slugResult.value);
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', {
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
           message: 'Failed to fetch blog post',
         }),
       );

--- a/packages/application/src/blog/use-cases/ListBlogPosts.ts
+++ b/packages/application/src/blog/use-cases/ListBlogPosts.ts
@@ -1,6 +1,7 @@
 import { BlogPost } from '@repo/core/blog';
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { BlogPostSummaryDTO } from '../dtos/BlogPostSummaryDTO';
 import { IBlogPostRepository } from '../ports';
@@ -25,7 +26,7 @@ export class ListBlogPosts extends UseCase<
       return right(posts.map((post) => this.toDTO(post, input.locale)));
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', {
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
           message: 'Failed to fetch blog posts',
         }),
       );

--- a/packages/application/src/identity/use-cases/EnsureAdmin.ts
+++ b/packages/application/src/identity/use-cases/EnsureAdmin.ts
@@ -8,6 +8,7 @@ import {
   right,
 } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 
 export type EnsureAdminInput = {
@@ -46,7 +47,7 @@ export class EnsureAdmin extends UseCase<
       return right(undefined);
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', {
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
           message: 'Failed to verify admin status',
         }),
       );

--- a/packages/application/src/identity/use-cases/GetCurrentUser.ts
+++ b/packages/application/src/identity/use-cases/GetCurrentUser.ts
@@ -8,6 +8,7 @@ import {
   right,
 } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { UserDTO } from '../dtos/UserDTO';
 
@@ -40,7 +41,9 @@ export class GetCurrentUser extends UseCase<
       return right(this.toDTO(user));
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', { message: 'Failed to fetch user' }),
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
+          message: 'Failed to fetch user',
+        }),
       );
     }
   }

--- a/packages/application/src/portfolio/use-cases/ArchiveProject.ts
+++ b/packages/application/src/portfolio/use-cases/ArchiveProject.ts
@@ -11,6 +11,7 @@ import {
 } from '@repo/core/shared';
 
 import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 
 export type ArchiveProjectInput = {
@@ -55,7 +56,9 @@ export class ArchiveProject extends UseCase<
       project = await this.projectRepository.findById(idResult.value);
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', { message: 'Failed to fetch project' }),
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
+          message: 'Failed to fetch project',
+        }),
       );
     }
 
@@ -70,7 +73,9 @@ export class ArchiveProject extends UseCase<
       return right(undefined);
     } catch {
       return left(
-        new DomainError('SAVE_FAILED', { message: 'Failed to save project' }),
+        new DomainError(ApplicationErrorCode.SAVE_FAILED, {
+          message: 'Failed to save project',
+        }),
       );
     }
   }

--- a/packages/application/src/portfolio/use-cases/GetExperiences.ts
+++ b/packages/application/src/portfolio/use-cases/GetExperiences.ts
@@ -5,6 +5,7 @@ import {
 } from '@repo/core/portfolio';
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { ExperienceDTO } from '../dtos/ExperienceDTO';
 import { SkillSummary } from '../dtos/ProjectSummaryDTO';
@@ -42,7 +43,7 @@ export class GetExperiences extends UseCase<
       return right(sorted.map((e) => this.toDTO(e, input.locale, skillNames)));
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', {
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
           message: 'Failed to fetch experiences',
         }),
       );

--- a/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetFeaturedProjects.ts
@@ -5,6 +5,7 @@ import {
 } from '@repo/core/portfolio';
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { ProjectSummaryDTO, SkillSummary } from '../dtos/ProjectSummaryDTO';
 
@@ -40,7 +41,7 @@ export class GetFeaturedProjects extends UseCase<
       );
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', {
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
           message: 'Failed to fetch featured projects',
         }),
       );

--- a/packages/application/src/portfolio/use-cases/GetProfessionalValues.ts
+++ b/packages/application/src/portfolio/use-cases/GetProfessionalValues.ts
@@ -4,6 +4,7 @@ import {
 } from '@repo/core/portfolio';
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { ProfessionalValueDTO } from '../dtos/ProfessionalValueDTO';
 
@@ -29,7 +30,7 @@ export class GetProfessionalValues extends UseCase<
       return right(values.map((v) => this.toDTO(v, input.locale)));
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', {
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
           message: 'Failed to fetch professional values',
         }),
       );

--- a/packages/application/src/portfolio/use-cases/GetProfile.ts
+++ b/packages/application/src/portfolio/use-cases/GetProfile.ts
@@ -8,6 +8,7 @@ import {
   right,
 } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { ProfileDTO } from '../dtos/ProfileDTO';
 import { ProfileStatDTO } from '../dtos/ProfileStatDTO';
@@ -35,7 +36,9 @@ export class GetProfile extends UseCase<
       return right(this.toDTO(profile, input.locale));
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', { message: 'Failed to fetch profile' }),
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
+          message: 'Failed to fetch profile',
+        }),
       );
     }
   }

--- a/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
+++ b/packages/application/src/portfolio/use-cases/GetProjectBySlug.ts
@@ -14,6 +14,7 @@ import {
   right,
 } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { ProjectDetailDTO } from '../dtos/ProjectDetailDTO';
 import { ProjectSummaryDTO, SkillSummary } from '../dtos/ProjectSummaryDTO';
@@ -48,7 +49,9 @@ export class GetProjectBySlug extends UseCase<
       project = await this.projectRepository.findBySlug(slugResult.value);
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', { message: 'Failed to fetch project' }),
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
+          message: 'Failed to fetch project',
+        }),
       );
     }
 

--- a/packages/application/src/portfolio/use-cases/GetPublishedProjects.ts
+++ b/packages/application/src/portfolio/use-cases/GetPublishedProjects.ts
@@ -5,6 +5,7 @@ import {
 } from '@repo/core/portfolio';
 import { DomainError, Either, Locale, left, right } from '@repo/core/shared';
 
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 import { ProjectSummaryDTO, SkillSummary } from '../dtos/ProjectSummaryDTO';
 
@@ -40,7 +41,7 @@ export class GetPublishedProjects extends UseCase<
       );
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', {
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
           message: 'Failed to fetch published projects',
         }),
       );

--- a/packages/application/src/portfolio/use-cases/PublishProject.ts
+++ b/packages/application/src/portfolio/use-cases/PublishProject.ts
@@ -11,6 +11,7 @@ import {
 } from '@repo/core/shared';
 
 import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 
 export type PublishProjectInput = {
@@ -55,7 +56,9 @@ export class PublishProject extends UseCase<
       project = await this.projectRepository.findById(idResult.value);
     } catch {
       return left(
-        new DomainError('FETCH_FAILED', { message: 'Failed to fetch project' }),
+        new DomainError(ApplicationErrorCode.FETCH_FAILED, {
+          message: 'Failed to fetch project',
+        }),
       );
     }
 
@@ -70,7 +73,9 @@ export class PublishProject extends UseCase<
       return right(undefined);
     } catch {
       return left(
-        new DomainError('SAVE_FAILED', { message: 'Failed to save project' }),
+        new DomainError(ApplicationErrorCode.SAVE_FAILED, {
+          message: 'Failed to save project',
+        }),
       );
     }
   }

--- a/packages/application/src/portfolio/use-cases/SaveExperience.ts
+++ b/packages/application/src/portfolio/use-cases/SaveExperience.ts
@@ -14,6 +14,7 @@ import {
 } from '@repo/core/shared';
 
 import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 
 export type SaveExperienceInput = {
@@ -52,7 +53,7 @@ export class SaveExperience extends UseCase<
       return right(undefined);
     } catch {
       return left(
-        new DomainError('SAVE_FAILED', {
+        new DomainError(ApplicationErrorCode.SAVE_FAILED, {
           message: 'Failed to save experience',
         }),
       );

--- a/packages/application/src/portfolio/use-cases/SaveProject.ts
+++ b/packages/application/src/portfolio/use-cases/SaveProject.ts
@@ -15,6 +15,7 @@ import {
 } from '@repo/core/shared';
 
 import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 
 export type SaveProjectInput = {
@@ -62,7 +63,9 @@ export class SaveProject extends UseCase<
     } catch (err) {
       if (err instanceof ConflictError) return left(err);
       return left(
-        new DomainError('SAVE_FAILED', { message: 'Failed to save project' }),
+        new DomainError(ApplicationErrorCode.SAVE_FAILED, {
+          message: 'Failed to save project',
+        }),
       );
     }
   }

--- a/packages/application/src/portfolio/use-cases/UpdateProfile.ts
+++ b/packages/application/src/portfolio/use-cases/UpdateProfile.ts
@@ -14,6 +14,7 @@ import {
 } from '@repo/core/shared';
 
 import { EnsureAdmin } from '../../identity/use-cases/EnsureAdmin';
+import { ApplicationErrorCode } from '../../shared/ApplicationErrorCode';
 import { UseCase } from '../../shared/UseCase';
 
 export type UpdateProfileInput = {
@@ -52,7 +53,9 @@ export class UpdateProfile extends UseCase<
       return right(undefined);
     } catch {
       return left(
-        new DomainError('SAVE_FAILED', { message: 'Failed to save profile' }),
+        new DomainError(ApplicationErrorCode.SAVE_FAILED, {
+          message: 'Failed to save profile',
+        }),
       );
     }
   }

--- a/packages/application/src/shared/ApplicationErrorCode.ts
+++ b/packages/application/src/shared/ApplicationErrorCode.ts
@@ -1,0 +1,9 @@
+/**
+ * Error codes shared across use cases for infrastructure-level failures
+ * (repository fetch/save operations), as opposed to domain-specific
+ * `DomainError`/`ValidationError` codes raised by entities and VOs.
+ */
+export const ApplicationErrorCode = {
+  FETCH_FAILED: 'FETCH_FAILED',
+  SAVE_FAILED: 'SAVE_FAILED',
+} as const;

--- a/packages/application/src/shared/index.ts
+++ b/packages/application/src/shared/index.ts
@@ -1,3 +1,4 @@
+export { ApplicationErrorCode } from './ApplicationErrorCode';
 export { UseCase } from './UseCase';
 export { toErrorDTO } from './ErrorDTO';
 export type { ErrorDTO } from './ErrorDTO';


### PR DESCRIPTION
## Summary
- Added `ApplicationErrorCode` const object in `packages/application/src/shared/ApplicationErrorCode.ts` with `FETCH_FAILED`/`SAVE_FAILED`.
- Updated all 15 use cases across `portfolio`, `identity`, and `blog` contexts to reference `ApplicationErrorCode.FETCH_FAILED`/`.SAVE_FAILED` instead of the repeated string literals — 17 call sites total.
- Re-exported from `packages/application/src/shared/index.ts`.

## Test plan
- [x] `pnpm --filter @repo/application test` — 22/22 files, 176/176 tests passing, unmodified (confirms behavior — the runtime string values are unchanged)
- [x] `grep -rn "'FETCH_FAILED'\|'SAVE_FAILED'"` across `packages/application/src` — only appears in `ApplicationErrorCode.ts`'s own definition
- [x] `pnpm turbo build/types/lint:check/test --filter="...@repo/application"` (package + every downstream consumer: `@repo/infra`, `site`, `blog`) — all green (the 5 pre-existing `@repo/infra` DB-connection test failures are unrelated, same as noted in prior PRs — no local Postgres)
- [x] `pnpm lint`, `pnpm format` — clean

Refs #662