### PR TITLE
refactor(core): extract magic numbers in VOs to named constants

### DIFF
--- a/docs/09-PATTERNS.md
+++ b/docs/09-PATTERNS.md
@@ -68,6 +68,8 @@ class Slug extends ValueObject<string> {
 - Must provide `equals()` (inherited from `ValueObject` base)
 - Use `Validator` from `@repo/utils` for all validation
 - Use stable `ERROR_CODE` constants
+- Extract numeric validation bounds (min/max length, count limits, etc.) as named `static readonly` constants — never leave unnamed literals in a `Validator` chain
+- Every such constant carries a one-line comment stating its source: an external standard/RFC, a persistence constraint it must stay consistent with (verify the constraint actually exists in `schema.prisma` before citing it), or an explicit product/business decision. If none of these exist, say so honestly (e.g. `// arbitrary, no documented source — confirm with product`) rather than implying a justification that isn't real
 
 ---
 

--- a/packages/core/src/shared/vo/Email.ts
+++ b/packages/core/src/shared/vo/Email.ts
@@ -6,6 +6,8 @@ import { ValidationError } from '../errors';
 
 export class Email extends ValueObject<string> {
   static readonly ERROR_CODE = 'INVALID_EMAIL';
+  private static readonly MIN_LENGTH = 3;
+  private static readonly MAX_LENGTH = 254;
 
   private constructor(value: string) {
     super({ value });
@@ -14,7 +16,7 @@ export class Email extends ValueObject<string> {
   static create(value?: string): Either<ValidationError, Email> {
     const normalized = value?.trim().toLowerCase() ?? '';
     const { isValid } = Validator.of(normalized)
-      .length(3, 254)
+      .length(Email.MIN_LENGTH, Email.MAX_LENGTH)
       .email()
       .validate();
 

--- a/packages/core/src/shared/vo/Email.ts
+++ b/packages/core/src/shared/vo/Email.ts
@@ -6,7 +6,9 @@ import { ValidationError } from '../errors';
 
 export class Email extends ValueObject<string> {
   static readonly ERROR_CODE = 'INVALID_EMAIL';
+  /** Practical minimum for a syntactically valid address, e.g. `a@b.co`. */
   private static readonly MIN_LENGTH = 3;
+  /** RFC 5321 §4.5.3.1.3 — max length of the reverse-path/forward-path (mailbox). */
   private static readonly MAX_LENGTH = 254;
 
   private constructor(value: string) {

--- a/packages/core/src/shared/vo/Name.ts
+++ b/packages/core/src/shared/vo/Name.ts
@@ -6,13 +6,18 @@ import { ValidationError } from '../errors';
 
 export class Name extends ValueObject<string> {
   static readonly ERROR_CODE = 'INVALID_NAME';
+  private static readonly MIN_LENGTH = 3;
+  private static readonly MAX_LENGTH = 100;
 
   private constructor(value: string) {
     super({ value });
   }
 
   static create(value?: string): Either<ValidationError, Name> {
-    const { isValid } = Validator.of(value).alpha().length(3, 100).validate();
+    const { isValid } = Validator.of(value)
+      .alpha()
+      .length(Name.MIN_LENGTH, Name.MAX_LENGTH)
+      .validate();
 
     if (!isValid) return left(new ValidationError({ code: Name.ERROR_CODE }));
 

--- a/packages/core/src/shared/vo/Name.ts
+++ b/packages/core/src/shared/vo/Name.ts
@@ -6,6 +6,9 @@ import { ValidationError } from '../errors';
 
 export class Name extends ValueObject<string> {
   static readonly ERROR_CODE = 'INVALID_NAME';
+  // Arbitrary — no external standard or schema.prisma constraint backs this
+  // range (the `name` columns are unconstrained Postgres `text`). Confirm
+  // with product if a real requirement should replace these bounds.
   private static readonly MIN_LENGTH = 3;
   private static readonly MAX_LENGTH = 100;
 

--- a/packages/core/src/shared/vo/Slug.ts
+++ b/packages/core/src/shared/vo/Slug.ts
@@ -7,6 +7,7 @@ import { ValidationError } from '../errors';
 export class Slug extends ValueObject<string> {
   static readonly ERROR_CODE = 'INVALID_SLUG';
   private static readonly SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+  private static readonly MIN_LENGTH = 3;
   private static readonly MAX_LENGTH = 100;
 
   private constructor(value: string) {
@@ -17,7 +18,7 @@ export class Slug extends ValueObject<string> {
     const normalized = raw?.trim().toLowerCase() ?? '';
 
     const { isValid } = Validator.of(normalized)
-      .length(3, Slug.MAX_LENGTH)
+      .length(Slug.MIN_LENGTH, Slug.MAX_LENGTH)
       .regex(Slug.SLUG_REGEX)
       .validate();
 

--- a/packages/core/src/shared/vo/Slug.ts
+++ b/packages/core/src/shared/vo/Slug.ts
@@ -7,6 +7,10 @@ import { ValidationError } from '../errors';
 export class Slug extends ValueObject<string> {
   static readonly ERROR_CODE = 'INVALID_SLUG';
   private static readonly SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+  // Arbitrary — no external standard or schema.prisma constraint backs this
+  // range (`slug` is an unconstrained Postgres `text` column). Confirm with
+  // product/SEO if a real requirement (e.g. URL length guidance) should
+  // replace these bounds.
   private static readonly MIN_LENGTH = 3;
   private static readonly MAX_LENGTH = 100;
 

--- a/packages/core/src/shared/vo/Text.ts
+++ b/packages/core/src/shared/vo/Text.ts
@@ -11,6 +11,8 @@ interface ITextConfig {
 
 export class Text extends ValueObject<string, ITextConfig> {
   static readonly ERROR_CODE = 'INVALID_TEXT';
+  private static readonly DEFAULT_MIN_LENGTH = 3;
+  private static readonly DEFAULT_MAX_LENGTH = 50;
 
   private constructor(value: string, config?: ITextConfig) {
     super({ value: value.trim() }, config);
@@ -20,7 +22,8 @@ export class Text extends ValueObject<string, ITextConfig> {
     value?: string,
     config?: ITextConfig,
   ): Either<ValidationError, Text> {
-    const { min = 3, max = 50 } = config ?? {};
+    const { min = Text.DEFAULT_MIN_LENGTH, max = Text.DEFAULT_MAX_LENGTH } =
+      config ?? {};
 
     const { isValid } = Validator.of(value).length(min, max).validate();
 

--- a/packages/core/src/shared/vo/Text.ts
+++ b/packages/core/src/shared/vo/Text.ts
@@ -11,6 +11,9 @@ interface ITextConfig {
 
 export class Text extends ValueObject<string, ITextConfig> {
   static readonly ERROR_CODE = 'INVALID_TEXT';
+  // Arbitrary defaults — no external standard or schema constraint backs
+  // this range; callers with a real requirement should pass their own
+  // `min`/`max` via ITextConfig instead of relying on these.
   private static readonly DEFAULT_MIN_LENGTH = 3;
   private static readonly DEFAULT_MAX_LENGTH = 50;
 


### PR DESCRIPTION
## Summary
- `Name.ts`, `Slug.ts`, `Email.ts`: added `MIN_LENGTH`/`MAX_LENGTH` `static readonly` constants, replacing inline numeric literals in the `.length()` Validator call (`Slug` already had `MAX_LENGTH`; added the missing `MIN_LENGTH`).
- `Text.ts`: added `DEFAULT_MIN_LENGTH`/`DEFAULT_MAX_LENGTH` for its configurable `min`/`max` defaults (distinguished from a fixed VO constraint since callers can override via `ITextConfig`).
- Followed `Tag.ts`'s existing `MIN_LENGTH`/`MAX_LENGTH` pattern (the one VO in this codebase that was already fully compliant) rather than the issue's cited `Profile.ts` example, which no longer has `MAX_FEATURED_PROJECTS` (removed by the `Project.weight` ordering work).
- Audited the rest of `packages/core/src` (all `Validator.of()` call sites, all `.length/.gt/.gte/.lt/.lte()` calls) — no other unnamed numeric literals found. The issue's `Project content .length(3, 500000, ...)` example is stale; no such check exists in current code (content validation is a plain `notEmpty()` via `LocalizedText`).
- **Follow-up round**: naming the constants wasn't enough on its own — a reviewer still couldn't tell whether a bound was backed by a real requirement or just made up. Each constant now carries a one-line comment stating its source:
  - `Email.MAX_LENGTH = 254` → RFC 5321 §4.5.3.1.3 (real external standard)
  - `Name`/`Slug`/`Text` bounds → verified against `packages/infra/prisma/schema.prisma`: the backing columns are unconstrained Postgres `text` (no `@db.VarChar(n)`), so these have **no** schema or standard backing. Marked explicitly as arbitrary, pending product confirmation, rather than left to look authoritative.
- Documented this "cite the source, or say there isn't one" convention in `docs/09-PATTERNS.md` (Value Object rules) so future VOs follow it, not just this batch.
- Issue #663's acceptance criteria were reformulated to require this (see issue for the added criterion).

## Test plan
- [x] `pnpm --filter @repo/core test` — 28/28 files, 292/292 tests passing, unmodified (confirms behavior unchanged — this PR only adds comments and constants, no logic change)
- [x] `grep -rnE '\.(length|gt|gte|lt|lte)\([0-9]' packages/core/src` — empty, no unnamed numeric literals remain
- [x] `pnpm turbo lint:check format:check types test --filter="...@repo/core"` (package + every downstream consumer) — all green (the 5 pre-existing `@repo/infra` DB-connection test failures are unrelated — no local Postgres)
- [x] Verified `packages/infra/prisma/schema.prisma` directly to confirm/deny schema backing for each bound, rather than assuming

Refs #663
