### PR TITLE
chore(blog): add Vercel deployment config for apps/blog

### DIFF
--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "cd ../.. && turbo run build --filter=blog",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- Adds `apps/blog/vercel.json`, mirroring `apps/site/vercel.json`'s pattern (`cd ../.. && turbo run build --filter=blog`, `framework: nextjs`).
- Paired with a new Vercel project created outside this repo: `portfolio-blog`, linked to `wallace-sf/portfolio`, `rootDirectory: apps/blog`, production branch `master`. No deployment triggered yet.

## Test plan
- [x] `pnpm turbo lint:check format:check --filter=blog` — clean (pre-existing warnings only, unrelated to this change)
- [x] `pnpm turbo build/types/test --filter="...@repo/core"` full monorepo checks — n/a to this change, config-only
- [ ] Manual: after merge, set `NEXT_PUBLIC_SITE_URL` on `portfolio-blog` and `BLOG_APP_URL` on `portfolio-web`, then verify `wallace-ferreira.dev/blog/en-US` in production (tracked in #982, not blocking this PR)

Refs #982
